### PR TITLE
Add income-statement command for CRA T2 fiscal year reporting

### DIFF
--- a/cli/income_statement_cmd.py
+++ b/cli/income_statement_cmd.py
@@ -1,0 +1,198 @@
+"""
+CLI command for generating an income statement.
+
+Supports CRA T2 fiscal year periods with optional FX conversion to CAD.
+Output formats: text (stdout), HTML, PDF.
+"""
+
+from datetime import date, datetime
+from typing import Optional
+
+import click
+
+from repositories.gnucash_repository import GnuCashRepository
+from services.fx_rates import FxRates, MissingFxRateError
+from use_cases.generate_income_statement import GenerateIncomeStatementUseCase, fiscal_year_start
+
+
+def _parse_date(ctx, param, value: Optional[str]) -> Optional[date]:
+    if value is None:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as e:
+        raise click.BadParameter(f"Date must be in YYYY-MM-DD format, got: {value}") from e
+
+
+@click.command("income-statement")
+@click.argument("gnucash_file", type=click.Path(exists=True))
+@click.option(
+    "--fiscal-year-end",
+    default=None,
+    callback=_parse_date,
+    is_eager=True,
+    expose_value=True,
+    help="Fiscal year end date (YYYY-MM-DD). Start is auto-computed as end − 1 year + 1 day.",
+)
+@click.option(
+    "--start",
+    default=None,
+    callback=_parse_date,
+    is_eager=True,
+    expose_value=True,
+    help="Period start date (YYYY-MM-DD). Use with --end for explicit range.",
+)
+@click.option(
+    "--end",
+    default=None,
+    callback=_parse_date,
+    is_eager=True,
+    expose_value=True,
+    help="Period end date (YYYY-MM-DD). Use with --start for explicit range.",
+)
+@click.option(
+    "--fx-rates",
+    "fx_rates_file",
+    default=None,
+    type=click.Path(exists=True),
+    help="YAML file with FX rates → CAD (required for CRA T2 multi-currency totals).",
+)
+@click.option(
+    "--output-format",
+    type=click.Choice(["text", "html", "pdf"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format.",
+)
+@click.option(
+    "--output",
+    "output_file",
+    default=None,
+    type=click.Path(),
+    help="Output file path. Required for html/pdf. Defaults to stdout for text.",
+)
+def income_statement(
+    gnucash_file,
+    fiscal_year_end,
+    start,
+    end,
+    fx_rates_file,
+    output_format,
+    output_file,
+):
+    """
+    Generate an income statement for a fiscal period.
+
+    Supports CRA T2 filing with optional FX conversion of all currencies to CAD.
+
+    \b
+    Date range — use ONE of:
+      --fiscal-year-end YYYY-MM-DD       (auto-computes start = end − 1 year + 1 day)
+      --start YYYY-MM-DD --end YYYY-MM-DD (explicit range)
+
+    \b
+    Examples:
+      Text output (calendar year 2024):
+        gnucash-plaintext income-statement ledger.gnucash --fiscal-year-end 2024-12-31
+
+      HTML with FX conversion to CAD:
+        gnucash-plaintext income-statement ledger.gnucash \\
+            --fiscal-year-end 2024-03-31 \\
+            --fx-rates rates.yaml \\
+            --output-format html --output report.html
+
+      PDF for CRA T2:
+        gnucash-plaintext income-statement ledger.gnucash \\
+            --start 2023-04-01 --end 2024-03-31 \\
+            --fx-rates rates.yaml \\
+            --output-format pdf --output report.pdf
+    """
+    # --- Resolve date range ---
+    if fiscal_year_end is not None and (start is not None or end is not None):
+        raise click.UsageError(
+            "--fiscal-year-end cannot be combined with --start/--end. Use one or the other."
+        )
+
+    if fiscal_year_end is not None:
+        period_end = fiscal_year_end
+        period_start = fiscal_year_start(fiscal_year_end)
+    elif start is not None and end is not None:
+        period_start = start
+        period_end = end
+    elif start is not None or end is not None:
+        raise click.UsageError("Provide both --start and --end together.")
+    else:
+        raise click.UsageError(
+            "Provide a date range: --fiscal-year-end YYYY-MM-DD  "
+            "or --start YYYY-MM-DD --end YYYY-MM-DD"
+        )
+
+    # --- Output file validation ---
+    if output_format in ("html", "pdf") and not output_file:
+        raise click.UsageError(f"--output <file> is required for --output-format {output_format}")
+
+    # --- Load FX rates ---
+    fx_rates: Optional[FxRates] = None
+    fx_rate_labels: list = []
+    if fx_rates_file:
+        try:
+            fx_rates = FxRates.load(fx_rates_file)
+            fx_rate_labels = [
+                f"{c}: {fx_rates.get_rate(c)}"
+                for c in sorted(fx_rates.available_currencies)
+                if c != "CAD"
+            ]
+        except (FileNotFoundError, ValueError) as e:
+            raise click.ClickException(str(e)) from e
+
+    # --- Run ---
+    repo = GnuCashRepository(gnucash_file)
+    repo.open()
+
+    try:
+        use_case = GenerateIncomeStatementUseCase(repo)
+        try:
+            result = use_case.execute(
+                start_date=period_start,
+                end_date=period_end,
+                fx_rates=fx_rates,
+            )
+        except MissingFxRateError as e:
+            raise click.ClickException(str(e)) from e
+        except ValueError as e:
+            raise click.ClickException(str(e)) from e
+    finally:
+        repo.close()
+
+    # --- Render ---
+    from services.income_statement_renderer import render_html, render_pdf, render_text
+
+    if output_format == "text":
+        text = render_text(result)
+        if output_file:
+            _write_file(output_file, text)
+            click.echo(f"Written to {output_file}")
+        else:
+            click.echo(text)
+
+    elif output_format == "html":
+        html = render_html(result, fx_rate_labels=fx_rate_labels)
+        _write_file(output_file, html)
+        click.echo(f"HTML report written to {output_file}")
+
+    elif output_format == "pdf":
+        try:
+            render_pdf(result, output_file, fx_rate_labels=fx_rate_labels)
+        except ImportError as e:
+            raise click.ClickException(
+                "WeasyPrint is not installed. Install it with:\n"
+                "  pip install weasyprint\n"
+                "or in Docker: apt install python3-weasyprint  (Debian) / "
+                "pip install weasyprint  (Ubuntu)"
+            ) from e
+        click.echo(f"PDF report written to {output_file}")
+
+
+def _write_file(path: str, content: str) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)

--- a/cli/main.py
+++ b/cli/main.py
@@ -12,6 +12,7 @@ from cli.export_beancount_cmd import export_beancount
 from cli.export_cmd import export_transactions
 from cli.import_beancount_cmd import import_beancount
 from cli.import_cmd import import_transactions
+from cli.income_statement_cmd import income_statement
 from cli.invoice_print_cmd import print_invoice
 from cli.validate_cmd import validate_ledger
 
@@ -55,6 +56,7 @@ cli.add_command(validate_ledger, name='validate')
 cli.add_command(export_beancount, name='export-beancount')
 cli.add_command(import_beancount, name='import-beancount')
 cli.add_command(close_books, name='close-books')
+cli.add_command(income_statement, name='income-statement')
 cli.add_command(print_invoice, name='print-invoice')
 
 

--- a/docs/income-statement-design.md
+++ b/docs/income-statement-design.md
@@ -1,0 +1,176 @@
+# Income Statement Feature — Design Document
+
+**Feature branch**: `feature/income-statement`
+**Created**: 2026-03-18
+**Status**: Approved, implementation pending
+
+---
+
+## Overview
+
+Generate an income statement (profit & loss report) from a GnuCash file, suitable for
+CRA (Canada Revenue Agency) T2 corporate income tax filing.
+
+New CLI command: `gnucash-plaintext income-statement`
+
+---
+
+## Design Decisions
+
+### 1. Date Range Input
+
+Support two modes, both accepted in the same command:
+
+**Explicit range** (always works, maximum control):
+```bash
+gnucash-plaintext income-statement ledger.gnucash \
+    --start 2023-04-01 --end 2024-03-31
+```
+
+**Fiscal-year-end shorthand** (auto-computes start as `end − 1 year + 1 day`):
+```bash
+gnucash-plaintext income-statement ledger.gnucash \
+    --fiscal-year-end 2024-03-31
+# → start = 2023-04-01, end = 2024-03-31
+```
+
+The shorthand works for any fiscal year, not just calendar year (Jan–Dec).
+CRA allows fiscal year ending on any date.
+
+If both `--start/--end` and `--fiscal-year-end` are given, raise an error.
+
+### 2. Multi-Currency and FX Rates
+
+T2 requires all amounts reported in CAD. The report provides:
+
+1. **Per-currency breakdown** — income and expenses in native currency
+2. **CAD total** — all amounts converted to CAD using user-supplied annual average rates
+
+FX rates are supplied via `--fx-rates rates.yaml`:
+
+```yaml
+# Annual average exchange rates → CAD
+# Source: Bank of Canada (https://www.bankofcanada.ca/rates/exchange/)
+HKD: 0.172
+CNY: 0.185
+JPY: 0.0090
+USD: 1.36
+CAD: 1.0   # always 1.0
+```
+
+- CAD is always 1.0 and need not be listed (assumed if absent)
+- CRA accepts Bank of Canada annual average rates for foreign currency conversion
+- If `--fx-rates` is omitted, the report is generated **per-currency only** with no CAD
+  total (and a warning that T2 filing requires FX conversion)
+- If a currency in the ledger has no rate in the file, the command fails with a clear error
+  listing which currencies are missing
+
+### 3. Output Formats
+
+Controlled by `--output-format` (default: `text`):
+
+| Flag | Output |
+|------|--------|
+| `text` | Plain text to stdout (or `--output file.txt`) |
+| `html` | HTML file (requires `--output file.html`) |
+| `pdf`  | PDF file via WeasyPrint (requires `--output file.pdf`) |
+
+Examples:
+```bash
+# Plain text to stdout
+gnucash-plaintext income-statement ledger.gnucash --fiscal-year-end 2024-12-31
+
+# HTML report
+gnucash-plaintext income-statement ledger.gnucash \
+    --fiscal-year-end 2024-12-31 \
+    --fx-rates rates.yaml \
+    --output-format html --output report.html
+
+# PDF report
+gnucash-plaintext income-statement ledger.gnucash \
+    --fiscal-year-end 2024-12-31 \
+    --fx-rates rates.yaml \
+    --output-format pdf --output report.pdf
+```
+
+### 4. Account Hierarchy Depth
+
+Show the **full account tree with subtotals at every level**.
+
+Rationale: T2 Schedule 125 requires correct categorization of each expense
+(advertising, meals & entertainment, professional fees, etc.). Collapsing the tree
+risks misclassifying expenses. The full hierarchy lets the user map GnuCash
+categories to T2 lines accurately.
+
+Example layout:
+```
+INCOME
+  Income:Salary                        12,000.00 CAD
+  Income:Other Income
+    Income:Other Income:Cashback           150.00 CAD
+    Income:Other Income:PC Points           60.00 CAD
+    Subtotal: Other Income                 210.00 CAD
+  Total Income                         12,210.00 CAD
+
+EXPENSES
+  Expenses-CAN:Dining                    1,200.00 CAD
+  Expenses-CAN:Groceries                 3,400.00 CAD
+  Expenses-HK:Transport                  1,050.00 HKD     180.60 CAD
+  ...
+  Total Expenses                                        4,780.60 CAD
+
+NET INCOME                                             7,429.40 CAD
+```
+
+### 5. Relationship to Close Books
+
+The income statement **does not require books to be closed**. It computes
+income and expense account balances directly from raw transactions within the
+date range. The `close-books` command is a separate operation.
+
+### 6. CRA Account Structure
+
+No artificial remapping of accounts to CRA line numbers. The report follows
+the user's existing GnuCash account hierarchy, which the user has already
+structured to match their CRA categories. The user maps accounts to T2 lines
+manually when filing.
+
+---
+
+## Implementation Plan
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `services/income_statement.py` | Core service: compute balances per account per currency, apply FX |
+| `use_cases/generate_income_statement.py` | Orchestration: open file, call service, render output |
+| `cli/income_statement_cmd.py` | CLI command with all options |
+| `services/fx_rates.py` | Load and validate FX rates YAML, convert amounts |
+| `templates/income_statement.html` | Jinja2 HTML template (also used for PDF via WeasyPrint) |
+| `tests/unit/services/test_income_statement.py` | Unit tests for service |
+| `tests/integration/test_cli_income_statement.py` | Integration tests |
+
+### Register in `cli/main.py`
+
+```python
+from cli.income_statement_cmd import income_statement
+cli.add_command(income_statement, name='income-statement')
+```
+
+### Reuse existing infrastructure
+
+- `BookCloser.get_balance_as_of_date()` — reuse to compute balances within a date range
+  (adapt to filter by start date as well as end date)
+- `GnuCashRepository` — open file, get root account, iterate accounts
+- `infrastructure/gnucash/utils.find_account()` — account lookup
+- WeasyPrint (already in Docker image from `print-invoice` command) — PDF rendering
+
+---
+
+## Open Questions
+
+- **Comparison column**: Should the report optionally show prior-year figures side by side?
+  (Deferred — not needed for initial implementation)
+- **Partial-year FX**: If a transaction is in a year with a different rate, should we
+  support per-year rates? (Deferred — single rate per currency per report is sufficient for now)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "beautifulsoup4>=4.9",  # Future QFX parsing alternative
     "lxml>=4.6",            # XML parsing
     "pyyaml>=5.4",          # Configuration file support
+    "jinja2>=3.0",          # HTML template rendering for income statement
     "typing_extensions>=4.0; python_version<'3.11'",  # NotRequired, TypedDict backport
 ]
 
