### PR TITLE
Relicense from GPLv3 to AGPLv3, add CLA

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,60 @@
+# Contributor License Agreement
+
+By submitting a pull request or otherwise contributing code, documentation,
+or other materials to this project ("Contribution"), you agree to the following
+terms:
+
+## 1. Grant of Copyright License
+
+You grant **Jimmy Huang** (the "Project Owner") a perpetual, worldwide,
+non-exclusive, royalty-free, irrevocable copyright license to reproduce,
+prepare derivative works of, publicly display, publicly perform, sublicense,
+and distribute your Contribution and such derivative works in any form and
+under any license, including but not limited to the GNU Affero General Public
+License v3 (AGPLv3) and any proprietary or commercial license.
+
+## 2. Grant of Patent License
+
+You grant the Project Owner a perpetual, worldwide, non-exclusive,
+royalty-free, irrevocable patent license to make, have made, use, offer to
+sell, sell, import, and otherwise transfer your Contribution, where such
+license applies only to those patent claims licensable by you that are
+necessarily infringed by your Contribution alone or by combination of your
+Contribution with the project.
+
+## 3. You Own Your Contribution
+
+You represent that:
+
+- The Contribution is your original work and you have the right to grant the
+  above licenses.
+- The Contribution does not include third-party code that would restrict the
+  Project Owner's ability to relicense it.
+- If your employer has rights to intellectual property you create, you have
+  received permission to make the Contribution on behalf of your employer, or
+  your employer has waived such rights for your Contribution.
+
+## 4. You Retain Your Rights
+
+This CLA does **not** transfer ownership of your Contribution to the Project
+Owner. You retain full copyright ownership. The license grant above is
+non-exclusive — you are free to use, license, or distribute your Contribution
+under any other terms you choose.
+
+## 5. Your Contribution Remains Open Source
+
+The Project Owner commits that gnucash-plaintext will always be available
+under an OSI-approved open source license. The dual-licensing right granted
+above allows the Project Owner to offer commercial licenses to parties that
+cannot comply with the AGPLv3, but the AGPLv3 version will always remain
+publicly available.
+
+## How to Sign
+
+To sign this CLA, add your name and GitHub username to the table below in your
+pull request. By doing so you confirm you have read and agree to the terms
+above.
+
+| Name | GitHub Username | Date |
+|------|----------------|------|
+| Jimmy Huang | @huangjimmy | 2026-03-12 |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to gnucash-plaintext
+
+Thank you for your interest in contributing!
+
+## Contributor License Agreement (CLA)
+
+Before your pull request can be merged, you must sign the
+[Contributor License Agreement](CLA.md).
+
+**How to sign:** Add your name, GitHub username, and the date to the
+signatories table in `CLA.md` as part of your pull request.
+
+The CLA grants the project owner the right to dual-license contributions
+(AGPLv3 for open source use; commercial license for parties that cannot
+comply with AGPLv3). You retain full copyright ownership of your contribution.
+
+## License
+
+This project is licensed under the **GNU Affero General Public License v3**
+(AGPLv3). See [LICENSE](LICENSE) for the full text.
+
+By contributing, you agree that your contributions will be licensed under
+AGPLv3, subject to the CLA terms above.
+
+## Development Setup
+
+### Prerequisites
+
+- Docker (for running tests against real GnuCash Python bindings)
+- Git
+
+### Running Tests
+
+Tests run inside Docker containers against real GnuCash files (no mocking):
+
+```bash
+# Test all supported versions in parallel
+./scripts/test-all-versions-parallel.sh
+
+# Build Docker images first if needed
+./scripts/build.sh
+```
+
+### Supported GnuCash Versions
+
+| Docker image | GnuCash version | Status |
+|---|---|---|
+| debian:13 | 5.10 | default |
+| debian:12 | 4.13 | supported |
+| debian:11 | 4.4 | supported |
+| ubuntu:20.04 | 3.8 | minimum |
+
+### Code Style
+
+This project uses `ruff` for linting. Run before committing:
+
+```bash
+ruff check .
+```
+
+The pre-commit hook runs linting and tests automatically.
+
+## Pull Request Process
+
+1. Fork the repository and create a branch from `main`
+2. Add your CLA signature to `CLA.md`
+3. Write tests for any new behaviour (tests run in Docker with real GnuCash files)
+4. Ensure all tests pass across all supported versions
+5. Open a pull request with a clear description of the change

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
@@ -7,17 +7,15 @@
 
                             Preamble
 
-  The GNU General Public License is a free, copyleft license for
-software and other kinds of works.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
   The licenses for most software and other practical works are designed
 to take away your freedom to share and change the works.  By contrast,
-the GNU General Public License is intended to guarantee your freedom to
+our General Public Licenses are intended to guarantee your freedom to
 share and change all versions of a program--to make sure it remains free
-software for all its users.  We, the Free Software Foundation, use the
-GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors.  You can apply it to
-your programs, too.
+software for all its users.
 
   When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
