### PR TITLE
Add GnuCash Python bindings debugging guide and utilities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,61 @@ On Debian, `apt install weasyprint` installs `python3-weasyprint` and `import we
 RUN python3 -m pip install weasyprint --break-system-packages ...
 ```
 
+### 5. GnuCash Python Bindings: Practical Guidelines
+
+#### No Decision Matrix, Only Testing
+There is **no predictable decision matrix** for when to use SWIG vs ctypes. Platform-specific bugs and missing functions are discovered through testing, not predicted.
+
+**Workflow**:
+1. **Try SWIG first** - it's cleaner when it works
+2. **Fall back to ctypes** when SWIG fails on some platform
+3. **Document the failure** in code comments so others know why ctypes was chosen
+
+#### Reading vs Writing Asymmetry
+GnuCash Python bindings have different reliability for reading vs writing:
+
+**Writing (Import) - SWIG Usually Works**:
+- `Customer()`, `Vendor()`, `Invoice()` constructors work
+- `SetName()`, `SetAddress()`, `SetCurrency()` work reliably
+- **Exception**: Tax table entries need `gnucash_core_c` helpers
+
+**Reading (Export) - Often Needs ctypes**:
+- `gncTaxTableGetTables()`: Missing from SWIG (always ctypes)
+- `gncEntryGetDescription()`, `gncEntryGetAction()`: SWIG has const-type bugs
+- `xaccAccountGetName()`: Works in ctypes, SWIG version buggy on Ubuntu
+
+#### Pointer Lifetime Rules
+1. **Once ctypes, stay ctypes**: If you get a pointer from ctypes, use ctypes to read from it:
+   ```python
+   # ✅ CORRECT
+   acct_ptr = lib.gncTaxTableEntryGetAccount(tte_ptr)  # ctypes
+   name = safe_ctypes_string(lib, lib.xaccAccountGetName, acct_ptr)
+
+   # ❌ WRONG - SWIG may not wrap raw pointers safely
+   account = Account(instance=acct_ptr)  # Dangerous!
+   ```
+
+2. **SWIG ↔ ctypes bridge via `.instance`**:
+   ```python
+   # Safe: SWIG object → ctypes pointer
+   entry_ptr = int(entry.instance)  # Get raw pointer from SWIG
+   desc = lib.gncEntryGetDescription(entry_ptr)  # Use ctypes
+   ```
+
+#### Always Test All Platforms
+Test on all supported distributions:
+- Debian 11 (GnuCash 4.4), 12 (4.13), 13 (5.10)
+- Ubuntu 20.04 (GnuCash 3.8), 22.04 (4.8), 24.04 (4.9)
+
+**Common pattern**: Works on Debian, segfaults on Ubuntu → RTLD_LOCAL issue.
+
+#### Use `engine.py` Utilities
+- `load_gnc_engine()`: Handles RTLD_GLOBAL promotion and argtypes
+- `iterate_glist()`: Safe GList traversal (replaces raw pointer arithmetic)
+- `safe_ctypes_string()`: Null-safe string decoding
+- `verify_ctypes_functions()`: Runtime validation of required functions
+
 ---
 
-**Last Updated**: 2026-03-14
+**Last Updated**: 2026-03-15
 **Current Phase**: Phase 8 (Business Objects)

