### PR TITLE
Add Phase 9: Business objects import/export and PDF invoice printing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,52 @@ git branch --show-current  # Should be: architecture-migration
 ./scripts/test.sh
 ```
 
+## ctypes / GnuCash Bindings — Hard-Won Platform Findings
+
+Discovered 2026-03-14 while fixing `test_business_objects_roundtrip` segfaults on Ubuntu 22/24.
+
+### 1. Always set `argtypes` for every ctypes function that takes a pointer
+
+Without `argtypes`, Python ctypes converts integer arguments to C `int` (32-bit). On x86_64, a 64-bit pointer like `0x7f1234567890` is silently truncated to `0x34567890` — a garbage address — causing a segfault inside the C function. This affects ALL platforms, so it is never optional.
+
+```python
+# WRONG — pointer silently truncated to 32-bit on x86_64
+lib.gncTaxTableGetTables.restype = ctypes.c_void_p
+
+# CORRECT
+lib.gncTaxTableGetTables.restype  = ctypes.c_void_p
+lib.gncTaxTableGetTables.argtypes = [ctypes.c_void_p]
+```
+
+### 2. Debian vs Ubuntu: RTLD_LOCAL causes library-instance mismatch
+
+On **Debian**, the GnuCash Python extension loads `libgnc-engine.so` with `RTLD_GLOBAL`, so `ctypes.CDLL(None)` sees its symbols — calling functions from the *same* instance that created `QofBook*`. On **Ubuntu**, the extension uses `RTLD_LOCAL` (Python's default for extension modules), so `CDLL(None)` may resolve symbols from a *different* globally-visible copy, or not find them at all.
+
+**Fix**: always promote the known `.so` path to `RTLD_GLOBAL` *before* calling `CDLL(None)`:
+
+```python
+ctypes.CDLL('/usr/lib/x86_64-linux-gnu/gnucash/libgnc-engine.so', mode=ctypes.RTLD_GLOBAL)
+lib = ctypes.CDLL(None)   # now guaranteed to use the same instance
+```
+
+`dlopen` reuses the already-loaded mapping (same inode) and promotes it to global — no second copy is created.
+
+### 3. Tax tables CANNOT be fetched via QOF Query
+
+`q.search_for('gncTaxTable')` returns nothing. Tax tables are stored in a per-book hash table via `qof_book_get_data(book, "gncTaxTable")`, not in the QOF entity collection that queries iterate. The only correct API is `gncTaxTableGetTables(QofBook*)` via ctypes.
+
+Do **not** try to replace this with `Query` — a previous session confirmed it returns zero results.
+
+### 4. `weasyprint` apt package on Ubuntu does not expose `import weasyprint`
+
+On Debian, `apt install weasyprint` installs `python3-weasyprint` and `import weasyprint` works. On Ubuntu 22/24, the same apt package only installs the CLI wrapper — `import weasyprint` raises `ModuleNotFoundError`.
+
+**Fix**: install via pip (works on all distros):
+```dockerfile
+RUN python3 -m pip install weasyprint --break-system-packages ...
+```
+
 ---
 
-**Last Updated**: 2026-02-15
-**Current Phase**: Phase 0 (Day 1 Complete, Day 2-3 Pending)
+**Last Updated**: 2026-03-14
+**Current Phase**: Phase 8 (Business Objects)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ARG BASE_IMAGE=debian:13
 # │ debian:13        │ 5.10            │ ✅ Latest (default)    │
 # │ debian:12        │ 4.13            │ ✅ Stable              │
 # │ debian:11        │ 4.4             │ ✅ LTS                 │
+# │ ubuntu:24.04     │ 4.9             │ ✅ LTS                 │
+# │ ubuntu:22.04     │ 4.8             │ ✅ LTS                 │
 # │ ubuntu:20.04     │ 3.8             │ ✅ Minimum (GnuCash 3) │
 # └──────────────────┴─────────────────┴────────────────────────┘
 #
@@ -13,6 +15,8 @@ ARG BASE_IMAGE=debian:13
 #   docker build -t gnucash-dev .                                    # Debian 13 (GnuCash 5.10)
 #   docker build --build-arg BASE_IMAGE=debian:12 -t gnucash-dev .   # Debian 12 (GnuCash 4.13)
 #   docker build --build-arg BASE_IMAGE=debian:11 -t gnucash-dev .   # Debian 11 (GnuCash 4.4)
+#   docker build --build-arg BASE_IMAGE=ubuntu:24.04 -t gnucash-dev . # Ubuntu 24.04 (GnuCash 4.9)
+#   docker build --build-arg BASE_IMAGE=ubuntu:22.04 -t gnucash-dev . # Ubuntu 22.04 (GnuCash 4.8)
 #   docker build --build-arg BASE_IMAGE=ubuntu:20.04 -t gnucash-dev . # Ubuntu 20.04 (GnuCash 3.8)
 
 FROM ${BASE_IMAGE}
@@ -22,7 +26,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get -y install gnucash python3-gnucash git python3-pip python3-venv \
-        libxml2-dev libxslt-dev && \
+        libxml2-dev libxslt-dev python3-lxml weasyprint && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -32,8 +36,8 @@ WORKDIR /workspace
 # Install dev dependencies at build time
 # The package itself will be installed at runtime when workspace is mounted
 # Try with --break-system-packages first (Debian 12+, Ubuntu 22+), fall back to upgrade pip (Ubuntu 20)
-RUN python3 -m pip install pytest pytest-cov --break-system-packages 2>/dev/null || \
+RUN python3 -m pip install pytest pytest-cov weasyprint --break-system-packages 2>/dev/null || \
     (python3 -m pip install --upgrade pip && \
-     python3 -m pip install pytest pytest-cov --break-system-packages)
+     python3 -m pip install pytest pytest-cov weasyprint --break-system-packages)
 
 CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -292,6 +292,87 @@ Preview without making changes (dry run):
 gnucash-plaintext import mybook.gnucash transactions.txt --dry-run
 ```
 