@@ -41,7 +42,7 @@ packages = [
 ]
 
 [tool.setuptools.package-data]
-"*" = ["*.yaml", "*.yml", "*.xslt"]
+"*" = ["*.yaml", "*.yml", "*.xslt", "*.html"]
 
 [build-system]
 requires = ["setuptools>=45", "wheel"]

--- a/services/fx_rates.py
+++ b/services/fx_rates.py
@@ -1,0 +1,140 @@
+"""
+FX rates service for currency conversion to CAD.
+
+Loads annual average exchange rates from a YAML file and converts amounts.
+CRA accepts Bank of Canada annual average rates for foreign currency conversion.
+"""
+
+from fractions import Fraction
+from pathlib import Path
+from typing import Dict, Set
+
+import yaml
+
+
+class MissingFxRateError(Exception):
+    """Raised when a required currency has no FX rate."""
+    pass
+
+
+class FxRates:
+    """
+    Holds exchange rates for converting foreign currencies to CAD.
+
+    All rates are expressed as: 1 unit of foreign currency = N CAD.
+    CAD is always 1.0.
+    """
+
+    def __init__(self, rates: Dict[str, float]):
+        """
+        Initialize with a dict of currency → CAD rate.
+
+        Args:
+            rates: e.g. {"HKD": 0.172, "CNY": 0.185, "JPY": 0.009}
+                   CAD need not be included (always 1.0).
+        """
+        self._rates: Dict[str, Fraction] = {"CAD": Fraction(1)}
+        for currency, rate in rates.items():
+            self._rates[currency.upper()] = Fraction(rate).limit_denominator(1_000_000)
+
+    @classmethod
+    def load(cls, path: str) -> "FxRates":
+        """
+        Load FX rates from a YAML file.
+
+        Expected format:
+            HKD: 0.172
+            CNY: 0.185
+            JPY: 0.009
+            USD: 1.36
+            CAD: 1.0   # optional
+
+        Args:
+            path: Path to YAML file
+
+        Returns:
+            FxRates instance
+
+        Raises:
+            FileNotFoundError: If file does not exist
+            ValueError: If file format is invalid
+        """
+        p = Path(path)
+        if not p.exists():
+            raise FileNotFoundError(f"FX rates file not found: {path}")
+
+        with open(p) as f:
+            data = yaml.safe_load(f)
+
+        if not isinstance(data, dict):
+            raise ValueError(f"FX rates file must be a YAML mapping, got: {type(data)}")
+
+        for key, value in data.items():
+            if not isinstance(key, str):
+                raise ValueError(f"Currency code must be a string, got: {key!r}")
+            if not isinstance(value, (int, float)):
+                raise ValueError(f"Rate for {key!r} must be a number, got: {value!r}")
+            if value <= 0:
+                raise ValueError(f"Rate for {key!r} must be positive, got: {value}")
+
+        return cls(data)
+
+    @classmethod
+    def cad_only(cls) -> "FxRates":
+        """Create an FxRates instance with only CAD (no conversion needed)."""
+        return cls({})
+
+    def to_cad(self, amount: Fraction, currency: str) -> Fraction:
+        """
+        Convert an amount in the given currency to CAD.
+
+        Args:
+            amount: Amount in foreign currency
+            currency: ISO currency code (e.g., "HKD")
+
+        Returns:
+            Amount in CAD
+
+        Raises:
+            MissingFxRateError: If no rate is available for the currency
+        """
+        code = currency.upper()
+        if code not in self._rates:
+            raise MissingFxRateError(
+                f"No FX rate for {code}. "
+                f"Add '{code}: <rate>' to your --fx-rates file."
+            )
+        return amount * self._rates[code]
+
+    def get_rate(self, currency: str) -> float:
+        """
+        Return the CAD rate for a currency as a float.
+
+        Raises:
+            MissingFxRateError: If no rate is available for the currency
+        """
+        code = currency.upper()
+        if code not in self._rates:
+            raise MissingFxRateError(f"No FX rate for {code}.")
+        return float(self._rates[code])
+
+    def has_rate(self, currency: str) -> bool:
+        """Check if a rate exists for the given currency."""
+        return currency.upper() in self._rates
+
+    def missing_currencies(self, currencies: Set[str]) -> Set[str]:
+        """
+        Return currencies from the given set that have no rate.
+
+        Args:
+            currencies: Set of currency codes to check
+
+        Returns:
+            Set of currencies with missing rates (empty if all covered)
+        """
+        return {c for c in currencies if not self.has_rate(c)}
+
+    @property
+    def available_currencies(self) -> Set[str]:
+        """Return set of currencies with known rates."""
+        return set(self._rates.keys())