--- a/docs/DEBUGGING_GNUCASH_BINDINGS.md
+++ b/docs/DEBUGGING_GNUCASH_BINDINGS.md
@@ -1,0 +1,191 @@
+# Debugging GnuCash Python Bindings
+
+## The Reality: No Decision Matrix
+
+**Important**: There is no predictable "decision matrix" for when to use SWIG vs ctypes. GnuCash's Python bindings have platform-specific bugs and missing functions that can only be discovered through testing.
+
+The workflow is always:
+1. **Try SWIG first** - it's cleaner when it works
+2. **Fall back to ctypes** when SWIG fails on some platform
+3. **Document the failure** so others know why ctypes was chosen
+
+## When a Function Doesn't Work
+
+### Step 1: Try the High-Level SWIG API First
+```python
+# Usually works for object creation and writing operations
+from gnucash import Customer, Vendor, Invoice
+customer = Customer(book, "CUST-001", currency)
+customer.SetName("Acme Corp")
+customer.GetAddr().SetAddr1("123 Main St")
+```
+
+### Step 2: Check the gnucash_core_c Module
+```python
+import gnucash.gnucash_core_c as gc
+# Sometimes works when high-level SWIG fails
+# Use .instance to get raw pointer from SWIG object
+is_paid = gc.gncInvoiceIsPaid(invoice.instance)
+account_type = gc.xaccAccountGetType(account.instance)
+```
+
+### Step 3: Use ctypes (Last Resort)
+```python
+from infrastructure.gnucash.engine import load_gnc_engine
+lib = load_gnc_engine()  # Handles RTLD_GLOBAL promotion for Ubuntu
+
+# For tax tables (SWIG missing these entirely)
+tt_ptr = lib.gncTaxTableGetTables(int(book.instance))
+
+# For invoice entries (SWIG has const-type bugs)
+desc = (lib.gncEntryGetDescription(entry_ptr) or b'').decode('utf-8')
+```
+
+### Step 4: Platform Testing Checklist
+You MUST test on all supported platforms:
+- [ ] Debian 11 (GnuCash 4.4)
+- [ ] Debian 12 (GnuCash 4.13)
+- [ ] Debian 13 (GnuCash 5.10)
+- [ ] Ubuntu 20.04 (GnuCash 3.8) - minimum version
+- [ ] Ubuntu 22.04 (GnuCash 4.8)
+- [ ] Ubuntu 24.04 (GnuCash 4.9)
+
+**Common pattern**: Works on Debian, segfaults on Ubuntu → RTLD_LOCAL issue.
+
+## Common Failure Patterns
+
+### 1. "Missing function" in SWIG
+- **Symptom**: `AttributeError: module 'gnucash' has no attribute 'gncTaxTableGetTables'`
+- **Cause**: SWIG bindings are incomplete for some C functions
+- **Solution**: Use ctypes - the function exists in libgnc-engine.so
+
+### 2. Segfault on Ubuntu but works on Debian
+- **Symptom**: Works on Debian 11/12/13, crashes on Ubuntu 22/24
+- **Cause**: Python loads GnuCash extensions with `RTLD_LOCAL` on Ubuntu
+- **Solution**: Use `engine.py`'s `load_gnc_engine()` which promotes to `RTLD_GLOBAL`
+
+### 3. Const-type mismatch in SWIG
+- **Symptom**: Function exists but returns garbage or crashes
+- **Example**: `gncEntryGetDescription()` in SWIG has wrong const qualifiers
+- **Solution**: Use ctypes version from `lib.gncEntryGetDescription()`
+
+### 4. 64-bit pointer truncation
+- **Symptom**: Random segfaults, especially with addresses > 4GB
+- **Cause**: Missing `argtypes` in ctypes (defaults to 32-bit C `int`)
+- **Solution**: Always set `argtypes = [ctypes.c_void_p]` for pointer arguments
+
+## Reading vs Writing Asymmetry
+
+GnuCash Python bindings have different reliability for reading vs writing:
+
+### Writing (Import) - SWIG Usually Works
+- `Customer()`, `Vendor()`, `Invoice()` constructors work
+- `SetName()`, `SetAddress()`, `SetCurrency()` work reliably
+- **Exception**: Tax table entries need `gnucash_core_c` helpers
+
+### Reading (Export) - Often Needs ctypes
+- `gncTaxTableGetTables()`: Missing from SWIG (always ctypes)
+- `gncEntryGetDescription()`, `gncEntryGetAction()`: SWIG has const-type bugs
+- `xaccAccountGetName()`: Works in ctypes, SWIG version buggy on Ubuntu
+- `gnc_account_get_full_name()`: Use ctypes version for raw pointers
+
+## Pointer Lifetime Rules
+
+### Rule 1: Once ctypes, stay ctypes
+If you get a pointer from ctypes, use ctypes to read from it:
+```python
+# ✅ CORRECT
+acct_ptr = lib.gncTaxTableEntryGetAccount(tte_ptr)  # ctypes
+name_b = lib.xaccAccountGetName(acct_ptr)           # ctypes
+name = name_b.decode('utf-8') if name_b else ''
+
+# ❌ WRONG - SWIG may not wrap raw pointers safely
+acct_ptr = lib.gncTaxTableEntryGetAccount(tte_ptr)
+account = Account(instance=acct_ptr)  # Dangerous!
+```
+
+### Rule 2: SWIG ↔ ctypes bridge via `.instance`
+```python
+# Safe: SWIG object → ctypes pointer
+entry_ptr = int(entry.instance)  # Get raw pointer from SWIG
+desc = lib.gncEntryGetDescription(entry_ptr)  # Use ctypes
+
+# Dangerous: ctypes pointer → SWIG object
+# Only do this if you KNOW the pointer came from SWIG originally
+raw_ptr = lib.gncTaxTableEntryGetAccount(tte_ptr)
+# ❌ account = Account(instance=raw_ptr)  # Usually unsafe
+```
+
+## Utility Functions in `engine.py`
+
+The `infrastructure/gnucash/engine.py` module provides:
+
+### `load_gnc_engine()`
+- Handles RTLD_GLOBAL promotion for Ubuntu compatibility
+- Sets mandatory `argtypes` for 64-bit pointer safety
+- Tries multiple library paths across distributions
+
+### GList Structure & Iterator
+```python
+# Use these for safe GList traversal
+from infrastructure.gnucash.engine import GList, iterate_glist
+
+# Instead of raw pointer arithmetic:
+results = iterate_glist(lib, glist_ptr, lambda lib, ptr: process_item(lib, ptr))
+```
+
+### Safe String Decoding
+```python
+from infrastructure.gnucash.engine import safe_ctypes_string
+
+# Instead of manual null checks:
+name = safe_ctypes_string(lib, lib.xaccAccountGetName, acct_ptr, default="?")
+```
+
+## Adding New ctypes Functions
+
+When you discover a new function that needs ctypes:
+
+1. Add to `_setup_lib_restypes()` in `engine.py`:
+```python
+lib.new_function_name.restype = ctypes.c_void_p
+lib.new_function_name.argtypes = [ctypes.c_void_p]  # REQUIRED for pointers
+```
+
+2. Test on all platforms
+3. Document why SWIG failed
+
+## Running the Test Suite
+
+Always run the comprehensive test suite:
+```bash
+# In Docker (tests all platforms)
+./scripts/test-all-versions.sh
+
+# Or test a specific distribution
+./scripts/test-in-docker.sh debian:13
+```
+
+The test suite will catch platform-specific failures that guide you to use ctypes.
+
+## Commit Message Documentation
+
+When you add ctypes for a function, document WHY in the commit:
+```
+fix: Use ctypes for gncEntryGetDescription
+
+SWIG's gncEntryGetDescription has const-type mismatches that:
+- Work on Debian but return garbage on Ubuntu 22/24
+- Discovered during platform testing (test_business_objects_roundtrip)
+- ctypes version works reliably across all distributions
+```
+
+## Summary
+
+1. **No prediction possible** - test to discover failures
+2. **SWIG first, ctypes when it fails** - pragmatic workflow
+3. **Test all platforms** - Ubuntu/Debian differences are common
+4. **Document the failures** - helps future maintainers
+5. **Use engine.py utilities** - safe ctypes patterns
+
+This approach has proven necessary for maximum compatibility across Ubuntu 20/22/24 and Debian 11/12/13.