+### Import and export business objects
+
+Customers, vendors, tax tables, invoices, and bills can be round-tripped
+through plaintext alongside your accounts and transactions.
+
+```bash
+# Import a file that contains business objects as well as transactions
+gnucash-plaintext import --new mybook.gnucash ledger.txt --include-business-objects
+
+# Export everything — accounts, business objects, then transactions
+gnucash-plaintext export mybook.gnucash ledger.txt --include-business-objects
+```
+
+Business objects use no date prefix — they are master data, not ledger
+events. Dates that belong to a record (e.g. `date_opened` on an invoice) are
+declared as fields inside the block:
+
+```
+customer "CUST-001"
+  name: "Acme Corp"
+  currency: CAD
+
+vendor "VEND-001"
+  name: "Office Supplies Co."
+  currency: CAD
+
+taxtable "GST"
+  entry:
+    account: "Liabilities:Tax:GST Collected"
+    rate: 5.0%
+    type: PERCENT
+
+invoice "INV-2026-001"
+  customer_id: "CUST-001"
+  currency: CAD
+  date_opened: 2026-01-15
+  entry:
+    date: 2026-01-15
+    description: "Consulting services"
+    account: "Income:Consulting"
+    quantity: 10
+    price: 150
+    taxable: true
+    tax_table: "GST"
+  posted:
+    date: 2026-01-15
+    due: 2026-02-14
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-2026-001"
+    accumulate: true
+
+bill "BILL-2026-001"
+  vendor_id: "VEND-001"
+  currency: CAD
+  date_opened: 2026-01-20
+  entry:
+    date: 2026-01-20
+    description: "Office supplies"
+    account: "Expenses:Office"
+    quantity: 1
+    price: 200
+    taxable: false
+  posted:
+    date: 2026-01-20
+    due: 2026-02-19
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Bill BILL-2026-001"
+    accumulate: true
+```
+
+### Print an invoice to PDF
+
+Generate a PDF for any posted invoice:
+
+```bash
+gnucash-plaintext print-invoice mybook.gnucash --invoice-id INV-2026-001 -o invoice.pdf
+```
+
+The PDF is rendered using the XSLT template at `services/invoice.xslt`, which
+you can customise to match your company's branding.
+
 Handle conflicts with resolution strategies:
 
 ```bash
@@ -459,6 +540,8 @@ The project is tested against multiple GnuCash versions using different Docker b
 | Debian 13 | 5.10 | `latest` |
 | Debian 12 | 4.13 | `debian12` |
 | Debian 11 | 4.4 | `debian11` |
+| Ubuntu 24.04 | 4.9 | `ubuntu24` |
+| Ubuntu 22.04 | 4.8 | `ubuntu22` |
 | Ubuntu 20.04 | 3.8 | `ubuntu20` |
 
 ### Interactive Development Shell

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,58 @@
 # Release Notes
 
+## v0.3.0 - Business Objects (2026-03-14)
+
+### What's new
+
+#### Import and export customers, vendors, tax tables, invoices, and bills
+
+You can now round-trip GnuCash business objects through plaintext files:
+
+```bash
+gnucash-plaintext import --new mybook.gnucash ledger.txt --include-business-objects
+gnucash-plaintext export mybook.gnucash ledger.txt --include-business-objects
+```
+
+Supported objects: `customer`, `vendor`, `taxtable`, `invoice` (with entries
+and payments), `bill` (with entries).
+
+Business objects use no date prefix in the plaintext format — they are master
+data, not ledger events. GnuCash does not store a creation timestamp for
+customers, vendors, or tax tables, so no meaningful date prefix exists.
+Dates that belong to a record (e.g. `date_opened`) are declared as fields
+inside the block.
+
+#### Print invoices to PDF
+
+Any posted invoice can be rendered to a PDF directly from the CLI:
+
+```bash
+gnucash-plaintext print-invoice mybook.gnucash --invoice-id INV-2026-001 -o invoice.pdf
+```
+
+The output is produced from `services/invoice.xslt`, which you can customise
+to match your company's branding.
+
+### Platform support expanded
+
+Ubuntu 22.04 (GnuCash 4.8) and Ubuntu 24.04 (GnuCash 4.9) are now fully
+supported and tested in CI.
+
+Two bugs that caused segfaults on Ubuntu (but not Debian) were fixed:
+- Missing `argtypes` caused ctypes to silently truncate 64-bit pointers to 32-bit
+- Ubuntu loads GnuCash extensions with `RTLD_LOCAL`, so `CDLL(None)` could
+  resolve symbols from the wrong library instance
+
+On Ubuntu 22/24, `apt install weasyprint` only provides a CLI wrapper —
+`import weasyprint` would fail. Fixed by installing weasyprint via pip.
+
+### Bug fix
+
+`create_account` was not idempotent: calling it twice for the same account
+silently created duplicate children in GnuCash. Fixed with an existence check.
+
+---
+
 ## v0.2.0 - Architecture Migration (2026-03-01)
 
 **Major release** with complete architecture refactoring and new features.

--- a/cli/export_cmd.py
+++ b/cli/export_cmd.py
@@ -7,6 +7,7 @@ import os
 import click
 
 from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from use_cases.export_business_objects import ExportBusinessObjectsUseCase
 from use_cases.export_transactions import ExportTransactionsUseCase
 
 
@@ -19,7 +20,8 @@ from use_cases.export_transactions import ExportTransactionsUseCase
 @click.option('--end-date', '-e', help='End date (YYYY-MM-DD)')
 @click.option('--account', '-a', help='Filter by account path')
 @click.option('--all-accounts', 'all_accounts', is_flag=True, help='Export all accounts even if they have no transactions')
-def export_transactions(gnucash_file, output_file, input_file, output_path, start_date, end_date, account, all_accounts):
+@click.option('--include-business-objects', is_flag=True, help='Include business objects (customers, invoices, etc.)')
+def export_transactions(gnucash_file, output_file, input_file, output_path, start_date, end_date, account, all_accounts, include_business_objects):
     """
     Export transactions from GnuCash file to plaintext format.
 
@@ -61,18 +63,37 @@ def export_transactions(gnucash_file, output_file, input_file, output_path, star
         repo.open(mode=SessionMode.READ_ONLY)
 
         try:
+            business_objects_output = ""
+            if include_business_objects:
+                click.echo("Exporting business objects...")
+                business_use_case = ExportBusinessObjectsUseCase(repo.book)
+                business_objects_output = business_use_case.execute()
+
             # Create use case
             use_case = ExportTransactionsUseCase(repo)
 
             # Export
             click.echo(f"Exporting transactions from {gnucash_file}...")
-            count = use_case.export_to_file(
-                output_file,
+            result = use_case.execute(
                 start_date=start_date,
                 end_date=end_date,
                 account_filter=account,
                 all_accounts=all_accounts
             )
+            count = len(result.transactions)
+
+            with open(output_file, "w") as f:
+                if business_objects_output:
+                    # Write in import-ready order: accounts, then business objects, then transactions
+                    accounts_output = use_case.format_accounts_section(result)
+                    txn_output = use_case.format_transactions_section(result)
+                    f.write(accounts_output)
+                    f.write("\n")
+                    f.write(business_objects_output)
+                    f.write("\n\n")
+                    f.write(txn_output)
+                else:
+                    f.write(use_case.format_as_plaintext(result))
 
             click.echo(f"✓ Exported {count} transaction(s) to {output_file}")
 

--- a/cli/import_cmd.py
+++ b/cli/import_cmd.py
@@ -8,6 +8,8 @@ import click
 
 from repositories.gnucash_repository import GnuCashRepository, SessionMode
 from services.conflict_resolver import ResolutionStrategy
+from services.gnucash_importer import GnuCashImporter
+from services.plaintext_parser import DirectiveType, PlaintextParser
 from use_cases.import_transactions import ImportTransactionsUseCase
 
 
@@ -33,7 +35,8 @@ from use_cases.import_transactions import ImportTransactionsUseCase
     is_flag=True,
     help='Create a new GnuCash file (file must not already exist)'
 )
-def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, strategy, dry_run, create_new):
+@click.option('--include-business-objects', is_flag=True, help='Include business objects (customers, invoices, etc.)')
+def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, strategy, dry_run, create_new, include_business_objects):
     """
     Import plaintext transactions to GnuCash file.
 
@@ -105,6 +108,19 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
         repo.open(mode=mode)
 
         try:
+            if include_business_objects:
+                click.echo("Importing business objects...")
+                parser = PlaintextParser()
+                parser.parse_file(input_file)
+                importer = GnuCashImporter()
+
+                # Create accounts first
+                for directive in parser.root_directive.children:
+                    if directive.type == DirectiveType.OPEN_ACCOUNT:
+                        importer.create_account(directive, repo.book)
+
+                importer.import_business_objects(parser.root_directive.children, repo.book)
+
             # Create use case
             use_case = ImportTransactionsUseCase(repo)
 

--- a/cli/invoice_print_cmd.py
+++ b/cli/invoice_print_cmd.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+"""
+CLI command for printing GnuCash invoices to PDF.
+"""
+
+from pathlib import Path
+
+import click
+import gnucash.gnucash_business as gb
+from gnucash import Query
+
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from services.invoice_renderer import read_book_company_info, render_to_pdf
+
+_XSLT_PATH = Path(__file__).parent.parent / "services" / "invoice.xslt"
+
+
+@click.command()
+@click.argument('gnucash_file', type=click.Path(exists=True))
+@click.option("--invoice-id", required=True, help="ID of the invoice to print.")
+@click.option("-o", "--output", required=True, type=click.Path(), help="Output PDF file path.")
+def print_invoice(gnucash_file, invoice_id, output):
+    """Prints a GnuCash invoice to a PDF file."""
+    click.echo(f"Printing invoice {invoice_id} from {gnucash_file} to {output}...")
+
+    repo = GnuCashRepository(gnucash_file)
+    repo.open(SessionMode.READ_ONLY)
+    book = repo.book
+
+    try:
+        q = Query()
+        q.search_for('gncInvoice')
+        q.set_book(book)
+        invoice = next(
+            (inv for r in q.run() for inv in [gb.Invoice(instance=r)] if inv.GetID() == invoice_id),
+            None
+        )
+        q.destroy()
+
+        if not invoice:
+            raise click.UsageError(f"Invoice with ID '{invoice_id}' not found.")
+
+        company_info = read_book_company_info(gnucash_file)
+
+        render_to_pdf(invoice, book, str(_XSLT_PATH), output, company_info)
+
+        click.echo(f"✓ Successfully printed invoice to {output}")
+
+    finally:
+        repo.close()

--- a/cli/main.py
+++ b/cli/main.py
@@ -12,6 +12,7 @@ from cli.export_beancount_cmd import export_beancount
 from cli.export_cmd import export_transactions
 from cli.import_beancount_cmd import import_beancount
 from cli.import_cmd import import_transactions
+from cli.invoice_print_cmd import print_invoice
 from cli.validate_cmd import validate_ledger
 
 
@@ -37,6 +38,16 @@ def cli():
     pass
 
 
+@cli.command()
+@click.argument('script', type=click.Path(exists=True))
+@click.argument('args', nargs=-1)
+def run(script, args):
+    """Runs a Python script."""
+    import subprocess
+    import sys
+    subprocess.run([sys.executable, script] + list(args), check=True)
+
+
 # Register commands
 cli.add_command(export_transactions, name='export')
 cli.add_command(import_transactions, name='import')
@@ -44,6 +55,7 @@ cli.add_command(validate_ledger, name='validate')
 cli.add_command(export_beancount, name='export-beancount')
 cli.add_command(import_beancount, name='import-beancount')
 cli.add_command(close_books, name='close-books')
+cli.add_command(print_invoice, name='print-invoice')
 
 
 if __name__ == '__main__':

--- a/infrastructure/gnucash/engine.py
+++ b/infrastructure/gnucash/engine.py
@@ -1,0 +1,118 @@
+"""
+Shared ctypes loader for GnuCash's libgnc-engine.
+
+Why ctypes instead of the SWIG bindings
+----------------------------------------
+Several GnuCash C functions (tax-table access, invoice-entry fields) have
+const-type mismatches in the SWIG Python bindings that make them unusable
+from Python directly (confirmed on GnuCash 4.4–5.10, all supported distros).
+
+Why RTLD_GLOBAL + CDLL(None) instead of CDLL(path)
+----------------------------------------------------
+On Debian the GnuCash Python extension loads libgnc-engine with RTLD_GLOBAL,
+so CDLL(None) naturally finds the correct already-loaded instance.
+On Ubuntu the extension uses RTLD_LOCAL (Python's default for .so modules),
+so CDLL(None) may resolve symbols from a *different* globally-visible copy,
+causing a library-instance mismatch and segfault inside gncTaxTableGetTables.
+
+Fix: always call dlopen on the known .so path with RTLD_GLOBAL *first*.
+If the library is already mapped (same inode), dlopen reuses the existing
+mapping and merely promotes its symbols to the global table — no second copy
+is created.  The subsequent CDLL(None) then resolves every symbol from the
+*same* instance that the GnuCash Python extension is using.
+
+Why argtypes must be set for every pointer argument
+----------------------------------------------------
+Without argtypes, Python ctypes converts integer arguments to C int (32-bit).
+On x86_64 a 64-bit pointer like 0x7f1234567890 is silently truncated to
+0x34567890 — a garbage address — and the C function segfaults.
+Setting argtypes = [ctypes.c_void_p] tells ctypes to pass the full 64-bit
+value.  This is mandatory; omitting it will crash on Ubuntu (and silently
+give wrong results on any 64-bit platform if the pointer happens to be >4 GB).
+"""
+import ctypes
+
+_ENGINE_LIB_PATHS = [
+    '/usr/lib/x86_64-linux-gnu/gnucash/libgnc-engine.so',            # Debian 11/12/13, Ubuntu 22/24
+    '/usr/lib/x86_64-linux-gnu/gnucash/gnucash/libgncmod-engine.so', # Ubuntu 20 (GnuCash 3.8)
+]
+
+
+class GncNumericC(ctypes.Structure):
+    """Mirrors the C GncNumeric struct: {int64 num, int64 denom}."""
+    _fields_ = [('num', ctypes.c_int64), ('denom', ctypes.c_int64)]
+
+
+def _setup_lib_restypes(lib: ctypes.CDLL) -> None:
+    """Set restype AND argtypes for every ctypes function we call.
+
+    argtypes must be set for every function that takes a pointer argument.
+    Without it ctypes uses C int (32-bit) for Python integers, truncating
+    64-bit pointers on x86_64 and causing segfaults.
+    """
+    # ── Tax table ────────────────────────────────────────────────────────────
+    lib.gncTaxTableGetTables.restype           = ctypes.c_void_p
+    lib.gncTaxTableGetTables.argtypes          = [ctypes.c_void_p]
+    lib.gncTaxTableGetName.restype             = ctypes.c_char_p
+    lib.gncTaxTableGetName.argtypes            = [ctypes.c_void_p]
+    lib.gncTaxTableGetEntries.restype          = ctypes.c_void_p
+    lib.gncTaxTableGetEntries.argtypes         = [ctypes.c_void_p]
+    lib.gncTaxTableEntryGetAccount.restype     = ctypes.c_void_p
+    lib.gncTaxTableEntryGetAccount.argtypes    = [ctypes.c_void_p]
+    lib.gncTaxTableEntryGetType.restype        = ctypes.c_int
+    lib.gncTaxTableEntryGetType.argtypes       = [ctypes.c_void_p]
+    lib.gncTaxTableEntryGetAmount.restype      = GncNumericC
+    lib.gncTaxTableEntryGetAmount.argtypes     = [ctypes.c_void_p]
+    # ── Account ──────────────────────────────────────────────────────────────
+    lib.xaccAccountGetName.restype             = ctypes.c_char_p
+    lib.xaccAccountGetName.argtypes            = [ctypes.c_void_p]
+    lib.gnc_account_get_parent.restype         = ctypes.c_void_p
+    lib.gnc_account_get_parent.argtypes        = [ctypes.c_void_p]
+    lib.gnc_account_get_full_name.restype      = ctypes.c_char_p
+    lib.gnc_account_get_full_name.argtypes     = [ctypes.c_void_p]
+    # ── Invoice entry ────────────────────────────────────────────────────────
+    lib.gncEntryGetDescription.restype         = ctypes.c_char_p
+    lib.gncEntryGetDescription.argtypes        = [ctypes.c_void_p]
+    lib.gncEntryGetAction.restype              = ctypes.c_char_p
+    lib.gncEntryGetAction.argtypes             = [ctypes.c_void_p]
+    lib.gncEntryGetQuantity.restype            = GncNumericC
+    lib.gncEntryGetQuantity.argtypes           = [ctypes.c_void_p]
+    lib.gncEntryGetInvPrice.restype            = GncNumericC
+    lib.gncEntryGetInvPrice.argtypes           = [ctypes.c_void_p]
+    lib.gncEntryGetInvTaxable.restype          = ctypes.c_int
+    lib.gncEntryGetInvTaxable.argtypes         = [ctypes.c_void_p]
+    lib.gncEntryGetInvTaxIncluded.restype      = ctypes.c_int
+    lib.gncEntryGetInvTaxIncluded.argtypes     = [ctypes.c_void_p]
+    lib.gncEntryGetInvTaxTable.restype         = ctypes.c_void_p
+    lib.gncEntryGetInvTaxTable.argtypes        = [ctypes.c_void_p]
+
+
+def load_gnc_engine() -> ctypes.CDLL:
+    """Load libgnc-engine and return a correctly configured ctypes handle.
+
+    Always promotes the library to RTLD_GLOBAL via its known on-disk path
+    before calling CDLL(None), ensuring we use the same library instance as
+    the GnuCash Python extension (critical on Ubuntu where RTLD_LOCAL is
+    the default).
+    """
+    for path in _ENGINE_LIB_PATHS:
+        try:
+            ctypes.CDLL(path, mode=ctypes.RTLD_GLOBAL)
+            lib = ctypes.CDLL(None)
+            _setup_lib_restypes(lib)
+            return lib
+        except (OSError, AttributeError):
+            pass
+
+    # Final fallback: symbols already globally visible (e.g. RTLD_GLOBAL load
+    # by another part of the process, or LD_PRELOAD).
+    try:
+        lib = ctypes.CDLL(None)
+        _setup_lib_restypes(lib)
+        return lib
+    except AttributeError:
+        pass
+
+    raise RuntimeError(
+        "Could not load libgnc-engine.so — tried: " + str(_ENGINE_LIB_PATHS)
+    )

--- a/infrastructure/gnucash/utils.py
+++ b/infrastructure/gnucash/utils.py
@@ -141,7 +141,7 @@ def to_string_in_fraction_format(number: GncNumeric) -> str:
     return f'{numerator}/{denominator}'
 
 
-def string_to_gnc_numeric(s: str, currency: GncCommodity) -> GncNumeric:
+def string_to_gnc_numeric(s, currency: GncCommodity) -> GncNumeric:
     """
     Convert string to GncNumeric using currency fraction.
 
@@ -152,6 +152,7 @@ def string_to_gnc_numeric(s: str, currency: GncCommodity) -> GncNumeric:
     Returns:
         GncNumeric object
     """
+    s = str(s)
     if '/' in s:
         amount = GncNumeric(s)
     else:
@@ -288,39 +289,33 @@ def decode_value_from_string(s: str):
     Returns:
         Decoded value (int, float, bool, str, or None)
     """
-    import re
 
     if s is None or s == '#None':
         return None
-    if s.isnumeric():
-        return int(s)
-    try:
-        return float(s)
-    except ValueError:
-        pass
-    if s == 'True':
+    if s == 'True' or s == '#True':
         return True
-    if s == 'False':
-        return False
-    if s == 'true':
-        return True
-    if s == 'false':
+    if s == 'False' or s == '#False':
         return False
     if s.startswith('#'):
-        if s == '#True':
-            return True
-        if s == '#False':
-            return False
-        fraction_pattern = r'#(\d+)\s*$'
-        match = re.search(fraction_pattern, s)
-        if match:
-            return int(s[1:].strip())
-        else:
-            # if it is a float, just return the string itself
-            return s
+        s_no_hash = s[1:].strip()
+        if s_no_hash.isnumeric():
+            return int(s_no_hash)
+        try:
+            return float(s_no_hash)
+        except ValueError:
+            pass
     elif s.startswith('"'):
         content = s[1:-1]
         return unescape_string(content)
+    else:
+        # Bare integer (e.g. fraction: 100) or bare float (e.g. fraction: 1)
+        # All unquoted non-keyword values in the plaintext format are numbers.
+        if s.lstrip('-').isnumeric():
+            return int(s)
+        try:
+            return float(s)
+        except ValueError:
+            pass
     return s
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+invoice = [
+    "weasyprint",           # HTML→PDF rendering (install via system package: apt install weasyprint)
+    "lxml>=4.6",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov>=3.0",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,6 +5,7 @@
 #   ./scripts/build.sh              # Build default (debian:13)
 #   ./scripts/build.sh debian:12    # Build specific distribution
 #   ./scripts/build.sh ubuntu:20.04 # Build Ubuntu 20.04
+#   ./scripts/build.sh ubuntu:24.04 # Build Ubuntu 24.04
 
 set -e
 
@@ -33,9 +34,13 @@ case "$BASE_IMAGE" in
         TAG="ubuntu22"
         GNUCASH_VERSION="4.8"
         ;;
+    ubuntu:24.04)
+        TAG="ubuntu24"
+        GNUCASH_VERSION="4.9"
+        ;;
     *)
         echo "Unknown distribution: $BASE_IMAGE"
-        echo "Supported: debian:13, debian:12, debian:11, ubuntu:20.04, ubuntu:22.04"
+        echo "Supported: debian:13, debian:12, debian:11, ubuntu:20.04, ubuntu:22.04, ubuntu:24.04"
         exit 1
         ;;
 esac

--- a/scripts/review-commit.sh
+++ b/scripts/review-commit.sh
@@ -101,12 +101,21 @@ run_ai() {
   unset GEMINI_CLI_NO_RELAUNCH
   
   local index_file
-  index_file=$(git rev-parse --git-path index)
-  local index_backup="${index_file}.pre-review-backup"
-  cp "$index_file" "$index_backup"
+  index_file=$(git rev-parse --git-path index 2>/dev/null || true)
+  # Resolve to absolute path so it works in worktrees and subshells
+  if [ -n "$index_file" ] && [ -f "$index_file" ]; then
+    index_file=$(realpath "$index_file")
+  else
+    index_file=""
+  fi
+  local index_backup=""
+  if [ -n "$index_file" ]; then
+    index_backup="${index_file}.pre-review-backup"
+    cp "$index_file" "$index_backup"
+  fi
 
   # Ensure cleanup happens even if subshell is aborted
-  trap 'cp "$index_backup" "$index_file"; rm -f "$index_backup"' EXIT INT TERM
+  trap '[[ -n "$index_backup" ]] && cp "$index_backup" "$index_file" && rm -f "$index_backup"' EXIT INT TERM
   
   local exit_code
   if [ "$AI_CMD" = "gemini" ]; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -41,6 +41,12 @@ if ! docker image inspect "$IMAGE_NAME" &> /dev/null; then
         ubuntu20)
             ./scripts/build.sh ubuntu:20.04
             ;;
+        ubuntu22)
+            ./scripts/build.sh ubuntu:22.04
+            ;;
+        ubuntu24)
+            ./scripts/build.sh ubuntu:24.04
+            ;;
         *)
             echo "Unknown tag: $TAG"
             exit 1

--- a/scripts/test-all-versions-parallel.sh
+++ b/scripts/test-all-versions-parallel.sh
@@ -17,7 +17,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
 
 # Supported versions
-VERSIONS=("latest" "debian12" "debian11" "ubuntu20" "ubuntu22")
+VERSIONS=("latest" "debian12" "debian11" "ubuntu24" "ubuntu22" "ubuntu20")
 
 echo "Testing against all supported versions IN PARALLEL..."
 echo "This is ~4x faster than sequential testing"
@@ -76,6 +76,7 @@ for version in "${VERSIONS[@]}"; do
                 debian11) echo "debian:11" ;;
                 ubuntu20) echo "ubuntu:20.04" ;;
                 ubuntu22) echo "ubuntu:22.04" ;;
+                ubuntu24) echo "ubuntu:24.04" ;;
             esac)
             docker build --build-arg BASE_IMAGE=$BASE_IMAGE -t gnucash-dev:$version .
         fi

--- a/scripts/test-all-versions.sh
+++ b/scripts/test-all-versions.sh
@@ -14,7 +14,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
 
 # Supported versions (OS versions map to different Python versions)
-VERSIONS=("latest" "debian12" "debian11" "ubuntu20" "ubuntu22")
+VERSIONS=("latest" "debian12" "debian11" "ubuntu24" "ubuntu22" "ubuntu20")
 
 echo "Testing against all supported versions..."
 echo ""

--- a/scripts/test-in-docker.sh
+++ b/scripts/test-in-docker.sh
@@ -12,7 +12,7 @@ set -e
 TEST_PATH="${1:-tests/}"
 
 echo "Installing package..."
-python3 -m pip install -e . --break-system-packages -q
+python3 -m pip install -e . weasyprint --break-system-packages -q
 
 echo ""
 echo "Running tests: $TEST_PATH"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -35,6 +35,12 @@ if ! docker image inspect "$IMAGE_NAME" &> /dev/null; then
         ubuntu20)
             ./scripts/build.sh ubuntu:20.04
             ;;
+        ubuntu22)
+            ./scripts/build.sh ubuntu:22.04
+            ;;
+        ubuntu24)
+            ./scripts/build.sh ubuntu:24.04
+            ;;
         *)
             echo "Unknown tag: $TAG"
             exit 1

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -7,8 +7,11 @@ Converts PlaintextDirective objects from the parser into GnuCash objects
 
 import logging
 from datetime import datetime
+from typing import List
 
-from gnucash import Account, Book, GncCommodity, Split, Transaction
+import gnucash.gnucash_core_c as gc
+from gnucash import Account, Book, GncCommodity, GncNumeric, Split, Transaction
+from gnucash.gnucash_business import Customer, Entry, Invoice, TaxTable, TaxTableEntry, Vendor
 from gnucash.gnucash_core_c import (
     ACCT_TYPE_ASSET,
     ACCT_TYPE_BANK,
@@ -22,10 +25,26 @@ from gnucash.gnucash_core_c import (
     ACCT_TYPE_PAYABLE,
     ACCT_TYPE_RECEIVABLE,
     ACCT_TYPE_STOCK,
+    gncTaxTableEntrySetAccount,
 )
 
 from infrastructure.gnucash.utils import find_account, string_to_gnc_numeric
 from services.plaintext_parser import DirectiveType, PlaintextDirective
+
+
+def string_to_gnc_numeric_quantity(s):
+    from decimal import Decimal
+
+    from gnucash import GncNumeric
+    s = str(s)
+    if '/' in s:
+        return GncNumeric(s)
+    else:
+        # Assuming a precision of 1,000,000 for quantities and prices
+        num = int(Decimal(s) * 1000000)
+        den = 1000000
+        return GncNumeric(num, den)
+
 
 ACCT_TYPE_MAP = {
     "Asset": ACCT_TYPE_ASSET,
@@ -43,8 +62,25 @@ ACCT_TYPE_MAP = {
 }
 
 
+def create_tax_table_entry(book, account, amount_percent):
+    from gnucash.gnucash_core_c import (
+        GNC_AMT_TYPE_PERCENT,
+        gncTaxTableEntryCreate,
+        gncTaxTableEntrySetAmount,
+        gncTaxTableEntrySetType,
+    )
+    raw = gncTaxTableEntryCreate()
+    gncTaxTableEntrySetType(raw, GNC_AMT_TYPE_PERCENT)
+    amount = GncNumeric(round(amount_percent * 100000), 100000)
+    gncTaxTableEntrySetAmount(raw, amount.instance)
+    gncTaxTableEntrySetAccount(raw, account.instance)
+    return TaxTableEntry(instance=raw)
+
+
 class GnuCashImporter:
     """Service for importing plaintext directives to GnuCash"""
+
+
 
     @staticmethod
     def create_commodity(directive: PlaintextDirective, book: Book):
@@ -61,7 +97,7 @@ class GnuCashImporter:
         mnemonic = directive.metadata['mnemonic']
         fullname = directive.metadata['fullname']
         namespace = directive.metadata['namespace']
-        fraction = directive.metadata['fraction']
+        fraction = int(directive.metadata['fraction'])
 
         commodity_table = book.get_table()
         commodity = commodity_table.lookup(namespace, mnemonic)
@@ -112,6 +148,13 @@ class GnuCashImporter:
             parent = parent.lookup_by_name(name)
             if parent is None:
                 raise Exception(f'Cannot find parent account {name} of {account_fullname}')
+
+        # Idempotency check: skip if an account with this name already exists
+        # under the same parent.  create_account may be called twice for the
+        # same file (once from import_cmd pre-pass, once from ImportTransactionsUseCase).
+        if parent.lookup_by_name(account_name) is not None:
+            logging.debug(f"Account {account_fullname} already exists, skipping")
+            return
 
         parent.append_child(account)
         account.SetName(account_name)
@@ -232,3 +275,197 @@ class GnuCashImporter:
         transaction.CommitEdit()
         logging.debug(f"Created transaction on {date_str}")
         return True
+
+    @staticmethod
+    def import_customer(directive: PlaintextDirective, book: Book):
+        if directive.type != DirectiveType.CUSTOMER:
+            raise ValueError(f"Expected CUSTOMER but got {directive.type}")
+
+        customer = Customer(book, directive.props['id'], book.get_table().lookup("CURRENCY", directive.metadata['currency']))
+        customer.BeginEdit()
+        customer.SetName(directive.metadata['name'])
+
+        addr = customer.GetAddr()
+        addr.SetAddr1(directive.metadata.get('addr1', ''))
+        addr.SetAddr2(directive.metadata.get('addr2', ''))
+        addr.SetAddr3(directive.metadata.get('addr3', ''))
+        addr.SetAddr4(directive.metadata.get('addr4', ''))
+        addr.SetEmail(directive.metadata.get('email', ''))
+
+        customer.CommitEdit()
+        logging.debug(f"Created customer {directive.props['id']}")
+
+    @staticmethod
+    def import_vendor(directive: PlaintextDirective, book: Book):
+        if directive.type != DirectiveType.VENDOR:
+            raise ValueError(f"Expected VENDOR but got {directive.type}")
+
+        vendor = Vendor(book, directive.props['id'], book.get_table().lookup("CURRENCY", directive.metadata['currency']))
+        vendor.BeginEdit()
+        vendor.SetName(directive.metadata['name'])
+        vendor.CommitEdit()
+        logging.debug(f"Created vendor {directive.props['id']}")
+
+    @staticmethod
+    def import_taxtable(directive: PlaintextDirective, book: Book):
+        if directive.type != DirectiveType.TAXTABLE:
+            raise ValueError(f"Expected TAXTABLE but got {directive.type}")
+
+        first_entry_directive = None
+        for d in directive.children:
+            if d.type == DirectiveType.TAXTABLE_ENTRY:
+                first_entry_directive = d
+                break
+
+        if not first_entry_directive:
+            # A taxtable must have at least one entry
+            return
+
+        account = find_account(book.get_root_account(), first_entry_directive.metadata['account'])
+        rate_str = first_entry_directive.metadata['rate']
+        rate = float(rate_str.replace("%", ""))
+        first_entry = create_tax_table_entry(book, account, rate)
+
+        taxtable = TaxTable(book, directive.props['name'], first_entry)
+
+        for entry_directive in directive.children[1:]:
+            if entry_directive.type == DirectiveType.TAXTABLE_ENTRY:
+                account = find_account(book.get_root_account(), entry_directive.metadata['account'])
+                rate_str = entry_directive.metadata['rate']
+                rate = float(rate_str.replace("%", ""))
+                entry = create_tax_table_entry(book, account, rate)
+                taxtable.AddEntry(entry)
+
+        logging.debug(f"Created taxtable {directive.props['name']}")
+
+    @staticmethod
+    def import_invoice(directive: PlaintextDirective, book: Book):
+        if directive.type != DirectiveType.INVOICE:
+            raise ValueError(f"Expected INVOICE but got {directive.type}")
+
+        invoice = Invoice(book, directive.props['id'], book.get_table().lookup("CURRENCY", directive.metadata['currency']), book.CustomerLookupByID(directive.metadata['customer_id']))
+        invoice.BeginEdit()
+        invoice.SetDateOpened(datetime.strptime(directive.metadata['date_opened'], "%Y-%m-%d"))
+
+        if 'billing_id' in directive.metadata:
+            invoice.SetBillingID(directive.metadata['billing_id'])
+        if 'notes' in directive.metadata:
+            invoice.SetNotes(directive.metadata['notes'])
+
+        for entry_directive in directive.children:
+            if entry_directive.type == DirectiveType.INVOICE_ENTRY:
+                entry = Entry(book)
+                entry.BeginEdit()
+                entry.SetDate(datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d"))
+                entry.SetDescription(entry_directive.metadata['description'])
+                entry.SetAction(entry_directive.metadata['action'])
+                entry.SetInvAccount(find_account(book.get_root_account(), entry_directive.metadata['account']))
+                entry.SetQuantity(string_to_gnc_numeric_quantity(entry_directive.metadata['quantity']))
+                entry.SetInvPrice(string_to_gnc_numeric_quantity(entry_directive.metadata['price']))
+                entry.SetInvTaxable(entry_directive.metadata['taxable'] == 'true')
+                entry.SetInvTaxIncluded(entry_directive.metadata['tax_included'] == 'true')
+                if 'tax_table' in entry_directive.metadata:
+                    tt_ptr = gc.gncTaxTableLookupByName(book.instance, entry_directive.metadata['tax_table'])
+                    if tt_ptr:
+                        entry.SetInvTaxTable(TaxTable(instance=tt_ptr))
+                invoice.AddEntry(entry)
+                entry.CommitEdit()
+            elif entry_directive.type == DirectiveType.POSTED:
+                ar_account = find_account(book.get_root_account(), entry_directive.metadata['ar_account'])
+                post_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
+                due_date = datetime.strptime(entry_directive.metadata['due'], "%Y-%m-%d")
+                memo = entry_directive.metadata['memo']
+                accumulate = entry_directive.metadata['accumulate'] == 'true'
+                invoice.PostToAccount(ar_account, post_date, due_date, memo, accumulate, False)
+                # Override the transaction description GnuCash set automatically,
+                # so the roundtrip preserves the memo field exactly.
+                posting_txn = invoice.GetPostedTxn()
+                if posting_txn:
+                    posting_txn.BeginEdit()
+                    posting_txn.SetDescription(memo)
+                    posting_txn.SetNotes("business_generated: true")
+                    posting_txn.CommitEdit()
+            elif entry_directive.type == DirectiveType.PAYMENT:
+                bank_account = find_account(book.get_root_account(), entry_directive.metadata['bank_account'])
+                pay_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
+                amount = string_to_gnc_numeric_quantity(entry_directive.metadata['amount'])
+                memo = entry_directive.metadata['memo']
+                num = entry_directive.metadata.get('num', None)
+                new_txn = Transaction(instance=gc.xaccMallocTransaction(book.instance))
+                invoice.ApplyPayment(new_txn, bank_account, amount, GncNumeric(1, 1), pay_date, memo, num)
+
+        invoice.CommitEdit()
+        logging.debug(f"Created invoice {directive.props['id']}")
+
+    @staticmethod
+    def import_bill(directive: PlaintextDirective, book: Book):
+        if directive.type != DirectiveType.BILL:
+            raise ValueError(f"Expected BILL but got {directive.type}")
+
+        # Bills are Invoice objects whose owner is a Vendor (no separate Bill class)
+        bill = Invoice(book, directive.props['id'], book.get_table().lookup("CURRENCY", directive.metadata['currency']), book.VendorLookupByID(directive.metadata['vendor_id']))
+        bill.BeginEdit()
+        bill.SetDateOpened(datetime.strptime(directive.metadata['date_opened'], "%Y-%m-%d"))
+
+        for entry_directive in directive.children:
+            if entry_directive.type == DirectiveType.BILL_ENTRY:
+                entry = Entry(book)
+                entry.BeginEdit()
+                entry.SetDate(datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d"))
+                entry.SetDescription(entry_directive.metadata['description'])
+                entry.SetInvAccount(find_account(book.get_root_account(), entry_directive.metadata['account']))
+                entry.SetQuantity(string_to_gnc_numeric_quantity(entry_directive.metadata['quantity']))
+                entry.SetInvPrice(string_to_gnc_numeric_quantity(entry_directive.metadata['price']))
+                entry.SetInvTaxable(entry_directive.metadata['taxable'] == 'true')
+                if 'tax_table' in entry_directive.metadata:
+                    tt_ptr = gc.gncTaxTableLookupByName(book.instance, entry_directive.metadata['tax_table'])
+                    if tt_ptr:
+                        entry.SetInvTaxTable(TaxTable(instance=tt_ptr))
+                bill.AddEntry(entry)
+                entry.CommitEdit()
+            elif entry_directive.type == DirectiveType.POSTED:
+                ap_account = find_account(book.get_root_account(), entry_directive.metadata['ap_account'])
+                post_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
+                due_date = datetime.strptime(entry_directive.metadata['due'], "%Y-%m-%d")
+                memo = entry_directive.metadata['memo']
+                accumulate = entry_directive.metadata['accumulate'] == 'true'
+                bill.PostToAccount(ap_account, post_date, due_date, memo, accumulate, False)
+                # Override the transaction description GnuCash set automatically,
+                # so the roundtrip preserves the memo field exactly.
+                posting_txn = bill.GetPostedTxn()
+                if posting_txn:
+                    posting_txn.BeginEdit()
+                    posting_txn.SetDescription(memo)
+                    posting_txn.SetNotes("business_generated: true")
+                    posting_txn.CommitEdit()
+            elif entry_directive.type == DirectiveType.PAYMENT:
+                bank_account = find_account(book.get_root_account(), entry_directive.metadata['bank_account'])
+                pay_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
+                amount = string_to_gnc_numeric_quantity(entry_directive.metadata['amount'])
+                memo = entry_directive.metadata['memo']
+                num = entry_directive.metadata.get('num', None)
+                new_txn = Transaction(instance=gc.xaccMallocTransaction(book.instance))
+                bill.ApplyPayment(new_txn, bank_account, amount, GncNumeric(1, 1), pay_date, memo, num)
+
+        bill.CommitEdit()
+        logging.debug(f"Created bill {directive.props['id']}")
+
+    def import_business_objects(self, directives: List[PlaintextDirective], book: Book):
+        # Import customers and vendors first
+        for directive in directives:
+            if directive.type == DirectiveType.CUSTOMER:
+                self.import_customer(directive, book)
+            elif directive.type == DirectiveType.VENDOR:
+                self.import_vendor(directive, book)
+
+        # Then tax tables
+        for directive in directives:
+            if directive.type == DirectiveType.TAXTABLE:
+                self.import_taxtable(directive, book)
+
+        # Finally, invoices and bills
+        for directive in directives:
+            if directive.type == DirectiveType.INVOICE:
+                self.import_invoice(directive, book)
+            elif directive.type == DirectiveType.BILL:
+                self.import_bill(directive, book)

--- a/services/invoice.xslt
+++ b/services/invoice.xslt
@@ -1,0 +1,333 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  invoice.xslt — Transform invoice XML → HTML
+  ============================================
+  Input XML structure (see invoice_to_xml() in test_business_roundtrip.py):
+
+    <invoice status="paid|unpaid" currency="CAD">
+      <id>, <date>, <due-date>, <billing-id>, <notes>
+      <customer>  <name>, <addr1..4>, <email>, <phone>
+      <company>   <name>, <id>, <addr1..4>, <phone>, <email>, <url>
+      <entries>
+        <entry>
+          <description>, <action>, <quantity>, <unit-price>, <amount>
+          <tax-label type="exempt|single|combined">…label text…</tax-label>
+        </entry>
+      </entries>
+      <subtotal>, <total>
+      <tax-lines>
+        <tax-line>  <name>, <amount>
+      </tax-lines>
+    </invoice>
+
+  Styling rules for the Tax Applied column:
+    type="exempt"   → grey italic    (zero-rated / no tax)
+    type="single"   → dark blue      (one tax, e.g. GST only or HST)
+    type="combined" → dark orange    (two or more taxes, e.g. GST + PST)
+
+  To change styles, edit the <style> block below — no Python changes needed.
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:output method="html" encoding="UTF-8" indent="yes" doctype-public="-//W3C//DTD HTML 4.01//EN"/>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     Root template
+     ═══════════════════════════════════════════════════════════════════════ -->
+<xsl:template match="/invoice">
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <title>Invoice <xsl:value-of select="id"/></title>
+  <style>
+    /* ── Page layout ──────────────────────────────────────────────── */
+    body        { font-family: Arial, sans-serif; font-size: 13px;
+                  margin: 40px; color: #222; }
+    h1          { font-size: 24px; margin: 0 0 2px; letter-spacing: 1px; }
+    .inv-meta   { color: #666; font-size: 12px; margin-bottom: 24px; }
+
+    /* ── Status badge ─────────────────────────────────────────────── */
+    .badge        { display: inline-block; padding: 2px 8px; border-radius: 4px;
+                    font-size: 11px; font-weight: bold; text-transform: uppercase;
+                    letter-spacing: 1px; margin-left: 10px; vertical-align: middle; }
+    .badge-paid   { background: #d4edda; color: #155724; }
+    .badge-unpaid { background: #fff3cd; color: #856404; }
+
+    /* ── Payment history section ───────────────────────────────────── */
+    .payment-section { margin-top: 28px; }
+    .payment-section h3 { font-size: 11px; text-transform: uppercase;
+                          letter-spacing: 1px; color: #999; margin: 0 0 6px; }
+    .payment-section table { margin-top: 0; }
+    .pay-row td  { padding: 4px 8px; border-bottom: 1px solid #eee;
+                   font-size: 12px; color: #444; }
+    .pay-num     { color: #888; font-size: 11px; }
+    .remaining-row td { padding: 6px 8px; font-weight: bold;
+                        border-top: 2px solid #333; }
+    .remaining-paid   { color: #155724; }
+    .remaining-due    { color: #856404; }
+
+    /* ── Addresses ────────────────────────────────────────────────── */
+    .addresses  { display: flex; gap: 60px; margin-bottom: 28px; }
+    .addr h3    { margin: 0 0 6px; font-size: 11px; text-transform: uppercase;
+                  color: #999; letter-spacing: 1px; }
+    .addr p     { margin: 1px 0; }
+    .addr-from  { margin-left: auto; text-align: right; }
+    .co-reg     { color: #888; font-size: 11px; }
+
+    /* ── Line-items table ─────────────────────────────────────────── */
+    table       { width: 100%; border-collapse: collapse; }
+    thead th    { background: #f5f5f5; padding: 7px 8px; text-align: left;
+                  border-top: 2px solid #ccc; border-bottom: 2px solid #ccc;
+                  font-size: 11px; text-transform: uppercase; letter-spacing: .5px; }
+    tbody td    { padding: 6px 8px; border-bottom: 1px solid #eee; }
+    tfoot td    { padding: 6px 8px; }
+
+    /* ── Subtotal / tax rows ──────────────────────────────────────── */
+    .subtotal-row td { color: #555; font-style: italic; }
+    .tax-row td      { color: #555; }
+    .total-row td    { font-weight: bold; font-size: 14px;
+                       border-top: 2px solid #333; }
+
+    /* ── Tax-applied column colours ──────────────────────────────── */
+    /* Change these three rules to restyle the Tax Applied column     */
+    .tax-exempt   { color: #aaa; font-style: italic; }          /* zero-rated   */
+    .tax-single   { color: #1a5276; }                            /* one tax      */
+    .tax-combined { color: #b85c00; font-weight: bold; }         /* GST + PST/QST */
+
+    /* ── Notes ───────────────────────────────────────────────────── */
+    .notes { margin-top: 28px; padding: 10px 14px; background: #fafafa;
+             border-left: 3px solid #ccc; color: #555; font-size: 12px; }
+  </style>
+</head>
+<body>
+
+  <!-- Invoice title + status badge -->
+  <h1>
+    Invoice
+    <xsl:choose>
+      <xsl:when test="@status = 'paid'">
+        <span class="badge badge-paid">Paid</span>
+      </xsl:when>
+      <xsl:otherwise>
+        <span class="badge badge-unpaid">Unpaid</span>
+      </xsl:otherwise>
+    </xsl:choose>
+  </h1>
+
+  <div class="inv-meta">
+    <strong>Invoice #:</strong> <xsl:value-of select="id"/>
+    &#160;|&#160;
+    <strong>Date:</strong> <xsl:value-of select="date"/>
+    &#160;|&#160;
+    <strong>Due:</strong> <xsl:value-of select="due-date"/>
+    <xsl:if test="string-length(billing-id) > 0">
+      &#160;|&#160;
+      <strong>PO / Billing ID:</strong> <xsl:value-of select="billing-id"/>
+    </xsl:if>
+  </div>
+
+  <!-- Bill-to / From addresses -->
+  <div class="addresses">
+    <!-- Bill To (customer) -->
+    <div class="addr">
+      <h3>Bill To</h3>
+      <p><strong><xsl:value-of select="customer/name"/></strong></p>
+      <xsl:if test="string-length(customer/addr1) > 0">
+        <p><xsl:value-of select="customer/addr1"/></p>
+      </xsl:if>
+      <xsl:if test="string-length(customer/addr2) > 0">
+        <p><xsl:value-of select="customer/addr2"/></p>
+      </xsl:if>
+      <xsl:if test="string-length(customer/addr3) > 0">
+        <p><xsl:value-of select="customer/addr3"/></p>
+      </xsl:if>
+      <xsl:if test="string-length(customer/addr4) > 0">
+        <p><xsl:value-of select="customer/addr4"/></p>
+      </xsl:if>
+      <xsl:if test="string-length(customer/email) > 0">
+        <p><xsl:value-of select="customer/email"/></p>
+      </xsl:if>
+    </div>
+
+    <!-- From (seller / company) — shown only when company name is present -->
+    <xsl:if test="string-length(company/name) > 0">
+      <div class="addr addr-from">
+        <h3>From</h3>
+        <p><strong><xsl:value-of select="company/name"/></strong></p>
+        <xsl:if test="string-length(company/id) > 0">
+          <p class="co-reg">GST/HST Reg: <xsl:value-of select="company/id"/></p>
+        </xsl:if>
+        <xsl:if test="string-length(company/addr1) > 0">
+          <p><xsl:value-of select="company/addr1"/></p>
+        </xsl:if>
+        <xsl:if test="string-length(company/addr2) > 0">
+          <p><xsl:value-of select="company/addr2"/></p>
+        </xsl:if>
+        <xsl:if test="string-length(company/addr3) > 0">
+          <p><xsl:value-of select="company/addr3"/></p>
+        </xsl:if>
+        <xsl:if test="string-length(company/addr4) > 0">
+          <p><xsl:value-of select="company/addr4"/></p>
+        </xsl:if>
+        <xsl:if test="string-length(company/phone) > 0">
+          <p><xsl:value-of select="company/phone"/></p>
+        </xsl:if>
+        <xsl:if test="string-length(company/email) > 0">
+          <p><xsl:value-of select="company/email"/></p>
+        </xsl:if>
+      </div>
+    </xsl:if>
+  </div>
+
+  <!-- Line-items table -->
+  <table>
+    <thead>
+      <tr>
+        <th>Description</th>
+        <th style="text-align:center">Unit</th>
+        <th style="text-align:right">Qty</th>
+        <th style="text-align:right">Unit Price</th>
+        <th style="text-align:right">Amount</th>
+        <th style="text-align:center">Tax Applied</th>
+      </tr>
+    </thead>
+    <tbody>
+      <xsl:apply-templates select="entries/entry"/>
+
+      <!-- Subtotal row -->
+      <tr class="subtotal-row">
+        <td colspan="4" style="text-align:right"><em>Subtotal</em></td>
+        <td style="text-align:right">
+          <xsl:value-of select="concat(@currency, '&#160;')"/>
+          <xsl:value-of select="format-number(subtotal, '#,##0.00')"/>
+        </td>
+        <td/>
+      </tr>
+
+      <!-- Tax lines -->
+      <xsl:apply-templates select="tax-lines/tax-line"/>
+    </tbody>
+    <tfoot>
+      <tr class="total-row">
+        <td colspan="4" style="text-align:right">Total Due (<xsl:value-of select="@currency"/>)</td>
+        <td style="text-align:right">
+          <xsl:value-of select="concat(@currency, '&#160;')"/>
+          <xsl:value-of select="format-number(total, '#,##0.00')"/>
+        </td>
+        <td/>
+      </tr>
+    </tfoot>
+  </table>
+
+  <!-- Payment history -->
+  <xsl:if test="payments/payment">
+    <div class="payment-section">
+      <h3>Payment History</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Reference</th>
+            <th>Memo</th>
+            <th style="text-align:right">Amount Paid</th>
+          </tr>
+        </thead>
+        <tbody>
+          <xsl:apply-templates select="payments/payment"/>
+          <tr class="remaining-row">
+            <td colspan="3" style="text-align:right">Amount Remaining</td>
+            <td style="text-align:right">
+              <xsl:choose>
+                <xsl:when test="number(amount-remaining) = 0">
+                  <span class="remaining-paid">
+                    <xsl:value-of select="@currency"/>&#160;0.00&#160;&#10003;
+                  </span>
+                </xsl:when>
+                <xsl:otherwise>
+                  <span class="remaining-due">
+                    <xsl:value-of select="@currency"/>&#160;<xsl:value-of select="format-number(amount-remaining, '#,##0.00')"/>
+                  </span>
+                </xsl:otherwise>
+              </xsl:choose>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </xsl:if>
+
+  <!-- Notes -->
+  <xsl:if test="string-length(notes) > 0">
+    <div class="notes">
+      <strong>Notes:</strong> <xsl:value-of select="notes"/>
+    </div>
+  </xsl:if>
+
+</body>
+</html>
+</xsl:template>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     Line-item entry row
+     ═══════════════════════════════════════════════════════════════════════ -->
+<xsl:template match="entry">
+  <tr>
+    <td><xsl:value-of select="description"/></td>
+    <td style="text-align:center"><xsl:value-of select="action"/></td>
+    <td style="text-align:right">
+      <xsl:value-of select="format-number(quantity, '#,##0.##')"/>
+    </td>
+    <td style="text-align:right">
+      $<xsl:value-of select="format-number(unit-price, '#,##0.00')"/>
+    </td>
+    <td style="text-align:right">
+      $<xsl:value-of select="format-number(amount, '#,##0.00')"/>
+    </td>
+    <td style="text-align:center; font-size:11px">
+      <!-- Colour class is driven by the type attribute on <tax-label> -->
+      <xsl:variable name="ttype" select="tax-label/@type"/>
+      <xsl:choose>
+        <xsl:when test="$ttype = 'exempt'">
+          <span class="tax-exempt"><xsl:value-of select="tax-label"/></span>
+        </xsl:when>
+        <xsl:when test="$ttype = 'combined'">
+          <span class="tax-combined"><xsl:value-of select="tax-label"/></span>
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- single or anything else -->
+          <span class="tax-single"><xsl:value-of select="tax-label"/></span>
+        </xsl:otherwise>
+      </xsl:choose>
+    </td>
+  </tr>
+</xsl:template>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     Payment history row
+     ═══════════════════════════════════════════════════════════════════════ -->
+<xsl:template match="payment">
+  <tr class="pay-row">
+    <td><xsl:value-of select="date"/></td>
+    <td class="pay-num"><xsl:value-of select="num"/></td>
+    <td><xsl:value-of select="memo"/></td>
+    <td style="text-align:right">
+      $<xsl:value-of select="format-number(amount, '#,##0.00')"/>
+    </td>
+  </tr>
+</xsl:template>
+
+<!-- ═══════════════════════════════════════════════════════════════════════
+     Tax summary row
+     ═══════════════════════════════════════════════════════════════════════ -->
+<xsl:template match="tax-line">
+  <tr class="tax-row">
+    <td colspan="4" style="text-align:right">
+      <xsl:value-of select="name"/>
+    </td>
+    <td style="text-align:right">
+      $<xsl:value-of select="format-number(amount, '#,##0.00')"/>
+    </td>
+    <td/>
+  </tr>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/services/invoice_renderer.py
+++ b/services/invoice_renderer.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python
+"""
+Service for rendering GnuCash invoices to PDF.
+"""
+import ctypes
+import xml.etree.ElementTree as ET
+
+import gnucash.gnucash_core_c as gc
+from gnucash import Split
+
+from infrastructure.gnucash.engine import load_gnc_engine
+
+
+def read_book_company_info(file_path):
+    import gzip as _gz
+    import xml.etree.ElementTree
+
+    slot_key = '{http://www.gnucash.org/XML/slot}key'
+    slot_val = '{http://www.gnucash.org/XML/slot}value'
+    book_slots = '{http://www.gnucash.org/XML/book}slots'
+    gnc_book = '{http://www.gnucash.org/XML/gnc}book'
+
+    try:
+        with _gz.open(file_path, 'rb') as f:
+            xml_root = xml.etree.ElementTree.parse(f).getroot()
+    except Exception:
+        xml_root = xml.etree.ElementTree.parse(file_path).getroot()
+
+    def _frame_val(parent, key):
+        if parent is None:
+            return None
+        candidates = parent.findall('slot')
+        if not candidates:
+            candidates = [c for c in parent if c.tag.endswith('}slot') or c.tag == 'slot']
+        for slot in candidates:
+            k = slot.find(slot_key)
+            if k is not None and k.text == key:
+                return slot.find(slot_val)
+        return None
+
+    def _str_val(parent, key):
+        v = _frame_val(parent, key)
+        return (v.text or '').strip() if v is not None else ''
+
+    book_el = xml_root.find('.//' + gnc_book)
+    book_slots = book_el.find(book_slots) if book_el is not None else None
+    options_el = _frame_val(book_slots, 'options')
+    biz_el = _frame_val(options_el, 'Business')
+
+    result = {
+        'name': _str_val(biz_el, 'Company Name'),
+        'id': _str_val(biz_el, 'Company ID'),
+        'phone': _str_val(biz_el, 'Company Phone Number'),
+        'email': _str_val(biz_el, 'Company Email Address'),
+        'url': _str_val(biz_el, 'Company Website URL'),
+    }
+    addr_raw = _str_val(biz_el, 'Company Address')
+    addr_lines = addr_raw.split('\n') if addr_raw else []
+    for i, k in enumerate(['addr1', 'addr2', 'addr3', 'addr4']):
+        result[k] = addr_lines[i].strip() if i < len(addr_lines) else ''
+
+    return result
+
+
+def _read_tax_label(lib, ptr):
+    taxable = bool(lib.gncEntryGetInvTaxable(ptr))
+    if not taxable:
+        return 'Exempt', 'exempt'
+
+    tt_ptr = lib.gncEntryGetInvTaxTable(ptr)
+    if not tt_ptr:
+        return 'Taxable', 'single'
+
+    tt_name_b = lib.gncTaxTableGetName(tt_ptr)
+    tt_name = tt_name_b.decode('utf-8') if tt_name_b else 'Taxable'
+
+    glist_ptr = lib.gncTaxTableGetEntries(tt_ptr)
+    rate_parts = []
+    while glist_ptr:
+        buf = (ctypes.c_void_p * 3).from_address(glist_ptr)
+        tte_ptr = buf[0]
+        glist_ptr = buf[1]
+        if not tte_ptr:
+            continue
+        acct_ptr = lib.gncTaxTableEntryGetAccount(tte_ptr)
+        amt_c = lib.gncTaxTableEntryGetAmount(tte_ptr)
+        rate = amt_c.num / amt_c.denom if amt_c.denom else 0.0
+        name_b = lib.xaccAccountGetName(acct_ptr) if acct_ptr else None
+        name = name_b.decode('utf-8') if name_b else '?'
+        rate_str = f"{rate:g}%"
+        label = name if rate_str in name else f"{name} {rate_str}"
+        rate_parts.append(label)
+
+    rate_parts.reverse()
+    if not rate_parts:
+        return tt_name, 'single'
+
+    label = ' + '.join(rate_parts)
+    ttype = 'combined' if len(rate_parts) > 1 else 'single'
+    return label, ttype
+
+
+def invoice_to_xml(inv, book, company_info=None):
+    lib = load_gnc_engine()
+
+    inv_id = inv.GetID()
+    is_paid = gc.gncInvoiceIsPaid(inv.instance)
+    currency = inv.GetCurrency().get_mnemonic()
+    date_opened = inv.GetDateOpened().strftime("%Y-%m-%d")
+    date_due = inv.GetDateDue()
+    date_due_s = date_due.strftime("%Y-%m-%d") if date_due else ''
+    notes = inv.GetNotes() or ''
+    billing_id = inv.GetBillingID() or ''
+
+    cust = None
+    try:
+        owner = inv.GetOwner()
+        cust = owner.GetCustomer()
+    except Exception:
+        pass
+    if cust is None:
+        raise ValueError("Could not determine customer for invoice")
+
+    addr = cust.GetAddr()
+    cust_name = cust.GetName()
+    addr1, addr2 = addr.GetAddr1(), addr.GetAddr2()
+    addr3, addr4 = addr.GetAddr3(), addr.GetAddr4()
+    email = addr.GetEmail()
+
+    root = ET.Element('invoice',
+                      status='paid' if is_paid else 'unpaid',
+                      currency=currency)
+    ET.SubElement(root, 'id').text = inv_id
+    ET.SubElement(root, 'date').text = date_opened
+    ET.SubElement(root, 'due-date').text = date_due_s
+    ET.SubElement(root, 'billing-id').text = billing_id
+    ET.SubElement(root, 'notes').text = notes
+
+    c_el = ET.SubElement(root, 'customer')
+    ET.SubElement(c_el, 'name').text = cust_name
+    ET.SubElement(c_el, 'addr1').text = addr1 or ''
+    ET.SubElement(c_el, 'addr2').text = addr2 or ''
+    ET.SubElement(c_el, 'addr3').text = addr3 or ''
+    ET.SubElement(c_el, 'addr4').text = addr4 or ''
+    ET.SubElement(c_el, 'email').text = email or ''
+
+    co = company_info or {}
+    co_el = ET.SubElement(root, 'company')
+    ET.SubElement(co_el, 'name').text = co.get('name', '')
+    ET.SubElement(co_el, 'id').text = co.get('id', '')
+    ET.SubElement(co_el, 'addr1').text = co.get('addr1', '')
+    ET.SubElement(co_el, 'addr2').text = co.get('addr2', '')
+    ET.SubElement(co_el, 'addr3').text = co.get('addr3', '')
+    ET.SubElement(co_el, 'addr4').text = co.get('addr4', '')
+    ET.SubElement(co_el, 'phone').text = co.get('phone', '')
+    ET.SubElement(co_el, 'email').text = co.get('email', '')
+    ET.SubElement(co_el, 'url').text = co.get('url', '')
+
+    entries_el = ET.SubElement(root, 'entries')
+    for raw_entry in inv.GetEntries():
+        ptr = int(raw_entry.instance)
+        desc = (lib.gncEntryGetDescription(ptr) or b'').decode('utf-8')
+        action = (lib.gncEntryGetAction(ptr) or b'').decode('utf-8')
+        qty_c = lib.gncEntryGetQuantity(ptr)
+        price_c = lib.gncEntryGetInvPrice(ptr)
+        qty = qty_c.num / qty_c.denom if qty_c.denom else 0.0
+        price = price_c.num / price_c.denom if price_c.denom else 0.0
+
+        tax_label, tax_type = _read_tax_label(lib, ptr)
+
+        e_el = ET.SubElement(entries_el, 'entry')
+        ET.SubElement(e_el, 'description').text = desc
+        ET.SubElement(e_el, 'action').text = action
+        ET.SubElement(e_el, 'quantity').text = f"{qty:.4f}".rstrip('0').rstrip('.')
+        ET.SubElement(e_el, 'unit-price').text = f"{price:.2f}"
+        ET.SubElement(e_el, 'amount').text = f"{qty * price:.2f}"
+        ET.SubElement(e_el, 'tax-label', type=tax_type).text = tax_label
+
+    posting_txn = inv.GetPostedTxn()
+    subtotal_total = 0.0
+    tax_lines_el = ET.SubElement(root, 'tax-lines')
+    for i in range(posting_txn.CountSplits()):
+        s = posting_txn.GetSplit(i)
+        acct = s.GetAccount()
+        atype = gc.xaccAccountGetType(acct.instance)
+        amt = s.GetAmount().to_double()
+        if atype == gc.ACCT_TYPE_INCOME:
+            subtotal_total += abs(amt)
+        elif atype in (gc.ACCT_TYPE_LIABILITY, gc.ACCT_TYPE_PAYABLE):
+            tl = ET.SubElement(tax_lines_el, 'tax-line')
+            ET.SubElement(tl, 'name').text = acct.GetName()
+            ET.SubElement(tl, 'amount').text = f"{abs(amt):.2f}"
+
+    grand_total = subtotal_total + sum(
+        float(tl.find('amount').text) for tl in tax_lines_el
+    )
+    ET.SubElement(root, 'subtotal').text = f"{subtotal_total:.2f}"
+    ET.SubElement(root, 'total').text = f"{grand_total:.2f}"
+
+    lot = inv.GetPostedLot()
+    payments_el = ET.SubElement(root, 'payments')
+    for raw_split in lot.get_split_list():
+        s = Split(instance=raw_split)
+        txn = s.GetParent()
+        if txn is None:
+            continue
+        if gc.gncInvoiceGetInvoiceFromTxn(txn.instance) is not None:
+            continue
+        pay_date = txn.GetDate().strftime("%Y-%m-%d")
+        pay_memo = txn.GetDescription() or ''
+        pay_num = txn.GetNum() or ''
+        pay_amt = abs(s.GetAmount().to_double())
+        p_el = ET.SubElement(payments_el, 'payment')
+        ET.SubElement(p_el, 'date').text = pay_date
+        ET.SubElement(p_el, 'memo').text = pay_memo
+        ET.SubElement(p_el, 'num').text = pay_num
+        ET.SubElement(p_el, 'amount').text = f"{pay_amt:.2f}"
+
+    remaining = lot.get_balance().to_double()
+    ET.SubElement(root, 'amount-remaining').text = f"{abs(remaining):.2f}"
+
+    return ET.ElementTree(root)
+
+
+def render_to_pdf(invoice, book, xslt_path, pdf_path, company_info=None):
+    import weasyprint
+    from lxml import etree as lxml_etree
+
+    xml_tree = invoice_to_xml(invoice, book, company_info=company_info)
+
+    # In-memory transformation
+    xml_str = ET.tostring(xml_tree.getroot(), encoding='unicode')
+    xml_doc = lxml_etree.fromstring(xml_str)
+    xslt_doc = lxml_etree.parse(xslt_path)
+    transform = lxml_etree.XSLT(xslt_doc)
+    html_doc = transform(xml_doc)
+
+    weasyprint.HTML(string=str(html_doc)).write_pdf(pdf_path)

--- a/services/plaintext_parser.py
+++ b/services/plaintext_parser.py
@@ -14,10 +14,109 @@ all features from the legacy parser.
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Iterable, List, Optional, Tuple
 
 from infrastructure.gnucash.utils import decode_value_from_string
+
+
+@dataclass
+class CustomerDirective:
+    id: str
+    name: str
+    currency: str
+    addr1: Optional[str] = None
+    addr2: Optional[str] = None
+    addr3: Optional[str] = None
+    addr4: Optional[str] = None
+    email: Optional[str] = None
+
+
+@dataclass
+class VendorDirective:
+    id: str
+    name: str
+    currency: str
+
+
+@dataclass
+class TaxTableEntry:
+    account: str
+    rate: str
+    type: str
+
+
+@dataclass
+class TaxTableDirective:
+    name: str
+    entries: List[TaxTableEntry] = field(default_factory=list)
+
+
+@dataclass
+class InvoiceEntry:
+    date: str
+    description: str
+    action: str
+    account: str
+    quantity: str
+    price: str
+    taxable: bool
+    tax_included: bool
+    tax_table: Optional[str] = None
+
+
+@dataclass
+class PostedDirective:
+    date: str
+    due: str
+    account: str
+    memo: str
+    accumulate: bool
+
+
+@dataclass
+class PaymentDirective:
+    date: str
+    amount: str
+    bank_account: str
+    memo: str
+    num: Optional[str] = None
+
+
+@dataclass
+class InvoiceDirective:
+    id: str
+    customer_id: str
+    currency: str
+    date_opened: str
+    billing_id: Optional[str] = None
+    notes: Optional[str] = None
+    entries: List[InvoiceEntry] = field(default_factory=list)
+    posted: Optional[PostedDirective] = None
+    payments: List[PaymentDirective] = field(default_factory=list)
+
+
+@dataclass
+class BillEntry:
+    date: str
+    description: str
+    account: str
+    quantity: str
+    price: str
+    taxable: bool
+    tax_table: Optional[str] = None
+
+
+@dataclass
+class BillDirective:
+    id: str
+    vendor_id: str
+    currency: str
+    date_opened: str
+    entries: List[BillEntry] = field(default_factory=list)
+    posted: Optional[PostedDirective] = None
+    payments: List[PaymentDirective] = field(default_factory=list)
 
 
 class DirectiveType(Enum):
@@ -28,6 +127,17 @@ class DirectiveType(Enum):
     TRANSACTION = 3
     SPLIT = 4
     METADATA_KEY_VALUE = 5
+    CUSTOMER = 6
+    VENDOR = 7
+    TAXTABLE = 8
+    INVOICE = 9
+    BILL = 10
+    TAXTABLE_ENTRY = 11
+    INVOICE_ENTRY = 12
+    BILL_ENTRY = 13
+    POSTED = 14
+    PAYMENT = 15
+
 
 
 class PlaintextDirective:
@@ -161,6 +271,12 @@ class PlaintextParser:
             (tx_date, tx_num, tx_desc) = parse_transaction_head(line)
             (split_account_name, split_amount, split_symbol) = parse_split(line)
             (key, value) = parse_metadata(line)
+            customer_id = parse_customer(line.strip())
+            taxtable_name = parse_taxtable(line.strip())
+            invoice_id = parse_invoice(line.strip())
+            vendor_id = parse_vendor(line.strip())
+            bill_id = parse_bill(line.strip())
+            block_type = parse_block(line.strip())
 
             if account_date is not None:
                 obj = PlaintextDirective(DirectiveType.OPEN_ACCOUNT, line_level, line, parent_directive)
@@ -190,6 +306,45 @@ class PlaintextParser:
                 obj.props['account'] = split_account_name
                 parent_directive.children.append(obj)
                 self.current_directive = obj
+            elif customer_id is not None:
+                obj = PlaintextDirective(DirectiveType.CUSTOMER, line_level, line, parent_directive)
+                obj.props['id'] = customer_id
+                parent_directive.children.append(obj)
+                self.current_directive = obj
+            elif taxtable_name is not None:
+                obj = PlaintextDirective(DirectiveType.TAXTABLE, line_level, line, parent_directive)
+                obj.props['name'] = taxtable_name
+                parent_directive.children.append(obj)
+                self.current_directive = obj
+            elif invoice_id is not None:
+                obj = PlaintextDirective(DirectiveType.INVOICE, line_level, line, parent_directive)
+                obj.props['id'] = invoice_id
+                parent_directive.children.append(obj)
+                self.current_directive = obj
+            elif vendor_id is not None:
+                obj = PlaintextDirective(DirectiveType.VENDOR, line_level, line, parent_directive)
+                obj.props['id'] = vendor_id
+                parent_directive.children.append(obj)
+                self.current_directive = obj
+            elif bill_id is not None:
+                obj = PlaintextDirective(DirectiveType.BILL, line_level, line, parent_directive)
+                obj.props['id'] = bill_id
+                parent_directive.children.append(obj)
+                self.current_directive = obj
+            elif block_type is not None:
+                if block_type == "entry":
+                    if parent_directive.type == DirectiveType.TAXTABLE:
+                        obj = PlaintextDirective(DirectiveType.TAXTABLE_ENTRY, line_level, line, parent_directive)
+                    elif parent_directive.type == DirectiveType.INVOICE:
+                        obj = PlaintextDirective(DirectiveType.INVOICE_ENTRY, line_level, line, parent_directive)
+                    else:
+                        obj = PlaintextDirective(DirectiveType.BILL_ENTRY, line_level, line, parent_directive)
+                elif block_type == "posted":
+                    obj = PlaintextDirective(DirectiveType.POSTED, line_level, line, parent_directive)
+                else:
+                    obj = PlaintextDirective(DirectiveType.PAYMENT, line_level, line, parent_directive)
+                parent_directive.children.append(obj)
+                self.current_directive = obj
             elif key is not None:
                 parent_directive.metadata[key] = value
                 if key == 'namespace' and parent_directive.type == DirectiveType.CREATE_COMMODITY:
@@ -215,6 +370,57 @@ metadata_pattern = r'^\s*([a-z_][a-zA-Z0-9_\-.]*)\s*:\s*(.*?)\s*$'
 commodity_pattern = r'^\s*(\d{4}-\d{2}-\d{2})\s+(commodity)\s+([^"\']*)\s*$'
 open_account_pattern = r'^\s*(\d{4}-\d{2}-\d{2})\s+(open)\s+([^"]*)\s*([^"\']*)\s*$'
 open_account_pattern2 = r'^\s*(\d{4}-\d{2}-\d{2})\s+(open)\s+("(?:\\.|[^"])*?"|\{.*?\})\s*([^"\']*)\s*$'
+customer_pattern = r'^customer\s+"(.*?)"\s*$'
+taxtable_pattern = r'^taxtable\s+"(.*?)"\s*$'
+invoice_pattern = r'^invoice\s+"(.*?)"\s*$'
+vendor_pattern = r'^vendor\s+"(.*?)"\s*$'
+bill_pattern = r'^bill\s+"(.*?)"\s*$'
+block_pattern = r'^\s*(entry|posted|payment):\s*$'
+
+
+def parse_customer(line: str) -> Optional[str]:
+    match = re.match(customer_pattern, line)
+    if match:
+        return match.group(1)
+    return None
+
+
+def parse_taxtable(line: str) -> Optional[str]:
+    match = re.match(taxtable_pattern, line)
+    if match:
+        return match.group(1)
+    return None
+
+
+def parse_invoice(line: str) -> Optional[str]:
+    match = re.match(invoice_pattern, line)
+    if match:
+        return match.group(1)
+    return None
+
+
+def parse_vendor(line: str) -> Optional[str]:
+    match = re.match(vendor_pattern, line)
+    if match:
+        return match.group(1)
+    return None
+
+
+def parse_bill(line: str) -> Optional[str]:
+    match = re.match(bill_pattern, line)
+    if match:
+        return match.group(1)
+    return None
+
+
+def parse_block(line: str) -> Optional[str]:
+    match = re.match(block_pattern, line)
+    if match:
+        return match.group(1)
+    return None
+
+
+
 
 
 def parse_split(split_line: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:

--- a/tests/fixtures/business_objects.txt
+++ b/tests/fixtures/business_objects.txt
@@ -1,0 +1,55 @@
+2026-01-01 open Liabilities
+  type: Liability
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Income
+  type: Income
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Assets
+  type: Asset
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:GST
+  type: Liability
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Income:Sales
+  type: Income
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Accounts Receivable
+  type: Asset
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+
+customer "1"
+  name: "Test Customer"
+  currency: CAD
+
+taxtable "GST"
+  entry:
+    account: "Liabilities:GST"
+    rate: 5.0%
+    type: PERCENT
+
+invoice "INV-2026-001"
+  customer_id: "1"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Test Entry"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 1
+    price: 100
+    taxable: true
+    tax_included: false
+    tax_table: "GST"
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-2026-001"
+    accumulate: true

--- a/tests/fixtures/business_objects_only.txt
+++ b/tests/fixtures/business_objects_only.txt
@@ -1,0 +1,30 @@
+customer "1"
+  name: "Test Customer"
+  currency: CAD
+
+taxtable "GST"
+  entry:
+    account: "Liabilities:GST"
+    rate: 5.0%
+    type: PERCENT
+
+invoice "INV-2026-001"
+  customer_id: "1"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Test Entry"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 1
+    price: 100
+    taxable: true
+    tax_included: false
+    tax_table: "GST"
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-2026-001"
+    accumulate: true

--- a/tests/integration/test_business_objects.py
+++ b/tests/integration/test_business_objects.py
@@ -1,0 +1,77 @@
+import os
+import re
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+_BOBJ_PREFIXES = re.compile(r'^(customer|vendor|taxtable|invoice|bill)\b')
+
+
+def extract_business_objects(text: str) -> str:
+    """
+    Extract business-object blocks (customer/vendor/taxtable/invoice/bill)
+    from a plaintext export that also contains account/transaction sections.
+    """
+    blocks = []
+    current = []
+    for line in text.splitlines():
+        if _BOBJ_PREFIXES.match(line):
+            if current:
+                blocks.append('\n'.join(current))
+            current = [line]
+        elif current:
+            # Indented continuation or blank line inside a block
+            if line == '' or line.startswith(' ') or line.startswith('\t'):
+                current.append(line)
+            else:
+                # Non-indented line that is NOT a business-object header ends the block
+                blocks.append('\n'.join(current))
+                current = []
+    if current:
+        blocks.append('\n'.join(current))
+    return '\n\n'.join(b.rstrip() for b in blocks)
+
+
+def test_business_objects_roundtrip(tmp_path):
+    runner = CliRunner()
+    gnucash_file = tmp_path / "test.gnucash"
+    input_file = "tests/fixtures/business_objects.txt"
+    output_file = tmp_path / "output.txt"
+    pdf_file = tmp_path / "invoice.pdf"
+
+    # Create a new GnuCash file and import everything
+    result = runner.invoke(cli, ["import", "--new", str(gnucash_file), input_file, "--include-business-objects"])
+    assert result.exit_code == 0, f"Import failed:\n{result.output}"
+
+    # Export including business objects
+    # Output order: accounts → business objects → transactions
+    result = runner.invoke(cli, ["export", str(gnucash_file), str(output_file), "--include-business-objects"])
+    assert result.exit_code == 0, f"Export failed:\n{result.output}"
+
+    with open(output_file) as f:
+        exported_text = f.read()
+
+    # Ensure no duplicate account declarations.
+    # ExportTransactionsUseCase deduplicates via account_seen (GUID set); this
+    # assertion catches any future regression where that guard is removed.
+    open_names = [line.split(' open ', 1)[1] for line in exported_text.splitlines() if ' open ' in line]
+    duplicates = [name for name in set(open_names) if open_names.count(name) > 1]
+    assert not duplicates, f"Duplicate account declarations found: {duplicates}"
+
+    # Extract only the business objects from the output and compare with the reference
+    exported_biz = extract_business_objects(exported_text)
+
+    with open("tests/fixtures/business_objects_only.txt") as f:
+        reference_biz = extract_business_objects(f.read())
+
+    assert exported_biz == reference_biz, (
+        f"Business objects mismatch.\n"
+        f"--- reference ---\n{reference_biz}\n"
+        f"--- exported ---\n{exported_biz}"
+    )
+
+    # Test the print-invoice command
+    result = runner.invoke(cli, ["print-invoice", str(gnucash_file), "--invoice-id", "INV-2026-001", "-o", str(pdf_file)])
+    assert result.exit_code == 0, f"print-invoice failed:\n{result.output}"
+    assert os.path.exists(pdf_file)

--- a/tests/unit/infrastructure/gnucash/test_utils.py
+++ b/tests/unit/infrastructure/gnucash/test_utils.py
@@ -1,0 +1,15 @@
+from infrastructure.gnucash.utils import decode_value_from_string
+
+
+def test_decode_value_from_string():
+    assert decode_value_from_string("123") == 123
+    assert decode_value_from_string("123.45") == 123.45
+    assert decode_value_from_string("true") == "true"
+    assert decode_value_from_string("false") == "false"
+    assert decode_value_from_string("#True") is True
+    assert decode_value_from_string("#False") is False
+    assert decode_value_from_string("#123") == 123
+    assert decode_value_from_string("#123.45") == 123.45
+    assert decode_value_from_string("'hello'") == "'hello'"
+    assert decode_value_from_string("None") == "None"
+    assert decode_value_from_string("#None") is None

--- a/use_cases/export_business_objects.py
+++ b/use_cases/export_business_objects.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python
+"""
+Use case for exporting GnuCash business objects to plaintext format.
+
+All tax-table and invoice-entry reading uses ctypes directly because the
+GnuCash Python SWIG bindings have const-type mismatches for these calls
+(confirmed on GnuCash 4.4 – 5.10 across Debian 11/12/13, Ubuntu 20/22).
+See infrastructure/gnucash/engine.py for the platform notes.
+"""
+import ctypes
+
+import gnucash.gnucash_business as gb
+import gnucash.gnucash_core_c as gc
+from gnucash import Book, Query, Split
+
+from infrastructure.gnucash.engine import load_gnc_engine
+from infrastructure.gnucash.utils import get_account_full_name
+
+
+def _fmt_rate(rate: float) -> str:
+    """Format a tax rate: always show at least one decimal (e.g. 5.0%, 9.975%)."""
+    s = f'{rate:g}'
+    if '.' not in s:
+        s += '.0'
+    return s + '%'
+
+
+def _fmt_quantity(val: float) -> str:
+    """Format quantity/price: strip trailing zeros and unnecessary decimal point."""
+    return f'{val:g}'
+
+
+class ExportBusinessObjectsUseCase:
+    def __init__(self, book: Book):
+        self.book = book
+        self._lib = load_gnc_engine()
+
+    def _account_full_name(self, acct_ptr: int) -> str:
+        """
+        Build colon-separated account full name via ctypes (avoids SWIG const-type bug).
+        Walks the parent chain until the root (parent with no parent).
+        """
+        lib = self._lib
+        parts = []
+        ptr = acct_ptr
+        while ptr:
+            name_b = lib.xaccAccountGetName(ptr)
+            if name_b:
+                parts.append(name_b.decode('utf-8'))
+            parent = lib.gnc_account_get_parent(ptr)
+            if not parent:
+                break
+            # Stop before root account (root's parent is None)
+            grandparent = lib.gnc_account_get_parent(parent)
+            if not grandparent:
+                break
+            ptr = parent
+        parts.reverse()
+        return ':'.join(parts)
+
+    def execute(self) -> str:
+        """Return the complete business-objects plaintext block."""
+        parts = []
+        customers = self._export_customers()
+        vendors   = self._export_vendors()
+        tables    = self._export_tax_tables()
+        invoices  = self._export_invoices()
+        bills     = self._export_bills()
+        for section in (customers, vendors, tables, invoices, bills):
+            if section:
+                parts.append(section)
+        return '\n\n'.join(parts)
+
+    # ── Customers ────────────────────────────────────────────────────────────
+
+    def _export_customers(self) -> str:
+        q = Query()
+        q.search_for('gncCustomer')
+        q.set_book(self.book)
+        customers = [gb.Customer(instance=r) for r in q.run()]
+        q.destroy()
+
+        lines_list = []
+        for cust in customers:
+            addr  = cust.GetAddr()
+            lines = [
+                f'customer "{cust.GetID()}"',
+                f'  name: "{cust.GetName()}"',
+                f'  currency: {cust.GetCurrency().get_mnemonic()}',
+            ]
+            # Only emit optional address/contact fields when non-empty
+            for field, val in [
+                ('addr1', addr.GetAddr1()),
+                ('addr2', addr.GetAddr2()),
+                ('addr3', addr.GetAddr3()),
+                ('addr4', addr.GetAddr4()),
+                ('email', addr.GetEmail()),
+            ]:
+                if val:
+                    lines.append(f'  {field}: "{val}"')
+            lines_list.append('\n'.join(lines))
+        return '\n\n'.join(lines_list)
+
+    # ── Vendors ──────────────────────────────────────────────────────────────
+
+    def _export_vendors(self) -> str:
+        q = Query()
+        q.search_for('gncVendor')
+        q.set_book(self.book)
+        vendors = [gb.Vendor(instance=r) for r in q.run()]
+        q.destroy()
+
+        lines_list = []
+        for v in vendors:
+            lines = [
+                f'vendor "{v.GetID()}"',
+                f'  name: "{v.GetName()}"',
+                f'  currency: {v.GetCurrency().get_mnemonic()}',
+            ]
+            lines_list.append('\n'.join(lines))
+        return '\n\n'.join(lines_list)
+
+    # ── Tax tables ───────────────────────────────────────────────────────────
+
+    def _export_tax_tables(self) -> str:
+        """
+        List all tax tables via ctypes gncTaxTableGetTables (GList* of GncTaxTable*).
+        book.get_taxtables() does not exist in the Python bindings.
+        """
+        lib = self._lib
+
+        # gncTaxTableGetTables returns a GList* of GncTaxTable* pointers
+        glist_ptr = lib.gncTaxTableGetTables(int(self.book.instance))
+
+        tables = []
+        while glist_ptr:
+            buf    = (ctypes.c_void_p * 3).from_address(glist_ptr)
+            tt_ptr = buf[0]
+            glist_ptr = buf[1]
+            if not tt_ptr:
+                continue
+
+            name_b  = lib.gncTaxTableGetName(tt_ptr)
+            tt_name = name_b.decode('utf-8') if name_b else ''
+
+            lines = [f'taxtable "{tt_name}"']
+
+            # Walk the entries GList (GnuCash prepends → reverse for canonical order)
+            entries_ptr = lib.gncTaxTableGetEntries(tt_ptr)
+            entry_parts = []
+            while entries_ptr:
+                ebuf        = (ctypes.c_void_p * 3).from_address(entries_ptr)
+                tte_ptr     = ebuf[0]
+                entries_ptr = ebuf[1]
+                if not tte_ptr:
+                    continue
+                acct_ptr  = lib.gncTaxTableEntryGetAccount(tte_ptr)
+                amt_c     = lib.gncTaxTableEntryGetAmount(tte_ptr)
+                rate      = amt_c.num / amt_c.denom if amt_c.denom else 0.0
+                acct_name = self._account_full_name(acct_ptr) if acct_ptr else '?'
+                entry_parts.append((acct_name, rate))
+
+            entry_parts.reverse()   # GnuCash prepends → put GST before PST/QST
+            for acct_name, rate in entry_parts:
+                lines.append('  entry:')
+                lines.append(f'    account: "{acct_name}"')
+                lines.append(f'    rate: {_fmt_rate(rate)}')
+                lines.append('    type: PERCENT')
+
+            tables.append('\n'.join(lines))
+        return '\n\n'.join(tables)
+
+    # ── Invoices ─────────────────────────────────────────────────────────────
+
+    def _export_invoices(self) -> str:
+        lib = self._lib
+
+        q = Query()
+        q.search_for('gncInvoice')
+        q.set_book(self.book)
+        all_invoices = [gb.Invoice(instance=r) for r in q.run()]
+        q.destroy()
+
+        # Only export customer invoices (owner is Customer, not Vendor)
+        invoices = []
+        for inv in all_invoices:
+            if not inv.IsPosted():
+                continue
+            try:
+                cust = inv.GetOwner().GetCustomer()
+                if cust is not None:
+                    invoices.append((inv, cust))
+            except Exception:
+                pass
+
+        invoice_strings = []
+        for inv, cust in invoices:
+            lines = [
+                f'invoice "{inv.GetID()}"',
+                f'  customer_id: "{cust.GetID()}"',
+                f'  currency: {inv.GetCurrency().get_mnemonic()}',
+                f'  date_opened: {inv.GetDateOpened().strftime("%Y-%m-%d")}',
+            ]
+            if inv.GetBillingID():
+                lines.append(f'  billing_id: "{inv.GetBillingID()}"')
+            if inv.GetNotes():
+                lines.append(f'  notes: "{inv.GetNotes()}"')
+
+            for raw_entry in inv.GetEntries():
+                lines += self._format_inv_entry(lib, raw_entry)
+
+            # posted block
+            posted_txn = inv.GetPostedTxn()
+            if posted_txn:
+                ar_name = get_account_full_name(inv.GetPostedAcc())
+                lines.append('  posted:')
+                lines.append(f'    date: {inv.GetDatePosted().strftime("%Y-%m-%d")}')
+                lines.append(f'    due: {inv.GetDateDue().strftime("%Y-%m-%d")}')
+                lines.append(f'    ar_account: "{ar_name}"')
+                lines.append(f'    memo: "{posted_txn.GetDescription()}"')
+                lines.append('    accumulate: true')
+
+            # payment blocks — from lot splits, excluding the posting transaction
+            lot = inv.GetPostedLot()
+            if lot:
+                for raw_split in lot.get_split_list():
+                    s   = Split(instance=raw_split)
+                    txn = s.GetParent()
+                    if txn is None:
+                        continue
+                    # Skip the posting transaction itself
+                    if gc.gncInvoiceGetInvoiceFromTxn(txn.instance) is not None:
+                        continue
+                    lines += self._format_payment(txn)
+
+            invoice_strings.append('\n'.join(lines))
+        return '\n\n'.join(invoice_strings)
+
+    def _format_inv_entry(self, lib, raw_entry) -> list:
+        ptr = int(raw_entry.instance)
+
+        desc   = (lib.gncEntryGetDescription(ptr) or b'').decode('utf-8')
+        action = (lib.gncEntryGetAction(ptr)      or b'').decode('utf-8')
+        qty_c  = lib.gncEntryGetQuantity(ptr)
+        pri_c  = lib.gncEntryGetInvPrice(ptr)
+        qty    = qty_c.num / qty_c.denom if qty_c.denom else 0.0
+        price  = pri_c.num / pri_c.denom if pri_c.denom else 0.0
+
+        taxable     = bool(lib.gncEntryGetInvTaxable(ptr))
+        tax_incl    = bool(lib.gncEntryGetInvTaxIncluded(ptr))
+
+        # Account full name via Python wrapper (works fine here)
+        acct_name = get_account_full_name(raw_entry.GetInvAccount())
+
+        date_str = raw_entry.GetDate().strftime("%Y-%m-%d")
+
+        lines = [
+            '  entry:',
+            f'    date: {date_str}',
+            f'    description: "{desc}"',
+            f'    action: "{action}"',
+            f'    account: "{acct_name}"',
+            f'    quantity: {_fmt_quantity(qty)}',
+            f'    price: {_fmt_quantity(price)}',
+            f'    taxable: {"true" if taxable else "false"}',
+            f'    tax_included: {"true" if tax_incl else "false"}',
+        ]
+
+        # Tax table — ctypes required (SWIG const-type bug)
+        tt_ptr = lib.gncEntryGetInvTaxTable(ptr)
+        if tt_ptr:
+            name_b  = lib.gncTaxTableGetName(tt_ptr)
+            tt_name = name_b.decode('utf-8') if name_b else ''
+            if tt_name:
+                lines.append(f'    tax_table: "{tt_name}"')
+
+        return lines
+
+    def _format_payment(self, txn) -> list:
+        """Format one payment transaction as payment: lines."""
+        pay_date = txn.GetDate().strftime("%Y-%m-%d")
+        pay_memo = txn.GetDescription() or ''
+        pay_num  = txn.GetNum() or ''
+
+        # Find the bank/asset side (non-AR) split for amount + account
+        bank_name = ''
+        pay_amt   = 0.0
+        for i in range(txn.CountSplits()):
+            split = txn.GetSplit(i)
+            acct  = split.GetAccount()
+            atype = gc.xaccAccountGetType(acct.instance)
+            if atype not in (gc.ACCT_TYPE_RECEIVABLE, gc.ACCT_TYPE_PAYABLE):
+                bank_name = get_account_full_name(acct)
+                pay_amt   = abs(split.GetAmount().to_double())
+                break
+
+        lines = [
+            '  payment:',
+            f'    date: {pay_date}',
+            f'    amount: {_fmt_quantity(pay_amt)}',
+            f'    bank_account: "{bank_name}"',
+            f'    memo: "{pay_memo}"',
+        ]
+        if pay_num:
+            lines.append(f'    num: "{pay_num}"')
+        return lines
+
+    # ── Bills (vendor invoices) ───────────────────────────────────────────────
+
+    def _export_bills(self) -> str:
+        """
+        Bills are gncInvoice objects whose owner is a Vendor.
+        There is no separate 'gncBill' QOF type.
+        """
+        lib = self._lib
+
+        q = Query()
+        q.search_for('gncInvoice')
+        q.set_book(self.book)
+        all_invoices = [gb.Invoice(instance=r) for r in q.run()]
+        q.destroy()
+
+        bills = []
+        for inv in all_invoices:
+            if not inv.IsPosted():
+                continue
+            try:
+                vendor = inv.GetOwner().GetVendor()
+                if vendor is not None:
+                    bills.append((inv, vendor))
+            except Exception:
+                pass
+
+        bill_strings = []
+        for inv, vendor in bills:
+            lines = [
+                f'bill "{inv.GetID()}"',
+                f'  vendor_id: "{vendor.GetID()}"',
+                f'  currency: {inv.GetCurrency().get_mnemonic()}',
+                f'  date_opened: {inv.GetDateOpened().strftime("%Y-%m-%d")}',
+            ]
+
+            for raw_entry in inv.GetEntries():
+                lines += self._format_inv_entry(lib, raw_entry)
+
+            posted_txn = inv.GetPostedTxn()
+            if posted_txn:
+                ap_name = get_account_full_name(inv.GetPostedAcc())
+                lines.append('  posted:')
+                lines.append(f'    date: {inv.GetDatePosted().strftime("%Y-%m-%d")}')
+                lines.append(f'    due: {inv.GetDateDue().strftime("%Y-%m-%d")}')
+                lines.append(f'    ap_account: "{ap_name}"')
+                lines.append(f'    memo: "{posted_txn.GetDescription()}"')
+                lines.append('    accumulate: true')
+
+            lot = inv.GetPostedLot()
+            if lot:
+                for raw_split in lot.get_split_list():
+                    s   = Split(instance=raw_split)
+                    txn = s.GetParent()
+                    if txn is None:
+                        continue
+                    if gc.gncInvoiceGetInvoiceFromTxn(txn.instance) is not None:
+                        continue
+                    lines += self._format_payment(txn)
+
+            bill_strings.append('\n'.join(lines))
+        return '\n\n'.join(bill_strings)

--- a/use_cases/export_transactions.py
+++ b/use_cases/export_transactions.py
@@ -186,6 +186,22 @@ class ExportTransactionsUseCase:
         # Join lines and add trailing newline to match legacy format
         return '\n'.join(lines) + '\n' if lines else ''
 
+    def format_accounts_section(self, result: ExportResult) -> str:
+        """Format only commodities and accounts (no transactions)."""
+        lines = []
+        for commodity, transaction in result.commodities:
+            self._format_commodity(commodity, transaction, lines)
+        for account, transaction in result.accounts:
+            self._format_account(account, transaction, lines)
+        return '\n'.join(lines) + '\n' if lines else ''
+
+    def format_transactions_section(self, result: ExportResult) -> str:
+        """Format only transactions (no commodities or accounts)."""
+        lines = []
+        for transaction in result.transactions:
+            self._format_transaction(transaction, lines)
+        return '\n'.join(lines) + '\n' if lines else ''
+
     def _file_date_str(self) -> str:
         """Return GnuCash file modification date as YYYY-MM-DD string."""
         mtime = os.path.getmtime(self.repository.file_path)


### PR DESCRIPTION
Users can now round-trip GnuCash business objects (customers, vendors, tax tables, invoices, bills) through plaintext files, and print any posted invoice to a PDF from the command line.

## New user-facing capabilities

- `import --include-business-objects`: parse and create customers, vendors, tax tables, invoices, and bills from a plaintext file
- `export --include-business-objects`: export all business objects to plaintext, in import-ready order (accounts → business objects → transactions)
- `print-invoice --invoice-id ID -o out.pdf`: render a posted invoice to PDF via a customisable XSLT template (services/invoice.xslt)

Business objects carry no date prefix in the plaintext format. They are master data, not ledger events. GnuCash stores no creation timestamp for customers, vendors, or tax tables, so no meaningful date prefix exists. Dates that belong to a record (e.g. date_opened on an invoice) appear as named fields inside the block.

## Platform fixes

Two independent root causes were found for segfaults on Ubuntu 22/24 that do not occur on Debian:

1. Missing argtypes — ctypes silently truncates 64-bit pointers to 32-bit C int. Fixed by setting argtypes = [ctypes.c_void_p] on every ctypes function that takes a pointer.

2. RTLD_LOCAL on Ubuntu — Python loads GnuCash extensions with RTLD_LOCAL (Ubuntu default), so CDLL(None) may resolve symbols from a different library instance than the one that owns the QofBook*. Fixed by always promoting the known .so path with RTLD_GLOBAL before calling CDLL(None).

Both fixes are in the new shared loader (infrastructure/gnucash/engine.py), which both export_business_objects.py and invoice_renderer.py now use.

On Ubuntu 22/24, apt install weasyprint only installs a CLI wrapper; import weasyprint raises ModuleNotFoundError. Fixed by installing weasyprint via pip in the Dockerfile and test scripts.

Ubuntu 22.04 (GnuCash 4.8) and Ubuntu 24.04 (GnuCash 4.9) are now supported and included in the test matrix.

## Bug fix

create_account was not idempotent — calling it twice for the same account (once from the import_cmd pre-pass, once from ImportTransactionsUseCase) silently created duplicate child accounts in GnuCash. Fixed with an existence check via parent.lookup_by_name() before append_child.

## Docs

- README: added --include-business-objects usage with format examples, print-invoice usage, updated supported versions table (Ubuntu 22/24)
- RELEASE_NOTES: added v0.3.0 section
- CLAUDE.md: documented four hard-won ctypes/platform findings