--- a/services/income_statement.py
+++ b/services/income_statement.py
@@ -1,0 +1,249 @@
+"""
+Income statement service.
+
+Computes income and expense account balances within a date range,
+with optional FX conversion to CAD for CRA T2 filing.
+"""
+
+from dataclasses import dataclass, field
+from datetime import date
+from fractions import Fraction
+from typing import Dict, List, Optional
+
+from gnucash import Account
+from gnucash.gnucash_core_c import ACCT_TYPE_EXPENSE, ACCT_TYPE_INCOME
+
+from services.fx_rates import FxRates
+
+
+@dataclass
+class AccountLine:
+    """One line in the income statement — a single account."""
+    path: str           # Full account path, e.g. "Income:Salary:Base"
+    name: str           # Account name only, e.g. "Base"
+    depth: int          # Nesting depth (0 = top-level like "Income")
+    currency: str       # Native currency code, e.g. "CAD"
+    balance: Fraction   # Balance in native currency (positive = amount earned/spent)
+    cad_balance: Optional[Fraction]  # Converted to CAD (None if no FX rates supplied)
+
+
+@dataclass
+class AccountSubtotal:
+    """Subtotal for an account group (accounts sharing a common parent path)."""
+    path: str               # Parent path, e.g. "Income:Salary"
+    name: str               # Parent name, e.g. "Salary"
+    depth: int              # Nesting depth of this subtotal
+    # Per-currency totals: {currency: native_total}
+    currency_totals: Dict[str, Fraction] = field(default_factory=dict)
+    # CAD total (None if no FX rates)
+    cad_total: Optional[Fraction] = None
+
+
+@dataclass
+class IncomeStatementSection:
+    """Either the Income or Expenses section of the report."""
+    title: str                          # "INCOME" or "EXPENSES"
+    lines: List[AccountLine] = field(default_factory=list)
+    # Top-level currency totals: {currency: total}
+    currency_totals: Dict[str, Fraction] = field(default_factory=dict)
+    cad_total: Optional[Fraction] = None  # None if no FX rates
+
+
+@dataclass
+class IncomeStatementResult:
+    """Full income statement result."""
+    start_date: date
+    end_date: date
+    income: IncomeStatementSection
+    expenses: IncomeStatementSection
+    # Net income per currency (income - expenses, positive = profit)
+    net_currency_totals: Dict[str, Fraction] = field(default_factory=dict)
+    net_cad_total: Optional[Fraction] = None  # None if no FX rates
+    fx_rates_provided: bool = False
+
+
+class IncomeStatementService:
+    """
+    Computes income and expense account balances within a date range.
+
+    Date range is INCLUSIVE on both ends: start_date <= tx_date <= end_date.
+    This is different from BookCloser.get_balance_as_of_date which is cumulative
+    (from the beginning of time up to a date).
+    """
+
+    def get_balance_in_range(
+        self,
+        account: Account,
+        start_date: date,
+        end_date: date,
+    ) -> Fraction:
+        """
+        Get account balance for transactions within [start_date, end_date].
+
+        Returns balance as a Python Fraction.
+        For Income accounts: negative means credit (revenue) in GnuCash convention.
+        We negate Income balances before displaying so they appear as positive revenue.
+        """
+        total = Fraction(0)
+        for split in account.GetSplitList():
+            tx = split.GetParent()
+            tx_date_raw = tx.GetDate()
+            tx_date = date(tx_date_raw.year, tx_date_raw.month, tx_date_raw.day)
+            if start_date <= tx_date <= end_date:
+                value = split.GetValue()
+                total += Fraction(value.num(), value.denom())
+        return total
+
+    def _account_full_path(self, account: Account) -> str:
+        """Build full colon-separated path for an account, excluding root."""
+        parts = []
+        acc = account
+        while acc is not None and not acc.is_root():
+            parts.append(acc.GetName())
+            acc = acc.get_parent()
+        parts.reverse()
+        return ":".join(parts)
+
+    def _account_depth(self, account: Account) -> int:
+        """Return nesting depth (0 = direct child of root)."""
+        depth = 0
+        acc = account.get_parent()
+        while acc is not None and not acc.is_root():
+            depth += 1
+            acc = acc.get_parent()
+        return depth
+
+    def compute(
+        self,
+        root: Account,
+        start_date: date,
+        end_date: date,
+        fx_rates: Optional[FxRates] = None,
+    ) -> IncomeStatementResult:
+        """
+        Compute the income statement for the given date range.
+
+        Args:
+            root: Root account from GnuCash book
+            start_date: First day of the period (inclusive)
+            end_date: Last day of the period (inclusive)
+            fx_rates: Optional FX rates for CAD conversion. If None, no CAD
+                      totals are computed and fx_rates_provided=False.
+
+        Returns:
+            IncomeStatementResult with all lines and totals
+        """
+        income_lines: List[AccountLine] = []
+        expense_lines: List[AccountLine] = []
+
+        for account in root.get_descendants():
+            acct_type = account.GetType()
+            if acct_type not in (ACCT_TYPE_INCOME, ACCT_TYPE_EXPENSE):
+                continue
+
+            commodity = account.GetCommodity()
+            if commodity is None:
+                continue
+
+            currency = commodity.get_mnemonic()
+            raw_balance = self.get_balance_in_range(account, start_date, end_date)
+
+            if raw_balance == Fraction(0):
+                continue
+
+            # Income accounts: GnuCash stores revenue as negative (credit).
+            # Negate so Income lines show positive = revenue earned.
+            display_balance = -raw_balance if acct_type == ACCT_TYPE_INCOME else raw_balance
+
+            cad_balance: Optional[Fraction] = None
+            if fx_rates is not None:
+                cad_balance = fx_rates.to_cad(display_balance, currency)
+
+            line = AccountLine(
+                path=self._account_full_path(account),
+                name=account.GetName(),
+                depth=self._account_depth(account),
+                currency=currency,
+                balance=display_balance,
+                cad_balance=cad_balance,
+            )
+
+            if acct_type == ACCT_TYPE_INCOME:
+                income_lines.append(line)
+            else:
+                expense_lines.append(line)
+
+        # Sort each section by account path for consistent ordering
+        income_lines.sort(key=lambda line: line.path)
+        expense_lines.sort(key=lambda line: line.path)
+
+        income_section = self._build_section("INCOME", income_lines, fx_rates)
+        expense_section = self._build_section("EXPENSES", expense_lines, fx_rates)
+
+        # Net income per currency
+        all_currencies = set(income_section.currency_totals) | set(expense_section.currency_totals)
+        net_currency_totals: Dict[str, Fraction] = {}
+        for currency in all_currencies:
+            inc = income_section.currency_totals.get(currency, Fraction(0))
+            exp = expense_section.currency_totals.get(currency, Fraction(0))
+            net_currency_totals[currency] = inc - exp
+
+        net_cad_total: Optional[Fraction] = None
+        if fx_rates is not None:
+            inc_cad = income_section.cad_total or Fraction(0)
+            exp_cad = expense_section.cad_total or Fraction(0)
+            net_cad_total = inc_cad - exp_cad
+
+        return IncomeStatementResult(
+            start_date=start_date,
+            end_date=end_date,
+            income=income_section,
+            expenses=expense_section,
+            net_currency_totals=net_currency_totals,
+            net_cad_total=net_cad_total,
+            fx_rates_provided=fx_rates is not None,
+        )
+
+    def _build_section(
+        self,
+        title: str,
+        lines: List[AccountLine],
+        fx_rates: Optional[FxRates],
+    ) -> IncomeStatementSection:
+        """Build a section (Income or Expenses) with per-currency totals."""
+        currency_totals: Dict[str, Fraction] = {}
+        cad_total = Fraction(0) if fx_rates is not None else None
+
+        for line in lines:
+            currency_totals[line.currency] = (
+                currency_totals.get(line.currency, Fraction(0)) + line.balance
+            )
+            if cad_total is not None and line.cad_balance is not None:
+                cad_total += line.cad_balance
+
+        return IncomeStatementSection(
+            title=title,
+            lines=lines,
+            currency_totals=currency_totals,
+            cad_total=cad_total,
+        )
+
+    def get_all_currencies(self, root: Account, start_date: date, end_date: date) -> set:
+        """
+        Return set of all currency codes used by Income/Expense accounts
+        with non-zero balances in the date range.
+
+        Useful for pre-validating that FX rates file covers all currencies.
+        """
+        currencies = set()
+        for account in root.get_descendants():
+            acct_type = account.GetType()
+            if acct_type not in (ACCT_TYPE_INCOME, ACCT_TYPE_EXPENSE):
+                continue
+            commodity = account.GetCommodity()
+            if commodity is None:
+                continue
+            balance = self.get_balance_in_range(account, start_date, end_date)
+            if balance != Fraction(0):
+                currencies.add(commodity.get_mnemonic())
+        return currencies