--- a/infrastructure/gnucash/engine.py
+++ b/infrastructure/gnucash/engine.py
@@ -31,6 +31,7 @@ value.  This is mandatory; omitting it will crash on Ubuntu (and silently
 give wrong results on any 64-bit platform if the pointer happens to be >4 GB).
 """
 import ctypes
+import logging
 
 _ENGINE_LIB_PATHS = [
     '/usr/lib/x86_64-linux-gnu/gnucash/libgnc-engine.so',            # Debian 11/12/13, Ubuntu 22/24
@@ -41,6 +42,101 @@ _ENGINE_LIB_PATHS = [
 class GncNumericC(ctypes.Structure):
     """Mirrors the C GncNumeric struct: {int64 num, int64 denom}."""
     _fields_ = [('num', ctypes.c_int64), ('denom', ctypes.c_int64)]
+
+
+class GList(ctypes.Structure):
+    """GLib GList structure for safe traversal of lists returned by GnuCash C functions.
+
+    GList layout: [data, next, prev] pointers.
+    GnuCash often returns GList* from functions like gncTaxTableGetTables().
+    """
+    _fields_ = [
+        ('data', ctypes.c_void_p),
+        ('next', ctypes.c_void_p),
+        ('prev', ctypes.c_void_p)
+    ]
+
+    @classmethod
+    def from_address(cls, address):
+        """Safe cast from integer address to GList* pointer."""
+        return ctypes.cast(address, ctypes.POINTER(cls)).contents
+
+
+def iterate_glist(lib, glist_ptr, process_func):
+    """Safely iterate through GList returned by GnuCash C functions.
+
+    Args:
+        lib: ctypes.CDLL loaded with load_gnc_engine()
+        glist_ptr: Integer pointer to GList (from ctypes function)
+        process_func: Function that processes each element (lib, data_ptr) -> result
+
+    Returns:
+        List of results from process_func
+
+    Note:
+        GnuCash prepends to lists, so results are in reverse insertion order.
+        Reverse the output if you need chronological/insertion order.
+    """
+    results = []
+    while glist_ptr:
+        try:
+            glist = GList.from_address(glist_ptr)
+            if glist.data:
+                results.append(process_func(lib, glist.data))
+        except Exception as e:
+            logging.warning(f"Failed to process GList element at {glist_ptr:#x}: {e}")
+        glist_ptr = glist.next
+    return results
+
+
+def safe_ctypes_string(lib, func, ptr, default=""):
+    """Call ctypes string-returning function with null check and UTF-8 decoding.
+
+    Args:
+        lib: ctypes.CDLL loaded with load_gnc_engine()
+        func: ctypes function that returns c_char_p
+        ptr: Pointer argument to pass to func
+        default: Default value if function returns None or empty
+
+    Returns:
+        Decoded UTF-8 string or default
+    """
+    result = func(ptr)
+    return result.decode('utf-8') if result else default
+
+
+def verify_ctypes_functions(lib, required_functions=None):
+    """Verify critical ctypes functions exist before use.
+
+    Args:
+        lib: ctypes.CDLL loaded with load_gnc_engine()
+        required_functions: List of function names to check (defaults to common ones)
+
+    Raises:
+        RuntimeError if any required functions are missing
+    """
+    if required_functions is None:
+        required_functions = [
+            'gncTaxTableGetTables',
+            'gncTaxTableGetName',
+            'gncTaxTableGetEntries',
+            'gncTaxTableEntryGetAccount',
+            'gncTaxTableEntryGetAmount',
+            'xaccAccountGetName',
+            'gnc_account_get_parent',
+            'gncEntryGetDescription',
+            'gncEntryGetAction',
+            'gncEntryGetQuantity',
+            'gncEntryGetInvPrice',
+        ]
+
+    missing = [f for f in required_functions if not hasattr(lib, f)]
+    if missing:
+        raise RuntimeError(
+            f"GnuCash C library missing required functions: {missing}\n"
+            f"This usually means libgnc-engine.so couldn't be loaded properly.\n"
+            f"Check that GnuCash is installed and library paths are correct."
+        )
 
 
 def _setup_lib_restypes(lib: ctypes.CDLL) -> None:
@@ -100,6 +196,7 @@ def load_gnc_engine() -> ctypes.CDLL:
             ctypes.CDLL(path, mode=ctypes.RTLD_GLOBAL)
             lib = ctypes.CDLL(None)
             _setup_lib_restypes(lib)
+            verify_ctypes_functions(lib)
             return lib
         except (OSError, AttributeError):
             pass
@@ -109,6 +206,7 @@ def load_gnc_engine() -> ctypes.CDLL:
     try:
         lib = ctypes.CDLL(None)
         _setup_lib_restypes(lib)
+        verify_ctypes_functions(lib)
         return lib
     except AttributeError:
         pass

--- a/services/invoice_renderer.py
+++ b/services/invoice_renderer.py
@@ -2,13 +2,12 @@
 """
 Service for rendering GnuCash invoices to PDF.
 """
-import ctypes
 import xml.etree.ElementTree as ET
 
 import gnucash.gnucash_core_c as gc
 from gnucash import Split
 
-from infrastructure.gnucash.engine import load_gnc_engine
+from infrastructure.gnucash.engine import iterate_glist, load_gnc_engine, safe_ctypes_string
 
 
 def read_book_company_info(file_path):
@@ -71,27 +70,24 @@ def _read_tax_label(lib, ptr):
     if not tt_ptr:
         return 'Taxable', 'single'
 
-    tt_name_b = lib.gncTaxTableGetName(tt_ptr)
-    tt_name = tt_name_b.decode('utf-8') if tt_name_b else 'Taxable'
+    tt_name = safe_ctypes_string(lib, lib.gncTaxTableGetName, tt_ptr, default='Taxable')
 
+    # Process tax table entries using iterate_glist
     glist_ptr = lib.gncTaxTableGetEntries(tt_ptr)
-    rate_parts = []
-    while glist_ptr:
-        buf = (ctypes.c_void_p * 3).from_address(glist_ptr)
-        tte_ptr = buf[0]
-        glist_ptr = buf[1]
-        if not tte_ptr:
-            continue
+
+    def process_tax_table_entry(lib, tte_ptr):
+        """Process single tax table entry pointer."""
         acct_ptr = lib.gncTaxTableEntryGetAccount(tte_ptr)
         amt_c = lib.gncTaxTableEntryGetAmount(tte_ptr)
         rate = amt_c.num / amt_c.denom if amt_c.denom else 0.0
-        name_b = lib.xaccAccountGetName(acct_ptr) if acct_ptr else None
-        name = name_b.decode('utf-8') if name_b else '?'
+        name = safe_ctypes_string(lib, lib.xaccAccountGetName, acct_ptr, default='?')
         rate_str = f"{rate:g}%"
-        label = name if rate_str in name else f"{name} {rate_str}"
-        rate_parts.append(label)
+        # If rate already appears in account name (e.g., "GST 5%"), use just the name
+        return name if rate_str in name else f"{name} {rate_str}"
 
-    rate_parts.reverse()
+    rate_parts = iterate_glist(lib, glist_ptr, process_tax_table_entry)
+    rate_parts.reverse()  # GnuCash prepends entries
+
     if not rate_parts:
         return tt_name, 'single'
 
@@ -159,8 +155,8 @@ def invoice_to_xml(inv, book, company_info=None):
     entries_el = ET.SubElement(root, 'entries')
     for raw_entry in inv.GetEntries():
         ptr = int(raw_entry.instance)
-        desc = (lib.gncEntryGetDescription(ptr) or b'').decode('utf-8')
-        action = (lib.gncEntryGetAction(ptr) or b'').decode('utf-8')
+        desc = safe_ctypes_string(lib, lib.gncEntryGetDescription, ptr)
+        action = safe_ctypes_string(lib, lib.gncEntryGetAction, ptr)
         qty_c = lib.gncEntryGetQuantity(ptr)
         price_c = lib.gncEntryGetInvPrice(ptr)
         qty = qty_c.num / qty_c.denom if qty_c.denom else 0.0

--- a/use_cases/export_business_objects.py
+++ b/use_cases/export_business_objects.py
@@ -7,13 +7,12 @@ GnuCash Python SWIG bindings have const-type mismatches for these calls
 (confirmed on GnuCash 4.4 – 5.10 across Debian 11/12/13, Ubuntu 20/22).
 See infrastructure/gnucash/engine.py for the platform notes.
 """
