### PR TITLE
fix: three bugs in engine.py utilities (iterate_glist, load_gnc_engine, safe_ctypes_string)

### DIFF
--- a/docs/DEBUGGING_GNUCASH_BINDINGS.md
+++ b/docs/DEBUGGING_GNUCASH_BINDINGS.md
@@ -38,7 +38,7 @@ lib = load_gnc_engine()  # Handles RTLD_GLOBAL promotion for Ubuntu
 tt_ptr = lib.gncTaxTableGetTables(int(book.instance))
 
 # For invoice entries (SWIG has const-type bugs)
-desc = (lib.gncEntryGetDescription(entry_ptr) or b'').decode('utf-8')
+desc = safe_ctypes_string(lib.gncEntryGetDescription, entry_ptr)
 ```
 
 ### Step 4: Platform Testing Checklist
@@ -96,8 +96,7 @@ If you get a pointer from ctypes, use ctypes to read from it:
 ```python
 # ✅ CORRECT
 acct_ptr = lib.gncTaxTableEntryGetAccount(tte_ptr)  # ctypes
-name_b = lib.xaccAccountGetName(acct_ptr)           # ctypes
-name = name_b.decode('utf-8') if name_b else ''
+name = safe_ctypes_string(lib.xaccAccountGetName, acct_ptr)
 
 # ❌ WRONG - SWIG may not wrap raw pointers safely
 acct_ptr = lib.gncTaxTableEntryGetAccount(tte_ptr)
@@ -139,7 +138,7 @@ results = iterate_glist(lib, glist_ptr, lambda lib, ptr: process_item(lib, ptr))
 from infrastructure.gnucash.engine import safe_ctypes_string
 
 # Instead of manual null checks:
-name = safe_ctypes_string(lib, lib.xaccAccountGetName, acct_ptr, default="?")
+name = safe_ctypes_string(lib.xaccAccountGetName, acct_ptr, default="?")
 ```
 
 ## Adding New ctypes Functions

--- a/infrastructure/gnucash/engine.py
+++ b/infrastructure/gnucash/engine.py
@@ -81,19 +81,22 @@ def iterate_glist(lib, glist_ptr, process_func):
     while glist_ptr:
         try:
             glist = GList.from_address(glist_ptr)
-            if glist.data:
-                results.append(process_func(lib, glist.data))
         except Exception as e:
-            logging.warning(f"Failed to process GList element at {glist_ptr:#x}: {e}")
-        glist_ptr = glist.next
+            logging.warning(f"Failed to read GList node at {glist_ptr:#x}: {e}")
+            break  # Cannot know where the next node is; stop safely
+        glist_ptr = glist.next  # Advance before processing so a bad element doesn't stall iteration
+        if glist.data:
+            try:
+                results.append(process_func(lib, glist.data))
+            except Exception as e:
+                logging.warning(f"Failed to process GList element at {glist.data:#x}: {e}")
     return results
 
 
-def safe_ctypes_string(lib, func, ptr, default=""):
+def safe_ctypes_string(func, ptr, default=""):
     """Call ctypes string-returning function with null check and UTF-8 decoding.
 
     Args:
-        lib: ctypes.CDLL loaded with load_gnc_engine()
         func: ctypes function that returns c_char_p
         ptr: Pointer argument to pass to func
         default: Default value if function returns None or empty
@@ -198,7 +201,7 @@ def load_gnc_engine() -> ctypes.CDLL:
             _setup_lib_restypes(lib)
             verify_ctypes_functions(lib)
             return lib
-        except (OSError, AttributeError):
+        except (OSError, AttributeError, RuntimeError):
             pass
 
     # Final fallback: symbols already globally visible (e.g. RTLD_GLOBAL load
@@ -208,7 +211,7 @@ def load_gnc_engine() -> ctypes.CDLL:
         _setup_lib_restypes(lib)
         verify_ctypes_functions(lib)
         return lib
-    except AttributeError:
+    except (OSError, AttributeError, RuntimeError):
         pass
 
     raise RuntimeError(

--- a/services/invoice_renderer.py
+++ b/services/invoice_renderer.py
@@ -70,7 +70,7 @@ def _read_tax_label(lib, ptr):
     if not tt_ptr:
         return 'Taxable', 'single'
 
-    tt_name = safe_ctypes_string(lib, lib.gncTaxTableGetName, tt_ptr, default='Taxable')
+    tt_name = safe_ctypes_string(lib.gncTaxTableGetName, tt_ptr, default='Taxable')
 
     # Process tax table entries using iterate_glist
     glist_ptr = lib.gncTaxTableGetEntries(tt_ptr)
@@ -80,7 +80,7 @@ def _read_tax_label(lib, ptr):
         acct_ptr = lib.gncTaxTableEntryGetAccount(tte_ptr)
         amt_c = lib.gncTaxTableEntryGetAmount(tte_ptr)
         rate = amt_c.num / amt_c.denom if amt_c.denom else 0.0
-        name = safe_ctypes_string(lib, lib.xaccAccountGetName, acct_ptr, default='?')
+        name = safe_ctypes_string(lib.xaccAccountGetName, acct_ptr, default='?')
         rate_str = f"{rate:g}%"
         # If rate already appears in account name (e.g., "GST 5%"), use just the name
         return name if rate_str in name else f"{name} {rate_str}"
@@ -155,8 +155,8 @@ def invoice_to_xml(inv, book, company_info=None):
     entries_el = ET.SubElement(root, 'entries')
     for raw_entry in inv.GetEntries():
         ptr = int(raw_entry.instance)
-        desc = safe_ctypes_string(lib, lib.gncEntryGetDescription, ptr)
-        action = safe_ctypes_string(lib, lib.gncEntryGetAction, ptr)
+        desc = safe_ctypes_string(lib.gncEntryGetDescription, ptr)
+        action = safe_ctypes_string(lib.gncEntryGetAction, ptr)
         qty_c = lib.gncEntryGetQuantity(ptr)
         price_c = lib.gncEntryGetInvPrice(ptr)
         qty = qty_c.num / qty_c.denom if qty_c.denom else 0.0

--- a/tests/unit/infrastructure/gnucash/test_engine.py
+++ b/tests/unit/infrastructure/gnucash/test_engine.py
@@ -1,0 +1,236 @@
+"""
+Unit tests for infrastructure/gnucash/engine.py utilities.
+
+These tests run without GnuCash installed — they mock ctypes to
+exercise pure-Python logic in iterate_glist, safe_ctypes_string,
+verify_ctypes_functions, and load_gnc_engine.
+
+Bug coverage (four bugs found in commit db9e600):
+
+  Bug #1 — iterate_glist: `glist_ptr = glist.next` was outside the try block.
+      If GList.from_address() raises on the first iteration, `glist` is never
+      assigned, so `glist.next` raises NameError and crashes the caller.
+
+  Bug #2 — load_gnc_engine fallback: the try/except only caught
+      (OSError, AttributeError). A RuntimeError raised by
+      verify_ctypes_functions propagated immediately, skipping all
+      remaining library paths in the fallback chain.
+
+  Bug #3 — safe_ctypes_string: the `lib` parameter was accepted but
+      never referenced inside the function body, making it dead weight
+      in the API.
+
+  Bug #4 — DEBUGGING_GNUCASH_BINDINGS.md line 41: a code example still
+      used the old pre-utility pattern instead of safe_ctypes_string.
+      (No test needed — documentation-only fix.)
+"""
+import ctypes
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from infrastructure.gnucash.engine import (
+    GList,
+    iterate_glist,
+    load_gnc_engine,
+    safe_ctypes_string,
+    verify_ctypes_functions,
+)
+
+# ---------------------------------------------------------------------------
+# Bug #1 — iterate_glist: NameError when GList.from_address raises on first
+#           iteration because glist_ptr = glist.next was outside the try block
+# ---------------------------------------------------------------------------
+
+class TestIterateGlist:
+    def test_empty_list_returns_empty(self):
+        """None pointer → empty result list, no error."""
+        assert iterate_glist(MagicMock(), None, lambda _lib, p: p) == []
+
+    def test_single_element_processed(self):
+        """Happy path: single-element list, process_func doubles the data pointer."""
+        lib = MagicMock()
+        node = MagicMock()
+        node.data = 0x1000
+        node.next = None
+
+        with patch.object(GList, "from_address", return_value=node):
+            result = iterate_glist(lib, 0xDEAD, lambda _lib, ptr: ptr * 2)
+
+        assert result == [0x2000]
+
+    def test_process_func_exception_skips_element_and_continues(self):
+        """process_func raising should log a warning and continue iteration.
+
+        glist.data IS accessible (from_address succeeded), so glist.next is
+        also accessible and iteration can continue to the next node.
+        """
+        lib = MagicMock()
+
+        # Two-node list: node1 → node2 → None
+        node2 = MagicMock()
+        node2.data = 0x2000
+        node2.next = None
+
+        node1 = MagicMock()
+        node1.data = 0x1000
+        node1.next = 0xBEEF  # non-zero so loop continues to node2
+
+        call_count = [0]
+
+        def from_addr(address):
+            call_count[0] += 1
+            return node1 if call_count[0] == 1 else node2
+
+        def bad_process(lib, ptr):
+            if ptr == 0x1000:
+                raise ValueError("simulated failure on first element")
+            return ptr
+
+        with patch.object(GList, "from_address", side_effect=from_addr):
+            result = iterate_glist(lib, 0xDEAD, bad_process)
+
+        # node1 failed → skipped; node2 succeeded → in results
+        assert result == [0x2000]
+
+    def test_from_address_exception_on_first_iteration_does_not_raise_nameerror(self):
+        """Bug #1: glist_ptr = glist.next was outside the try block.
+
+        When GList.from_address() raises on the very first iteration,
+        `glist` is never assigned.  The old code then hit `glist.next`
+        outside the try, raising NameError and crashing the caller.
+
+        After the fix the exception must be caught and the function must
+        return an empty list (with a logged warning) instead of raising.
+        """
+        lib = MagicMock()
+
+        with patch.object(GList, "from_address", side_effect=ValueError("corrupt address")):
+            # Must NOT raise — should return [] and log a warning
+            result = iterate_glist(lib, 0xDEADBEEF, lambda _lib, p: p)
+
+        assert result == []
+
+    def test_from_address_exception_mid_iteration_does_not_raise(self):
+        """from_address failure on iteration N>1 must not bleed into next loop cycle."""
+        lib = MagicMock()
+
+        good_node = MagicMock()
+        good_node.data = 0xABC
+        good_node.next = 0x999  # non-zero → try second iteration
+
+        call_count = [0]
+
+        def from_addr(address):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return good_node
+            raise ValueError("second node corrupt")
+
+        with patch.object(GList, "from_address", side_effect=from_addr):
+            result = iterate_glist(lib, 0x111, lambda _lib, p: p)
+
+        assert result == [0xABC]
+
+
+# ---------------------------------------------------------------------------
+# Bug #2 — load_gnc_engine fallback: RuntimeError from verify_ctypes_functions
+#           was not caught, breaking the library-path fallback chain
+# ---------------------------------------------------------------------------
+
+class TestLoadGncEngineFallback:
+    def test_runtime_error_from_verify_does_not_break_fallback_chain(self):
+        """Bug #2: RuntimeError was not in the except clause.
+
+        With the old code the loop catches only (OSError, AttributeError),
+        so a RuntimeError from verify_ctypes_functions propagates immediately —
+        the second library path is never tried.
+
+        After the fix RuntimeError must also be caught and the loop must
+        continue to the next path.
+        """
+        verify_calls = [0]
+
+        def mock_verify(lib, required_functions=None):
+            verify_calls[0] += 1
+            if verify_calls[0] == 1:
+                raise RuntimeError("verify failed on first path")
+            # Second call succeeds (returns None implicitly)
+
+        mock_lib = MagicMock()
+
+        with patch("infrastructure.gnucash.engine.verify_ctypes_functions", mock_verify), \
+                patch("infrastructure.gnucash.engine._setup_lib_restypes"), \
+                patch("ctypes.CDLL", return_value=mock_lib):
+            result = load_gnc_engine()
+
+        # Before fix: verify_calls[0] == 1 (RuntimeError broke the loop)
+        # After fix:  verify_calls[0] >= 2 (first path caught, second path tried)
+        assert verify_calls[0] >= 2
+        assert result is mock_lib
+
+    def test_all_paths_exhausted_raises_runtime_error(self):
+        """When every path fails, load_gnc_engine must raise RuntimeError."""
+        with patch("infrastructure.gnucash.engine._setup_lib_restypes", side_effect=OSError("not found")), \
+                patch("ctypes.CDLL", side_effect=OSError("not found")), \
+                pytest.raises(RuntimeError, match="Could not load"):
+            load_gnc_engine()
+
+
+# ---------------------------------------------------------------------------
+# Bug #3 — safe_ctypes_string: `lib` parameter was accepted but never used
+# ---------------------------------------------------------------------------
+
+class TestSafeCtypesString:
+    def test_decodes_bytes_to_string(self):
+        func = MagicMock(return_value=b"hello world")
+        assert safe_ctypes_string(func, 0x1234) == "hello world"
+
+    def test_returns_empty_default_when_func_returns_none(self):
+        func = MagicMock(return_value=None)
+        assert safe_ctypes_string(func, 0x1234) == ""
+
+    def test_returns_custom_default_when_func_returns_none(self):
+        func = MagicMock(return_value=None)
+        assert safe_ctypes_string(func, 0x1234, default="?") == "?"
+
+    def test_returns_custom_default_when_func_returns_empty_bytes(self):
+        func = MagicMock(return_value=b"")
+        assert safe_ctypes_string(func, 0x1234, default="fallback") == "fallback"
+
+    def test_lib_parameter_removed_from_signature(self):
+        """Bug #3: lib was a dead parameter — callers no longer pass it.
+
+        With the old signature safe_ctypes_string(lib, func, ptr, default="")
+        this call raises TypeError: too many positional arguments.
+        After the fix (signature: safe_ctypes_string(func, ptr, default=""))
+        it must succeed.
+        """
+        func = MagicMock(return_value=b"test")
+        # New signature: no lib argument
+        result = safe_ctypes_string(func, 0x1234)
+        assert result == "test"
+
+    def test_ptr_is_forwarded_to_func(self):
+        """Ensure the ptr argument is actually passed through to the function."""
+        func = MagicMock(return_value=b"ok")
+        safe_ctypes_string(func, 0xABCD)
+        func.assert_called_once_with(0xABCD)
+
+
+# ---------------------------------------------------------------------------
+# verify_ctypes_functions — basic sanity (not a bug fix, just coverage)
+# ---------------------------------------------------------------------------
+
+class TestVerifyCtypesFunctions:
+    def test_passes_when_all_functions_present(self):
+        """If all requested functions exist on the lib object, no exception."""
+        lib = MagicMock()
+        # MagicMock has every attribute → hasattr returns True for all names
+        verify_ctypes_functions(lib, ["gncTaxTableGetTables", "xaccAccountGetName"])
+
+    def test_raises_when_function_missing(self):
+        """Functions not on the object must trigger RuntimeError."""
+        lib = MagicMock(spec=[])  # spec=[] means no attributes at all
+        with pytest.raises(RuntimeError, match="missing required functions"):
+            verify_ctypes_functions(lib, ["gncTaxTableGetTables"])

--- a/use_cases/export_business_objects.py
+++ b/use_cases/export_business_objects.py
@@ -48,7 +48,7 @@ class ExportBusinessObjectsUseCase:
         parts = []
         ptr = acct_ptr
         while ptr:
-            name = safe_ctypes_string(lib, lib.xaccAccountGetName, ptr)
+            name = safe_ctypes_string(lib.xaccAccountGetName, ptr)
             if name:
                 parts.append(name)
             parent = lib.gnc_account_get_parent(ptr)
@@ -138,7 +138,7 @@ class ExportBusinessObjectsUseCase:
 
         def process_tax_table(lib, tt_ptr):
             """Process single tax table pointer to plaintext lines."""
-            tt_name = safe_ctypes_string(lib, lib.gncTaxTableGetName, tt_ptr)
+            tt_name = safe_ctypes_string(lib.gncTaxTableGetName, tt_ptr)
             lines = [f'taxtable "{tt_name}"']
 
             # Process entries using iterate_glist
@@ -235,8 +235,8 @@ class ExportBusinessObjectsUseCase:
     def _format_inv_entry(self, lib, raw_entry) -> list:
         ptr = int(raw_entry.instance)
 
-        desc   = safe_ctypes_string(lib, lib.gncEntryGetDescription, ptr)
-        action = safe_ctypes_string(lib, lib.gncEntryGetAction, ptr)
+        desc   = safe_ctypes_string(lib.gncEntryGetDescription, ptr)
+        action = safe_ctypes_string(lib.gncEntryGetAction, ptr)
         qty_c  = lib.gncEntryGetQuantity(ptr)
         pri_c  = lib.gncEntryGetInvPrice(ptr)
         qty    = qty_c.num / qty_c.denom if qty_c.denom else 0.0
@@ -265,7 +265,7 @@ class ExportBusinessObjectsUseCase:
         # Tax table — ctypes required (SWIG const-type bug)
         tt_ptr = lib.gncEntryGetInvTaxTable(ptr)
         if tt_ptr:
-            tt_name = safe_ctypes_string(lib, lib.gncTaxTableGetName, tt_ptr)
+            tt_name = safe_ctypes_string(lib.gncTaxTableGetName, tt_ptr)
             if tt_name:
                 lines.append(f'    tax_table: "{tt_name}"')
 


### PR DESCRIPTION

Bug 1 — iterate_glist: NameError / infinite loop on GList.from_address failure

  glist_ptr = glist.next was placed after the try/except block.  If
  GList.from_address() raised on the first iteration, `glist` was never
  assigned and `glist.next` raised NameError, crashing the caller.
  On later iterations the stale `glist` from the previous cycle was used,
  causing either an infinite loop or traversal of the wrong node chain.

  Fix: split into two separate try blocks.  The outer block wraps only
  from_address() and breaks on failure (we cannot know where the next
  node is without the current node).  glist_ptr is advanced immediately
  after from_address() succeeds.  The inner block wraps process_func()
  and skips the element on failure so iteration continues.

Bug 2 — load_gnc_engine: RuntimeError from verify_ctypes_functions
          broke the library-path fallback chain

  Both except clauses caught only (OSError, AttributeError).  A
  RuntimeError raised by verify_ctypes_functions escaped the loop,
  bypassing all remaining entries in _ENGINE_LIB_PATHS and the final
  CDLL(None) fallback.

  Fix: add RuntimeError to both except tuples so every failure mode
  is handled and the fallback chain runs to completion.

Bug 3 — safe_ctypes_string: dead `lib` parameter

  The `lib` argument was accepted but never referenced inside the
  function body, adding noise to every call site without benefit.

  Fix: remove `lib` from the signature.  All callers in
  export_business_objects.py and invoice_renderer.py updated accordingly.

Doc fix — DEBUGGING_GNUCASH_BINDINGS.md

  Three code examples still used the pre-utility patterns
  (manual b''.decode(), old safe_ctypes_string(lib, ...) signature).
  Updated to match the current API.

Tests added: tests/unit/infrastructure/gnucash/test_engine.py

  15 unit tests covering happy paths and all three bug scenarios.
  Tests run without GnuCash installed (pure mock/ctypes).
  Confirmed: bug tests FAIL against the pre-fix code, PASS after.