### PR TITLE
fix: include invoice.xslt in package distribution and add deployment test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
               pytest tests/ -v --tb=short"
         # Note: --break-system-packages is safe in Docker containers (isolated environment)
 
+      - name: Run deployment test
+        run: ./scripts/test-deployment.sh ${{ matrix.tag }}
+
       - name: Run linting
         if: matrix.tag == 'latest'
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ packages = [
 ]
 
 [tool.setuptools.package-data]
-"*" = ["*.yaml", "*.yml"]
+"*" = ["*.yaml", "*.yml", "*.xslt"]
 
 [build-system]
 requires = ["setuptools>=45", "wheel"]

--- a/scripts/test-deployment-inner.sh
+++ b/scripts/test-deployment-inner.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+echo "Building package..."
+# Install build tools
+python3 -m pip install build --break-system-packages 2>/dev/null || python3 -m pip install build
+python3 -m build
+
+echo "Installing package..."
+# Install the built wheel
+python3 -m pip install dist/*.whl --break-system-packages 2>/dev/null || python3 -m pip install dist/*.whl
+
+echo "Creating temp dir for testing outside source tree..."
+mkdir -p /tmp/deployment-test
+cd /tmp/deployment-test
+
+# Copy a fixture to test with
+cp /workspace/tests/fixtures/business_objects.txt ./test.txt
+
+# Use absolute paths to avoid GnuCash backend issues
+GC_FILE="$(pwd)/test.gnucash"
+
+echo "Running import..."
+gnucash-plaintext import --new "$GC_FILE" test.txt --include-business-objects
+
+echo "Running export..."
+gnucash-plaintext export "$GC_FILE" test_exported.txt --include-business-objects
+
+echo "Running print invoice..."
+gnucash-plaintext print-invoice "$GC_FILE" --invoice-id "INV-2026-001" -o test.pdf
+
+echo "Checking if PDF was created..."
+if [ -f "test.pdf" ]; then
+    echo "Success! test.pdf was created."
+    ls -l test.pdf
+else
+    echo "Error: test.pdf was not created!"
+    exit 1
+fi

--- a/scripts/test-deployment.sh
+++ b/scripts/test-deployment.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Run tests using the locally built python package inside the Docker container
+# This simulates how a user would use the installed package, rather than testing from the source directory.
+
+cd "$(dirname "$0")/.."
+PROJECT_ROOT=$(pwd)
+
+# Allow passing a specific tag, default to 'latest'
+TAG=${1:-latest}
+
+echo "Testing pip installed package inside container using tag $TAG..."
+
+# Make sure the inner script is executable
+chmod +x ./scripts/test-deployment-inner.sh
+
+# Run the inner script inside the Docker container
+./scripts/run.sh "$TAG" ./scripts/test-deployment-inner.sh


### PR DESCRIPTION
Fixes a bug where pip install of gnucash-plaintext does not distribute the xslt file, causing the print-invoice command to fail.

- Update pyproject.toml to include .xslt files in package data.
- Add scripts/test-deployment.sh to verify pip installation locally.
- Add deployment test to .github/workflows/ci.yml to ensure all CLI commands (import, export, print-invoice) function correctly when installed system-wide outside the source tree.