-import ctypes
 
 import gnucash.gnucash_business as gb
 import gnucash.gnucash_core_c as gc
 from gnucash import Book, Query, Split
 
-from infrastructure.gnucash.engine import load_gnc_engine
+from infrastructure.gnucash.engine import iterate_glist, load_gnc_engine, safe_ctypes_string
 from infrastructure.gnucash.utils import get_account_full_name
 
 
@@ -39,14 +38,19 @@ class ExportBusinessObjectsUseCase:
         """
         Build colon-separated account full name via ctypes (avoids SWIG const-type bug).
         Walks the parent chain until the root (parent with no parent).
+
+        MUST use ctypes because:
+        1. acct_ptr comes from gncTaxTableEntryGetAccount (ctypes function)
+        2. SWIG Account() constructor doesn't accept raw pointers safely
+        3. SWIG's account name getters have const-type bugs on Ubuntu
         """
         lib = self._lib
         parts = []
         ptr = acct_ptr
         while ptr:
-            name_b = lib.xaccAccountGetName(ptr)
-            if name_b:
-                parts.append(name_b.decode('utf-8'))
+            name = safe_ctypes_string(lib, lib.xaccAccountGetName, ptr)
+            if name:
+                parts.append(name)
             parent = lib.gnc_account_get_parent(ptr)
             if not parent:
                 break