@@ -26,44 +24,34 @@ them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
 free programs, and that you know you can do these things.
 
-  To protect your rights, we need to prevent others from denying you
-these rights or asking you to surrender the rights.  Therefore, you have
-certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
 
-  For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must pass on to the recipients the same
-freedoms that you received.  You must make sure that they, too, receive
-or can get the source code.  And you must show them these terms so they
-know their rights.
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
 
-  Developers that use the GNU GPL protect your rights with two steps:
-(1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
 
-  For the developers' and authors' protection, the GPL clearly explains
-that there is no warranty for this free software.  For both users' and
-authors' sake, the GPL requires that modified versions be marked as
-changed, so that their problems will not be attributed erroneously to
-authors of previous versions.
-
-  Some devices are designed to deny users access to install or run
-modified versions of the software inside them, although the manufacturer
-can do so.  This is fundamentally incompatible with the aim of
-protecting users' freedom to change the software.  The systematic
-pattern of such abuse occurs in the area of products for individuals to
-use, which is precisely where it is most unacceptable.  Therefore, we
-have designed this version of the GPL to prohibit the practice for those
-products.  If such problems arise substantially in other domains, we
-stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.
-
-  Finally, every program is threatened constantly by software patents.
-States should not allow patents to restrict development and use of
-software on general-purpose computers, but in those that do, we wish to
-avoid the special danger that patents applied to a free program could
-make it effectively proprietary.  To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
@@ -72,7 +60,7 @@ modification follow.
 
   0. Definitions.
 
-  "This License" refers to version 3 of the GNU General Public License.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
   "Copyright" also means copyright-like laws that apply to other kinds of
 works, such as semiconductor masks.
@@ -549,35 +537,45 @@ to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
 
-  13. Use with the GNU Affero General Public License.
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
 
   Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a single
+under version 3 of the GNU General Public License into a single
 combined work, and to convey the resulting work.  The terms of this
 License will continue to apply to the part which is the covered work,
-but the special requirements of the GNU Affero General Public License,
-section 13, concerning interaction through a network will apply to the
-combination as such.
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
 
   14. Revised Versions of this License.
 
   The Free Software Foundation may publish revised and/or new versions of
-the GNU General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
   Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU General
+Program specifies that a certain numbered version of the GNU Affero General
 Public License "or any later version" applies to it, you have the
 option of following the terms and conditions either of that numbered
 version or of any later version published by the Free Software
 Foundation.  If the Program does not specify a version number of the
-GNU General Public License, you may choose any version ever published
+GNU Affero General Public License, you may choose any version ever published
 by the Free Software Foundation.
 
   If the Program specifies that a proxy can decide which future
-versions of the GNU General Public License can be used, that proxy's
+versions of the GNU Affero General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
 to choose that version for the Program.
 
@@ -635,40 +633,29 @@ the "copyright" line and a pointer to where the full notice is found.
     Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
+    it under the terms of the GNU Affero General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
+    You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-  If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:
-
-    <program>  Copyright (C) <year>  <name of author>
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an "about box".
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
 
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
+For more information on this, and how to apply and follow the GNU AGPL, see
 <https://www.gnu.org/licenses/>.
-
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,23 @@
+gnucash-plaintext
+Copyright (C) 2024-2026 Jimmy Huang
+
+This software is licensed under the GNU Affero General Public License v3
+(AGPLv3). See LICENSE for the full text.
+
+-------------------------------------------------------------------------------
+NOTICE REGARDING MACHINE LEARNING
+
+The source code, test cases, fixture files, and datasets in this repository
+are the original creative work of the copyright holder.
+
+You may not use any part of this repository — including but not limited to
+source code, test fixtures, and sample data files — to train, fine-tune, or
+otherwise build machine learning or artificial intelligence models without
+explicit written permission from the copyright holder.
+
+This notice does not restrict any rights granted by the AGPLv3 license for
+running, copying, modifying, or distributing the software.
+
+To request permission, open an issue at:
+https://github.com/huangjimmy/gnucash-plaintext/issues
+-------------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "gnucash-plaintext"
 version = "0.2.0"
 description = "GnuCash Plaintext - Convert between GnuCash and human-readable plaintext format"
 readme = "README.md"
+license = {file = "LICENSE"}
 requires-python = ">=3.7"
 dependencies = [
     "click>=8.0",


### PR DESCRIPTION
GPLv3 does not require source disclosure when the software is used to provide a network service (the SaaS loophole). AGPLv3 closes this by requiring source disclosure for network use as well.

As the sole copyright holder, no contributor consent is required.

Changes:
- LICENSE: replace GPLv3 text with AGPLv3 text
- CLA.md: contributor license agreement granting the project owner the right to dual-license contributions (AGPLv3 + commercial)
- CONTRIBUTING.md: contribution guide covering CLA, testing, and supported GnuCash versions
- pyproject.toml: add license field pointing to LICENSE file