--- a/services/income_statement_renderer.py
+++ b/services/income_statement_renderer.py
@@ -1,0 +1,272 @@
+"""
+Renders an IncomeStatementResult to text, HTML, or PDF.
+"""
+
+from fractions import Fraction
+from pathlib import Path
+from typing import Dict, Optional
+
+from services.income_statement import IncomeStatementResult, IncomeStatementSection
+
+# ---------------------------------------------------------------------------
+# Plain text renderer
+# ---------------------------------------------------------------------------
+
+def _fmt(amount: Fraction, currency: str, width: int = 14) -> str:
+    """Format a Fraction as a fixed-width currency string."""
+    s = f"{float(amount):,.2f} {currency}"
+    return s.rjust(width)
+
+
+def _render_section_text(section: IncomeStatementSection, fx_rates_provided: bool) -> list:
+    lines = []
+    lines.append(section.title)
+    lines.append("-" * 60)
+
+    prev_parent = ""
+    subtotal_native: Dict[str, Fraction] = {}
+    subtotal_cad = Fraction(0)
+
+    def _flush_subtotal(parent_path: str):
+        nonlocal subtotal_cad
+        if not parent_path:
+            return
+        indent = "  " * (len(parent_path.split(":")) - 1)
+        label = f"{indent}  Subtotal: {parent_path.split(':')[-1]}"
+        native_str = "  ".join(
+            f"{float(v):>12,.2f} {c}" for c, v in sorted(subtotal_native.items())
+        )
+        if fx_rates_provided:
+            cad_str = _fmt(subtotal_cad, "CAD")
+            lines.append(f"  {label:<50} {native_str}  {cad_str}")
+        else:
+            lines.append(f"  {label:<50} {native_str}")
+        subtotal_native.clear()
+        subtotal_cad = Fraction(0)
+
+    for line in section.lines:
+        parts = line.path.split(":")
+        parent = ":".join(parts[:-1]) if len(parts) > 1 else ""
+
+        if prev_parent and parent != prev_parent:
+            _flush_subtotal(prev_parent)
+            subtotal_native.clear()
+            subtotal_cad = Fraction(0)
+
+        if parent:
+            subtotal_native[line.currency] = (
+                subtotal_native.get(line.currency, Fraction(0)) + line.balance
+            )
+            if fx_rates_provided and line.cad_balance is not None:
+                subtotal_cad += line.cad_balance
+
+        indent = "  " * line.depth
+        label = f"{indent}{line.name}"
+        native_str = _fmt(line.balance, line.currency)
+        if fx_rates_provided:
+            cad_str = _fmt(line.cad_balance or Fraction(0), "CAD") if line.cad_balance is not None else ""
+            lines.append(f"  {label:<48} {native_str}  {cad_str}")
+        else:
+            lines.append(f"  {label:<48} {native_str}")
+
+        prev_parent = parent
+
+    if prev_parent:
+        _flush_subtotal(prev_parent)
+
+    # Section total
+    lines.append("-" * 60)
+    total_label = f"Total {section.title.title()}"
+    native_totals = "  ".join(
+        f"{float(v):>12,.2f} {c}" for c, v in sorted(section.currency_totals.items())
+    )
+    if fx_rates_provided and section.cad_total is not None:
+        cad_str = _fmt(section.cad_total, "CAD")
+        lines.append(f"  {total_label:<48} {native_totals}  {cad_str}")
+    else:
+        lines.append(f"  {total_label:<48} {native_totals}")
+    lines.append("")
+    return lines
+
+
+def render_text(result: IncomeStatementResult) -> str:
+    """Render income statement as plain text."""
+    out = []
+    out.append("=" * 60)
+    out.append("INCOME STATEMENT")
+    out.append(f"Period: {result.start_date} to {result.end_date}")
+    out.append("=" * 60)
+    out.append("")
+
+    if not result.fx_rates_provided:
+        out.append(
+            "NOTE: No FX rates supplied. CAD totals not available.\n"
+            "      Rerun with --fx-rates rates.yaml for CRA T2 filing.\n"
+        )
+
+    out.extend(_render_section_text(result.income, result.fx_rates_provided))
+    out.extend(_render_section_text(result.expenses, result.fx_rates_provided))
+
+    # Net income
+    out.append("=" * 60)
+    net_totals = "  ".join(
+        f"{float(v):>12,.2f} {c}" for c, v in sorted(result.net_currency_totals.items())
+    )
+    if result.fx_rates_provided and result.net_cad_total is not None:
+        net_is_loss = result.net_cad_total < Fraction(0)
+        label = "NET INCOME (LOSS)" if net_is_loss else "NET INCOME"
+        cad_str = _fmt(result.net_cad_total, "CAD")
+        out.append(f"  {label:<48} {net_totals}  {cad_str}")
+    else:
+        out.append(f"  {'NET INCOME':<48} {net_totals}")
+    out.append("=" * 60)
+
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# HTML renderer
+# ---------------------------------------------------------------------------
+
+def _build_rows(section: IncomeStatementSection, fx_rates_provided: bool) -> list:
+    """
+    Build a flat list of row dicts for template rendering.
+
+    Each row is one of:
+      {"kind": "line",     "depth": int, "name": str, "balance": float,
+       "currency": str, "cad_balance": float|None}
+      {"kind": "subtotal", "depth": int, "label": str,
+       "native_totals": [(currency, float)], "cad_total": float|None}
+      {"kind": "total",    "label": str,
+       "native_totals": [(currency, float)], "cad_total": float|None}
+    """
+    rows = []
+    prev_parent = ""
+    subtotal_native: Dict[str, Fraction] = {}
+    subtotal_cad = Fraction(0)
+
+    def flush_subtotal(parent_path: str):
+        nonlocal subtotal_cad
+        if not parent_path:
+            return
+        depth = len(parent_path.split(":")) - 1
+        label = f"Subtotal: {parent_path.split(':')[-1]}"
+        rows.append({
+            "kind": "subtotal",
+            "depth": depth,
+            "label": label,
+            "native_totals": sorted(subtotal_native.items()),
+            "cad_total": float(subtotal_cad) if fx_rates_provided else None,
+        })
+        subtotal_native.clear()
+        subtotal_cad = Fraction(0)
+
+    for line in section.lines:
+        parts = line.path.split(":")
+        parent = ":".join(parts[:-1]) if len(parts) > 1 else ""
+
+        if prev_parent and parent != prev_parent:
+            flush_subtotal(prev_parent)
+            subtotal_native.clear()
+            subtotal_cad = Fraction(0)
+
+        if parent:
+            subtotal_native[line.currency] = (
+                subtotal_native.get(line.currency, Fraction(0)) + line.balance
+            )
+            if fx_rates_provided and line.cad_balance is not None:
+                subtotal_cad += line.cad_balance
+
+        rows.append({
+            "kind": "line",
+            "depth": line.depth,
+            "name": line.name,
+            "balance": float(line.balance),
+            "currency": line.currency,
+            "cad_balance": float(line.cad_balance) if line.cad_balance is not None else None,
+        })
+        prev_parent = parent
+
+    if prev_parent:
+        flush_subtotal(prev_parent)
+
+    rows.append({
+        "kind": "total",
+        "label": f"Total {section.title.title()}",
+        "native_totals": sorted(
+            (c, float(v)) for c, v in section.currency_totals.items()
+        ),
+        "cad_total": float(section.cad_total) if section.cad_total is not None else None,
+    })
+    return rows
+
+
+def render_html(
+    result: IncomeStatementResult,
+    fx_rate_labels: Optional[list] = None,
+) -> str:
+    """
+    Render income statement as HTML using the Jinja2 template.
+
+    Args:
+        result: IncomeStatementResult
+        fx_rate_labels: List of strings like ["HKD: 0.172", "CNY: 0.185"]
+                        for the footer note. Pass None if no FX rates.
+    Returns:
+        HTML string
+    """
+    from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+    template_dir = Path(__file__).parent.parent / "templates"
+    env = Environment(
+        loader=FileSystemLoader(str(template_dir)),
+        autoescape=select_autoescape(["html"]),
+    )
+
+    template = env.get_template("income_statement.html")
+
+    income_rows = _build_rows(result.income, result.fx_rates_provided)
+    expense_rows = _build_rows(result.expenses, result.fx_rates_provided)
+
+    net_currency_totals = sorted(
+        (c, float(v)) for c, v in result.net_currency_totals.items()
+    )
+    net_cad_total = float(result.net_cad_total) if result.net_cad_total is not None else None
+    net_is_loss = result.net_cad_total is not None and result.net_cad_total < Fraction(0)
+
+    return template.render(
+        start_date=result.start_date,
+        end_date=result.end_date,
+        fx_rates_provided=result.fx_rates_provided,
+        income_title=result.income.title,
+        income_rows=income_rows,
+        expense_title=result.expenses.title,
+        expense_rows=expense_rows,
+        net_currency_totals=net_currency_totals,
+        net_cad_total=net_cad_total,
+        net_is_loss=net_is_loss,
+        fx_rate_labels=fx_rate_labels or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# PDF renderer
+# ---------------------------------------------------------------------------
+
+def render_pdf(
+    result: IncomeStatementResult,
+    output_path: str,
+    fx_rate_labels: Optional[list] = None,
+) -> None:
+    """
+    Render income statement as PDF via WeasyPrint.
+
+    Args:
+        result: IncomeStatementResult
+        output_path: Path to write PDF file
+        fx_rate_labels: List of FX rate label strings for footer
+    """
+    import weasyprint
+
+    html = render_html(result, fx_rate_labels=fx_rate_labels)
+    weasyprint.HTML(string=html).write_pdf(output_path)

--- a/templates/income_statement.html
+++ b/templates/income_statement.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Income Statement {{ start_date }} to {{ end_date }}</title>
+  <style>
+    body { font-family: Arial, sans-serif; font-size: 11pt; color: #222; margin: 2cm; }
+    h1   { font-size: 16pt; margin-bottom: 4px; }
+    h2   { font-size: 13pt; margin-top: 20px; margin-bottom: 4px; color: #444; }
+    .period  { font-size: 10pt; color: #666; margin-bottom: 20px; }
+    .warning { color: #b45309; font-size: 10pt; margin-bottom: 12px; }
+
+    table { width: 100%; border-collapse: collapse; margin-bottom: 8px; }
+    th { text-align: left; font-size: 9pt; color: #666;
+         border-bottom: 1px solid #ccc; padding: 3px 6px; }
+    th.amt { text-align: right; }
+    td { padding: 2px 6px; font-size: 10pt; }
+    td.amt { text-align: right; white-space: nowrap; }
+
+    tr.subtotal td { border-top: 1px solid #ccc; font-style: italic; color: #555; }
+    tr.section-total td { border-top: 2px solid #888; font-weight: bold; }
+    tr.net-income td { border-top: 3px double #333; font-weight: bold;
+                       font-size: 11pt; padding-top: 6px; }
+    tr.net-income.loss td { color: #c0392b; }
+
+    .fx-note { font-size: 9pt; color: #888; margin-top: 24px; }
+  </style>
+</head>
+<body>
+
+<h1>Income Statement</h1>
+<div class="period">
+  Fiscal period: <strong>{{ start_date }}</strong> to <strong>{{ end_date }}</strong>
+</div>
+
+{% if not fx_rates_provided %}
+<div class="warning">
+  Note: No FX rates supplied — CAD totals not available.
+  Rerun with <code>--fx-rates rates.yaml</code> for CRA T2 filing.
+</div>
+{% endif %}
+
+{# ---- Macro: render one section using pre-built rows ---- #}
+{% macro render_section(title, rows) %}
+<h2>{{ title }}</h2>
+<table>
+  <tr>
+    <th>Account</th>
+    <th class="amt">Amount</th>
+    {% if fx_rates_provided %}<th class="amt">CAD</th>{% endif %}
+  </tr>
+  {% for row in rows %}
+    {% if row.kind == 'line' %}
+    <tr>
+      <td style="padding-left: {{ row.depth * 16 }}px">{{ row.name }}</td>
+      <td class="amt">{{ "%.2f"|format(row.balance) }} {{ row.currency }}</td>
+      {% if fx_rates_provided %}
+      <td class="amt">{% if row.cad_balance is not none %}{{ "%.2f"|format(row.cad_balance) }} CAD{% endif %}</td>
+      {% endif %}
+    </tr>
+    {% elif row.kind == 'subtotal' %}
+    <tr class="subtotal">
+      <td style="padding-left: {{ row.depth * 16 }}px"><em>{{ row.label }}</em></td>
+      <td class="amt">
+        {% for cur, total in row.native_totals %}{{ "%.2f"|format(total) }} {{ cur }}<br>{% endfor %}
+      </td>
+      {% if fx_rates_provided %}
+      <td class="amt">{% if row.cad_total is not none %}{{ "%.2f"|format(row.cad_total) }} CAD{% endif %}</td>
+      {% endif %}
+    </tr>
+    {% elif row.kind == 'total' %}
+    <tr class="section-total">
+      <td>{{ row.label }}</td>
+      <td class="amt">
+        {% for cur, total in row.native_totals %}{{ "%.2f"|format(total) }} {{ cur }}<br>{% endfor %}
+      </td>
+      {% if fx_rates_provided %}
+      <td class="amt">{% if row.cad_total is not none %}{{ "%.2f"|format(row.cad_total) }} CAD{% endif %}</td>
+      {% endif %}
+    </tr>
+    {% endif %}
+  {% endfor %}
+</table>
+{% endmacro %}
+
+{{ render_section(income_title, income_rows) }}
+{{ render_section(expense_title, expense_rows) }}
+
+{# ---- Net Income ---- #}
+<table>
+  <tr class="net-income {% if net_is_loss %}loss{% endif %}">
+    <td>NET INCOME{% if net_is_loss %} (LOSS){% endif %}</td>
+    <td class="amt">
+      {% for cur, total in net_currency_totals %}{{ "%.2f"|format(total) }} {{ cur }}<br>{% endfor %}
+    </td>
+    {% if fx_rates_provided %}
+    <td class="amt">{% if net_cad_total is not none %}{{ "%.2f"|format(net_cad_total) }} CAD{% endif %}</td>
+    {% endif %}
+  </tr>
+</table>
+
+{% if fx_rates_provided and fx_rate_labels %}
+<div class="fx-note">FX rates used (to CAD): {{ fx_rate_labels | join(', ') }}</div>
+{% endif %}
+
+</body>
+</html>

--- a/tests/integration/test_cli_income_statement.py
+++ b/tests/integration/test_cli_income_statement.py
@@ -1,0 +1,214 @@
+"""
+Integration tests for the income-statement CLI command.
+
+Uses temp_gnucash_for_close_books fixture (CAD + USD transactions across 2024).
+Tests the full CLI path: argument parsing → use case → text/HTML rendering.
+"""
+
+import os
+import tempfile
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FULL_YEAR_ARGS = ["--fiscal-year-end", "2024-12-31"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def run_cli(*args):
+    runner = CliRunner()
+    return runner.invoke(cli, ["income-statement"] + list(args))
+
+
+def _fx_rates_file(tmp_path, content="USD: 1.35\n"):
+    p = tmp_path / "rates.yaml"
+    p.write_text(content)
+    return str(p)
+
+
+# ---------------------------------------------------------------------------
+# Date range validation
+# ---------------------------------------------------------------------------
+
+class TestDateRangeValidation:
+
+    def test_no_date_args_fails(self, temp_gnucash_for_close_books):
+        result = run_cli(temp_gnucash_for_close_books)
+        assert result.exit_code != 0
+        assert "date range" in result.output.lower() or "usage" in result.output.lower()
+
+    def test_fiscal_year_end_only(self, temp_gnucash_for_close_books):
+        result = run_cli(temp_gnucash_for_close_books, "--fiscal-year-end", "2024-12-31")
+        assert result.exit_code == 0
+
+    def test_start_end_explicit(self, temp_gnucash_for_close_books):
+        result = run_cli(
+            temp_gnucash_for_close_books,
+            "--start", "2024-01-01",
+            "--end", "2024-12-31",
+        )
+        assert result.exit_code == 0
+
+    def test_fiscal_year_end_plus_start_fails(self, temp_gnucash_for_close_books):
+        result = run_cli(
+            temp_gnucash_for_close_books,
+            "--fiscal-year-end", "2024-12-31",
+            "--start", "2024-01-01",
+        )
+        assert result.exit_code != 0
+
+    def test_only_start_fails(self, temp_gnucash_for_close_books):
+        result = run_cli(temp_gnucash_for_close_books, "--start", "2024-01-01")
+        assert result.exit_code != 0
+
+    def test_start_after_end_fails(self, temp_gnucash_for_close_books):
+        result = run_cli(
+            temp_gnucash_for_close_books,
+            "--start", "2024-12-31",
+            "--end", "2024-01-01",
+        )
+        assert result.exit_code != 0
+
+    def test_invalid_date_format_fails(self, temp_gnucash_for_close_books):
+        result = run_cli(temp_gnucash_for_close_books, "--fiscal-year-end", "31/12/2024")
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Text output content
+# ---------------------------------------------------------------------------
+
+class TestTextOutput:
+
+    def test_contains_income_section(self, temp_gnucash_for_close_books):
+        result = run_cli(temp_gnucash_for_close_books, *FULL_YEAR_ARGS)
+        assert result.exit_code == 0
+        assert "INCOME" in result.output
+
+    def test_contains_expenses_section(self, temp_gnucash_for_close_books):
+        result = run_cli(temp_gnucash_for_close_books, *FULL_YEAR_ARGS)
+        assert result.exit_code == 0
+        assert "EXPENSES" in result.output
+
+    def test_contains_net_income(self, temp_gnucash_for_close_books):
+        result = run_cli(temp_gnucash_for_close_books, *FULL_YEAR_ARGS)
+        assert result.exit_code == 0
+        assert "NET INCOME" in result.output
+
+    def test_shows_cad_amounts(self, temp_gnucash_for_close_books):
+        result = run_cli(temp_gnucash_for_close_books, *FULL_YEAR_ARGS)
+        assert "CAD" in result.output
+
+    def test_shows_usd_amounts(self, temp_gnucash_for_close_books):
+        result = run_cli(temp_gnucash_for_close_books, *FULL_YEAR_ARGS)
+        assert "USD" in result.output
+
+    def test_shows_fiscal_period_in_output(self, temp_gnucash_for_close_books):
+        result = run_cli(temp_gnucash_for_close_books, *FULL_YEAR_ARGS)
+        assert "2024-01-01" in result.output
+        assert "2024-12-31" in result.output
+
+    def test_no_fx_warning_shown_without_fx_rates(self, temp_gnucash_for_close_books):
+        result = run_cli(temp_gnucash_for_close_books, *FULL_YEAR_ARGS)
+        assert "No FX rates" in result.output or "fx-rates" in result.output.lower()
+
+    def test_write_to_file(self, temp_gnucash_for_close_books, tmp_path):
+        out_file = str(tmp_path / "report.txt")
+        result = run_cli(
+            temp_gnucash_for_close_books,
+            *FULL_YEAR_ARGS,
+            "--output", out_file,
+        )
+        assert result.exit_code == 0
+        assert os.path.exists(out_file)
+        with open(out_file) as f:
+            content = f.read()
+        assert "INCOME" in content
+
+
+# ---------------------------------------------------------------------------
+# FX rates integration
+# ---------------------------------------------------------------------------
+
+class TestFxRatesIntegration:
+
+    def test_with_fx_rates_no_warning(self, temp_gnucash_for_close_books, tmp_path):
+        fx_file = _fx_rates_file(tmp_path)
+        result = run_cli(
+            temp_gnucash_for_close_books,
+            *FULL_YEAR_ARGS,
+            "--fx-rates", fx_file,
+        )
+        assert result.exit_code == 0
+        # Warning should NOT appear when FX rates are provided
+        assert "No FX rates" not in result.output
+
+    def test_with_fx_rates_shows_cad_total(self, temp_gnucash_for_close_books, tmp_path):
+        fx_file = _fx_rates_file(tmp_path)
+        result = run_cli(
+            temp_gnucash_for_close_books,
+            *FULL_YEAR_ARGS,
+            "--fx-rates", fx_file,
+        )
+        assert result.exit_code == 0
+        # With USD:1.35, net CAD = 5850 + 400*1.35 = 6390
+        assert "6,390" in result.output or "6390" in result.output
+
+    def test_missing_fx_rate_fails(self, temp_gnucash_for_close_books, tmp_path):
+        # Rates file missing USD — book has USD transactions
+        fx_file = _fx_rates_file(tmp_path, content="HKD: 0.172\n")
+        result = run_cli(
+            temp_gnucash_for_close_books,
+            *FULL_YEAR_ARGS,
+            "--fx-rates", fx_file,
+        )
+        assert result.exit_code != 0
+        assert "USD" in result.output
+
+
+# ---------------------------------------------------------------------------
+# HTML output
+# ---------------------------------------------------------------------------
+
+class TestHtmlOutput:
+
+    def test_html_requires_output_file(self, temp_gnucash_for_close_books):
+        result = run_cli(
+            temp_gnucash_for_close_books,
+            *FULL_YEAR_ARGS,
+            "--output-format", "html",
+        )
+        assert result.exit_code != 0
+
+    def test_html_output_written(self, temp_gnucash_for_close_books, tmp_path):
+        out_file = str(tmp_path / "report.html")
+        result = run_cli(
+            temp_gnucash_for_close_books,
+            *FULL_YEAR_ARGS,
+            "--output-format", "html",
+            "--output", out_file,
+        )
+        assert result.exit_code == 0, result.output
+        assert os.path.exists(out_file)
+        with open(out_file) as f:
+            content = f.read()
+        assert "<html" in content.lower()
+        assert "INCOME" in content
+
+    def test_html_contains_account_names(self, temp_gnucash_for_close_books, tmp_path):
+        out_file = str(tmp_path / "report.html")
+        run_cli(
+            temp_gnucash_for_close_books,
+            *FULL_YEAR_ARGS,
+            "--output-format", "html",
+            "--output", out_file,
+        )
+        with open(out_file) as f:
+            content = f.read()
+        assert "Salary" in content
+        assert "Groceries" in content

--- a/tests/unit/services/test_income_statement.py
+++ b/tests/unit/services/test_income_statement.py
@@ -1,0 +1,391 @@
+"""
+Unit tests for IncomeStatementService and FxRates.
+
+Uses temp_gnucash_for_close_books fixture (imported from plaintext).
+All transactions are in 2024; tests verify balances within different date ranges.
+
+Account structure and balances (full year 2024):
+    Income:Salary:Base    (CAD)  6000  (Jan + Feb salaries)
+    Income:Salary:Bonus   (CAD)  1000  (Mar bonus)
+    Income:Interest       (CAD)   200  (Apr)
+    Income:Freelance      (USD)   500  (Aug)
+    Expenses:Travel:Train (CAD)   150  (May)
+    Expenses:Travel:Flight(CAD)   800  (Jun)
+    Expenses:Groceries    (CAD)   400  (Jul)
+    Expenses:SaaS         (USD)   100  (Sep)
+
+    CAD net income = 7200 - 1350 = 5850
+    USD net income = 500 - 100 = 400
+"""
+
+from datetime import date
+from fractions import Fraction
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _open_read_only(path):
+    from gnucash import Session
+    try:
+        from gnucash import SessionOpenMode
+        return Session(f"xml://{path}", SessionOpenMode.SESSION_READ_ONLY)
+    except ImportError:
+        return Session(f"xml://{path}", ignore_lock=True)
+
+
+FULL_YEAR = (date(2024, 1, 1), date(2024, 12, 31))
+H1 = (date(2024, 1, 1), date(2024, 6, 30))   # Jan–Jun
+H2 = (date(2024, 7, 1), date(2024, 12, 31))  # Jul–Dec
+
+
+# ---------------------------------------------------------------------------
+# TestGetBalanceInRange
+# ---------------------------------------------------------------------------
+
+class TestGetBalanceInRange:
+
+    def test_zero_before_period(self, temp_gnucash_for_close_books):
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            from infrastructure.gnucash.utils import find_account
+            acc = find_account(root, "Income:Salary:Base")
+            svc = IncomeStatementService()
+            bal = svc.get_balance_in_range(acc, date(2023, 1, 1), date(2023, 12, 31))
+            assert bal == Fraction(0)
+        finally:
+            session.end()
+
+    def test_includes_transaction_on_start_date(self, temp_gnucash_for_close_books):
+        """Transaction on Jan 31 is included when start = Jan 1."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            from infrastructure.gnucash.utils import find_account
+            acc = find_account(root, "Income:Salary:Base")
+            svc = IncomeStatementService()
+            bal = svc.get_balance_in_range(acc, date(2024, 1, 31), date(2024, 1, 31))
+            # Raw GnuCash value: income is credit = -3000
+            assert bal == Fraction(-3000)
+        finally:
+            session.end()
+
+    def test_excludes_transaction_before_start(self, temp_gnucash_for_close_books):
+        """Jan transaction excluded when start = Feb 1."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            from infrastructure.gnucash.utils import find_account
+            acc = find_account(root, "Income:Salary:Base")
+            svc = IncomeStatementService()
+            bal = svc.get_balance_in_range(acc, date(2024, 2, 1), date(2024, 12, 31))
+            assert bal == Fraction(-3000)  # only Feb
+        finally:
+            session.end()
+
+    def test_excludes_transaction_after_end(self, temp_gnucash_for_close_books):
+        """Feb transaction excluded when end = Jan 31."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            from infrastructure.gnucash.utils import find_account
+            acc = find_account(root, "Income:Salary:Base")
+            svc = IncomeStatementService()
+            bal = svc.get_balance_in_range(acc, date(2024, 1, 1), date(2024, 1, 31))
+            assert bal == Fraction(-3000)  # only Jan
+        finally:
+            session.end()
+
+
+# ---------------------------------------------------------------------------
+# TestIncomeStatementCompute — CAD only
+# ---------------------------------------------------------------------------
+
+class TestIncomeStatementComputeCadOnly:
+
+    def test_full_year_income_lines(self, temp_gnucash_for_close_books):
+        """Full year: income section has 4 leaf accounts."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            svc = IncomeStatementService()
+            result = svc.compute(root, *FULL_YEAR)
+            # Income lines: Base, Bonus, Interest (CAD), Freelance (USD)
+            assert len(result.income.lines) == 4
+        finally:
+            session.end()
+
+    def test_full_year_income_cad_total(self, temp_gnucash_for_close_books):
+        """Full year CAD income = 7200."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            svc = IncomeStatementService()
+            result = svc.compute(root, *FULL_YEAR)
+            assert result.income.currency_totals.get("CAD") == Fraction(7200)
+        finally:
+            session.end()
+
+    def test_full_year_income_usd_total(self, temp_gnucash_for_close_books):
+        """Full year USD income = 500."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            svc = IncomeStatementService()
+            result = svc.compute(root, *FULL_YEAR)
+            assert result.income.currency_totals.get("USD") == Fraction(500)
+        finally:
+            session.end()
+
+    def test_full_year_expense_cad_total(self, temp_gnucash_for_close_books):
+        """Full year CAD expenses = 1350."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            svc = IncomeStatementService()
+            result = svc.compute(root, *FULL_YEAR)
+            assert result.expenses.currency_totals.get("CAD") == Fraction(1350)
+        finally:
+            session.end()
+
+    def test_full_year_net_cad(self, temp_gnucash_for_close_books):
+        """CAD net income = 7200 - 1350 = 5850."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            svc = IncomeStatementService()
+            result = svc.compute(root, *FULL_YEAR)
+            assert result.net_currency_totals.get("CAD") == Fraction(5850)
+        finally:
+            session.end()
+
+    def test_full_year_net_usd(self, temp_gnucash_for_close_books):
+        """USD net income = 500 - 100 = 400."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            svc = IncomeStatementService()
+            result = svc.compute(root, *FULL_YEAR)
+            assert result.net_currency_totals.get("USD") == Fraction(400)
+        finally:
+            session.end()
+
+    def test_no_cad_total_without_fx_rates(self, temp_gnucash_for_close_books):
+        """Without FX rates, cad_total is None and fx_rates_provided is False."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            svc = IncomeStatementService()
+            result = svc.compute(root, *FULL_YEAR)
+            assert result.fx_rates_provided is False
+            assert result.net_cad_total is None
+            assert result.income.cad_total is None
+            assert result.expenses.cad_total is None
+        finally:
+            session.end()
+
+    def test_half_year_h1_excludes_h2_transactions(self, temp_gnucash_for_close_books):
+        """H1 (Jan-Jun): groceries (Jul), SaaS (Sep), freelance (Aug) excluded."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            svc = IncomeStatementService()
+            result = svc.compute(root, *H1)
+            # H1 expenses: only Train (May=150) + Flight (Jun=800) = 950
+            assert result.expenses.currency_totals.get("CAD") == Fraction(950)
+            # H1 income: Salary Base (Jan+Feb=6000) + Bonus (Mar=1000) + Interest (Apr=200)
+            assert result.income.currency_totals.get("CAD") == Fraction(7200)
+            # No USD in H1 (freelance = Aug, SaaS = Sep)
+            assert "USD" not in result.income.currency_totals
+            assert "USD" not in result.expenses.currency_totals
+        finally:
+            session.end()
+
+    def test_income_lines_show_positive_display_balance(self, temp_gnucash_for_close_books):
+        """Income lines show positive balance (negated from GnuCash's credit convention)."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            svc = IncomeStatementService()
+            result = svc.compute(root, *FULL_YEAR)
+            for line in result.income.lines:
+                assert line.balance > 0, f"Income line {line.path} has non-positive balance"
+        finally:
+            session.end()
+
+    def test_expense_lines_show_positive_display_balance(self, temp_gnucash_for_close_books):
+        """Expense lines show positive balance (debit convention, already positive)."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            svc = IncomeStatementService()
+            result = svc.compute(root, *FULL_YEAR)
+            for line in result.expenses.lines:
+                assert line.balance > 0, f"Expense line {line.path} has non-positive balance"
+        finally:
+            session.end()
+
+
+# ---------------------------------------------------------------------------
+# TestIncomeStatementComputeWithFx
+# ---------------------------------------------------------------------------
+
+class TestIncomeStatementComputeWithFx:
+
+    def _fx(self):
+        from services.fx_rates import FxRates
+        return FxRates({"USD": 1.35})  # 1 USD = 1.35 CAD
+
+    def test_cad_total_income_with_fx(self, temp_gnucash_for_close_books):
+        """Income CAD total = 7200 + 500*1.35 = 7875."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            svc = IncomeStatementService()
+            result = svc.compute(root, *FULL_YEAR, fx_rates=self._fx())
+            expected = Fraction(7200) + Fraction(500) * Fraction(135, 100)
+            assert result.income.cad_total == expected
+        finally:
+            session.end()
+
+    def test_cad_total_expenses_with_fx(self, temp_gnucash_for_close_books):
+        """Expenses CAD total = 1350 + 100*1.35 = 1485."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            svc = IncomeStatementService()
+            result = svc.compute(root, *FULL_YEAR, fx_rates=self._fx())
+            expected = Fraction(1350) + Fraction(100) * Fraction(135, 100)
+            assert result.expenses.cad_total == expected
+        finally:
+            session.end()
+
+    def test_net_cad_total_with_fx(self, temp_gnucash_for_close_books):
+        """Net CAD = income_cad - expense_cad = (7200+675) - (1350+135) = 6390."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            svc = IncomeStatementService()
+            result = svc.compute(root, *FULL_YEAR, fx_rates=self._fx())
+            assert result.fx_rates_provided is True
+            income_cad = Fraction(7200) + Fraction(500) * Fraction(135, 100)
+            expense_cad = Fraction(1350) + Fraction(100) * Fraction(135, 100)
+            assert result.net_cad_total == income_cad - expense_cad
+        finally:
+            session.end()
+
+    def test_each_line_has_cad_balance(self, temp_gnucash_for_close_books):
+        """When FX rates provided, every line has a non-None cad_balance."""
+        from services.income_statement import IncomeStatementService
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            svc = IncomeStatementService()
+            result = svc.compute(root, *FULL_YEAR, fx_rates=self._fx())
+            for line in result.income.lines + result.expenses.lines:
+                assert line.cad_balance is not None, f"{line.path} missing cad_balance"
+        finally:
+            session.end()
+
+
+# ---------------------------------------------------------------------------
+# TestFxRates
+# ---------------------------------------------------------------------------
+
+class TestFxRates:
+
+    def test_to_cad_known_currency(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({"HKD": 0.172})
+        result = fx.to_cad(Fraction(1000), "HKD")
+        assert abs(float(result) - 172.0) < 0.01
+
+    def test_to_cad_cad_is_one(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({})
+        assert fx.to_cad(Fraction(500), "CAD") == Fraction(500)
+
+    def test_to_cad_missing_raises(self):
+        from services.fx_rates import FxRates, MissingFxRateError
+        fx = FxRates({"HKD": 0.172})
+        with pytest.raises(MissingFxRateError, match="CNY"):
+            fx.to_cad(Fraction(100), "CNY")
+
+    def test_missing_currencies(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({"HKD": 0.172, "USD": 1.35})
+        missing = fx.missing_currencies({"HKD", "USD", "CNY", "JPY"})
+        assert missing == {"CNY", "JPY"}
+
+    def test_load_valid_yaml(self, tmp_path):
+        from services.fx_rates import FxRates
+        f = tmp_path / "rates.yaml"
+        f.write_text("HKD: 0.172\nCNY: 0.185\n")
+        fx = FxRates.load(str(f))
+        assert fx.has_rate("HKD")
+        assert fx.has_rate("CNY")
+        assert fx.has_rate("CAD")  # always present
+
+    def test_load_missing_file_raises(self, tmp_path):
+        from services.fx_rates import FxRates
+        with pytest.raises(FileNotFoundError):
+            FxRates.load(str(tmp_path / "nonexistent.yaml"))
+
+    def test_load_invalid_rate_raises(self, tmp_path):
+        from services.fx_rates import FxRates
+        f = tmp_path / "bad.yaml"
+        f.write_text("HKD: -0.1\n")
+        with pytest.raises(ValueError, match="positive"):
+            FxRates.load(str(f))
+
+    def test_load_non_numeric_raises(self, tmp_path):
+        from services.fx_rates import FxRates
+        f = tmp_path / "bad.yaml"
+        f.write_text("HKD: not_a_number\n")
+        with pytest.raises(ValueError):
+            FxRates.load(str(f))
+
+
+# ---------------------------------------------------------------------------
+# TestFiscalYearStart
+# ---------------------------------------------------------------------------
+
+class TestFiscalYearStart:
+
+    def test_calendar_year(self):
+        from use_cases.generate_income_statement import fiscal_year_start
+        assert fiscal_year_start(date(2024, 12, 31)) == date(2024, 1, 1)
+
+    def test_march_fiscal_year(self):
+        from use_cases.generate_income_statement import fiscal_year_start
+        assert fiscal_year_start(date(2024, 3, 31)) == date(2023, 4, 1)
+
+    def test_mid_year(self):
+        from use_cases.generate_income_statement import fiscal_year_start
+        assert fiscal_year_start(date(2024, 6, 30)) == date(2023, 7, 1)
+
+    def test_leap_year_feb29(self):
+        """Feb 29 fiscal year end: prior year has no Feb 29, falls back to Mar 1 start."""
+        from use_cases.generate_income_statement import fiscal_year_start
+        # 2024-02-29 → one year ago = 2023-02-28 (fallback) → +1 day = 2023-03-01
+        assert fiscal_year_start(date(2024, 2, 29)) == date(2023, 3, 1)

--- a/use_cases/generate_income_statement.py
+++ b/use_cases/generate_income_statement.py
@@ -1,0 +1,81 @@
+"""
+Use case for generating an income statement.
+
+Orchestrates IncomeStatementService and renderers to produce
+text/HTML/PDF output for a given fiscal period.
+"""
+
+from datetime import date, timedelta
+from typing import Optional
+
+from repositories.gnucash_repository import GnuCashRepository
+from services.fx_rates import FxRates, MissingFxRateError
+from services.income_statement import IncomeStatementResult, IncomeStatementService
+
+
+def fiscal_year_start(fiscal_year_end: date) -> date:
+    """
+    Compute fiscal year start from fiscal year end.
+
+    Returns the same month/day one year earlier, plus one day.
+    Examples:
+        2024-12-31 → 2024-01-01
+        2024-03-31 → 2023-04-01
+        2024-02-29 → 2023-03-01 (Feb 29 falls back to Feb 28, then +1 day = Mar 1)
+    """
+    try:
+        one_year_ago = date(fiscal_year_end.year - 1, fiscal_year_end.month, fiscal_year_end.day)
+    except ValueError:
+        # Feb 29 in a non-leap prior year: fall back to Feb 28
+        one_year_ago = date(fiscal_year_end.year - 1, fiscal_year_end.month, fiscal_year_end.day - 1)
+    return one_year_ago + timedelta(days=1)
+
+
+class GenerateIncomeStatementUseCase:
+    """Use case for generating an income statement report."""
+
+    def __init__(self, repository: GnuCashRepository):
+        self.repository = repository
+        self.service = IncomeStatementService()
+
+    def execute(
+        self,
+        start_date: date,
+        end_date: date,
+        fx_rates: Optional[FxRates] = None,
+    ) -> IncomeStatementResult:
+        """
+        Generate income statement for the given date range.
+
+        Args:
+            start_date: First day of the period (inclusive)
+            end_date: Last day of the period (inclusive)
+            fx_rates: Optional FX rates for CAD conversion.
+                      If provided, validates all currencies are covered before running.
+
+        Returns:
+            IncomeStatementResult
+
+        Raises:
+            MissingFxRateError: If fx_rates provided but a currency in the ledger has no rate
+            ValueError: If start_date > end_date
+        """
+        if start_date > end_date:
+            raise ValueError(
+                f"start_date ({start_date}) must be on or before end_date ({end_date})"
+            )
+
+        root = self.repository.get_root_account()
+
+        # Pre-validate FX coverage before doing any computation
+        if fx_rates is not None:
+            currencies = self.service.get_all_currencies(root, start_date, end_date)
+            missing = fx_rates.missing_currencies(currencies)
+            if missing:
+                missing_list = ", ".join(sorted(missing))
+                raise MissingFxRateError(
+                    f"Missing FX rates for: {missing_list}. "
+                    f"Add these currencies to your --fx-rates file."
+                )
+
+        return self.service.compute(root, start_date, end_date, fx_rates)


### PR DESCRIPTION
Implements a new `gnucash-plaintext income-statement` CLI command that generates a profit & loss report suitable for CRA T2 corporate income tax filing.

Key features:
- Two date range modes: --fiscal-year-end (auto-computes start as end − 1 year + 1 day) or explicit --start/--end
- Multi-currency support: per-currency breakdown with optional CAD conversion via --fx-rates rates.yaml (Bank of Canada annual averages)
- Three output formats: text (stdout), HTML (Jinja2), PDF (WeasyPrint)
- Full account tree with subtotals at every level — required for accurate T2 Schedule 125 categorisation
- Does not require books to be closed; works on raw transactions

New files:
- services/fx_rates.py         — load/validate FX rates YAML, convert to CAD
- services/income_statement.py — compute per-account balances in date range
- services/income_statement_renderer.py — text/HTML/PDF rendering
- use_cases/generate_income_statement.py — orchestration + FX validation
- cli/income_statement_cmd.py  — Click command with all options
- templates/income_statement.html — Jinja2 template (HTML + PDF)
- docs/income-statement-design.md — design decisions document
- tests/unit/services/test_income_statement.py   — 22 unit tests (incl. Feb 29 edge case)
- tests/integration/test_cli_income_statement.py — 17 integration tests

Bug fixes vs initial draft:
- fiscal_year_start: handle Feb 29 fiscal year end (prior year has no Feb 29)
- FxRates: add public get_rate() method; remove private _rates access in CLI

Also adds jinja2 as a core dependency in pyproject.toml (was already installed in Docker but not declared).