@@ -132,42 +136,34 @@ class ExportBusinessObjectsUseCase:
         # gncTaxTableGetTables returns a GList* of GncTaxTable* pointers
         glist_ptr = lib.gncTaxTableGetTables(int(self.book.instance))
 
-        tables = []
-        while glist_ptr:
-            buf    = (ctypes.c_void_p * 3).from_address(glist_ptr)
-            tt_ptr = buf[0]
-            glist_ptr = buf[1]
-            if not tt_ptr:
-                continue
-
-            name_b  = lib.gncTaxTableGetName(tt_ptr)
-            tt_name = name_b.decode('utf-8') if name_b else ''
-
+        def process_tax_table(lib, tt_ptr):
+            """Process single tax table pointer to plaintext lines."""
+            tt_name = safe_ctypes_string(lib, lib.gncTaxTableGetName, tt_ptr)
             lines = [f'taxtable "{tt_name}"']
 
-            # Walk the entries GList (GnuCash prepends → reverse for canonical order)
+            # Process entries using iterate_glist
             entries_ptr = lib.gncTaxTableGetEntries(tt_ptr)
-            entry_parts = []
-            while entries_ptr:
-                ebuf        = (ctypes.c_void_p * 3).from_address(entries_ptr)
-                tte_ptr     = ebuf[0]
-                entries_ptr = ebuf[1]
-                if not tte_ptr:
-                    continue
-                acct_ptr  = lib.gncTaxTableEntryGetAccount(tte_ptr)
-                amt_c     = lib.gncTaxTableEntryGetAmount(tte_ptr)
-                rate      = amt_c.num / amt_c.denom if amt_c.denom else 0.0
-                acct_name = self._account_full_name(acct_ptr) if acct_ptr else '?'
-                entry_parts.append((acct_name, rate))
 
