### PR TITLE
Add Ubuntu 22.04 (GnuCash 4.8) to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           - distribution: 'GnuCash-38_Ubuntu-2004'
             base_image: 'ubuntu:20.04'
             tag: 'ubuntu20'
+          - distribution: 'GnuCash-48_Ubuntu-2204'
+            base_image: 'ubuntu:22.04'
+            tag: 'ubuntu22'
 
     steps:
       - name: Checkout code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Merge criteria:
 - debian:12 (GnuCash 4.13)
 - debian:11 (GnuCash 4.4)
 - ubuntu:20.04 (GnuCash 3.8) - minimum
+- ubuntu:22.04 (GnuCash 4.8)
 
 ### ❌ Do NOT Support
 - debian:10 (EOL, broken dependencies)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -29,9 +29,13 @@ case "$BASE_IMAGE" in
         TAG="ubuntu20"
         GNUCASH_VERSION="3.8"
         ;;
+    ubuntu:22.04)
+        TAG="ubuntu22"
+        GNUCASH_VERSION="4.8"
+        ;;
     *)
         echo "Unknown distribution: $BASE_IMAGE"
-        echo "Supported: debian:13, debian:12, debian:11, ubuntu:20.04"
+        echo "Supported: debian:13, debian:12, debian:11, ubuntu:20.04, ubuntu:22.04"
         exit 1
         ;;
 esac

--- a/scripts/test-all-versions-parallel.sh
+++ b/scripts/test-all-versions-parallel.sh
@@ -17,7 +17,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
 
 # Supported versions
-VERSIONS=("latest" "debian12" "debian11" "ubuntu20")
+VERSIONS=("latest" "debian12" "debian11" "ubuntu20" "ubuntu22")
 
 echo "Testing against all supported versions IN PARALLEL..."
 echo "This is ~4x faster than sequential testing"
@@ -75,6 +75,7 @@ for version in "${VERSIONS[@]}"; do
                 debian12) echo "debian:12" ;;
                 debian11) echo "debian:11" ;;
                 ubuntu20) echo "ubuntu:20.04" ;;
+                ubuntu22) echo "ubuntu:22.04" ;;
             esac)
             docker build --build-arg BASE_IMAGE=$BASE_IMAGE -t gnucash-dev:$version .
         fi

--- a/scripts/test-all-versions.sh
+++ b/scripts/test-all-versions.sh
@@ -14,7 +14,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
 
 # Supported versions (OS versions map to different Python versions)
-VERSIONS=("latest" "debian12" "debian11" "ubuntu20")
+VERSIONS=("latest" "debian12" "debian11" "ubuntu20" "ubuntu22")
 
 echo "Testing against all supported versions..."
 echo ""


### PR DESCRIPTION
- Add ubuntu:22.04 case to scripts/build.sh (tag: ubuntu22, GnuCash 4.8)
- Add ubuntu22 to VERSIONS array in test-all-versions.sh and test-all-versions-parallel.sh, including build case mapping
- Add GnuCash-48_Ubuntu-2204 matrix entry to .github/workflows/ci.yml
- Update CLAUDE.md supported distributions list