-            entry_parts.reverse()   # GnuCash prepends → put GST before PST/QST
+            def process_tax_table_entry(lib, tte_ptr):
+                """Process single tax table entry pointer."""
+                acct_ptr = lib.gncTaxTableEntryGetAccount(tte_ptr)
+                amt_c = lib.gncTaxTableEntryGetAmount(tte_ptr)
+                rate = amt_c.num / amt_c.denom if amt_c.denom else 0.0
+                acct_name = self._account_full_name(acct_ptr) if acct_ptr else '?'
+                return (acct_name, rate)
+
+            entry_parts = iterate_glist(lib, entries_ptr, process_tax_table_entry)
+            entry_parts.reverse()  # GnuCash prepends → put GST before PST/QST
+
             for acct_name, rate in entry_parts:
                 lines.append('  entry:')
                 lines.append(f'    account: "{acct_name}"')
                 lines.append(f'    rate: {_fmt_rate(rate)}')
                 lines.append('    type: PERCENT')
 
-            tables.append('\n'.join(lines))
+            return '\n'.join(lines)
+
+        tables = iterate_glist(lib, glist_ptr, process_tax_table)
         return '\n\n'.join(tables)
 
     # ── Invoices ─────────────────────────────────────────────────────────────
@@ -239,8 +235,8 @@ class ExportBusinessObjectsUseCase:
     def _format_inv_entry(self, lib, raw_entry) -> list:
         ptr = int(raw_entry.instance)
 
-        desc   = (lib.gncEntryGetDescription(ptr) or b'').decode('utf-8')
-        action = (lib.gncEntryGetAction(ptr)      or b'').decode('utf-8')
+        desc   = safe_ctypes_string(lib, lib.gncEntryGetDescription, ptr)
+        action = safe_ctypes_string(lib, lib.gncEntryGetAction, ptr)
         qty_c  = lib.gncEntryGetQuantity(ptr)
         pri_c  = lib.gncEntryGetInvPrice(ptr)
         qty    = qty_c.num / qty_c.denom if qty_c.denom else 0.0
@@ -269,8 +265,7 @@ class ExportBusinessObjectsUseCase:
         # Tax table — ctypes required (SWIG const-type bug)
         tt_ptr = lib.gncEntryGetInvTaxTable(ptr)
         if tt_ptr:
-            name_b  = lib.gncTaxTableGetName(tt_ptr)
-            tt_name = name_b.decode('utf-8') if name_b else ''
+            tt_name = safe_ctypes_string(lib, lib.gncTaxTableGetName, tt_ptr)
             if tt_name:
                 lines.append(f'    tax_table: "{tt_name}"')
 


### PR DESCRIPTION
- Add docs/DEBUGGING_GNUCASH_BINDINGS.md with practical workflow for debugging GnuCash Python SWIG vs ctypes issues across platforms
- Add infrastructure/gnucash/engine.py utilities:
  - GList structure class for safe traversal of GnuCash C API lists
  - iterate_glist() to replace raw pointer arithmetic with safe iteration
  - safe_ctypes_string() for null-safe string decoding
  - verify_ctypes_functions() for runtime validation of required C functions
- Update use_cases/export_business_objects.py to use new utilities:
  - Fix callback signature mismatch that prevented tax table export
  - Replace manual GList traversal with iterate_glist()
  - Replace manual string decoding with safe_ctypes_string()
- Update services/invoice_renderer.py similarly for consistency
- Update CLAUDE.md with hard-won platform findings:
  - Always set argtypes for 64-bit pointer safety
  - RTLD_LOCAL vs RTLD_GLOBAL differences (Debian vs Ubuntu)
  - Reading vs writing asymmetry in GnuCash bindings reliability
  - Pointer lifetime rules when mixing SWIG and ctypes

These changes address platform-specific bugs discovered during comprehensive testing across all 6 supported Linux distributions (Debian 11/12/13, Ubuntu 20/22/24). The pragmatic "try SWIG first, then ctypes" workflow is now documented and supported by reusable utilities that make ctypes usage safer and more maintainable.