### PR TITLE
Add update-by-guid: in-place transaction update preserving GUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,28 @@ gnucash-plaintext import mybook.gnucash transactions.txt --strategy keep-existin
 
 # Replace with incoming transactions on conflict
 gnucash-plaintext import mybook.gnucash transactions.txt --strategy keep-incoming
+
+# Update existing transactions in-place by GUID (preserves GUID)
+gnucash-plaintext import mybook.gnucash transactions.txt --strategy update
 ```
+
+**`--strategy update`: stable edit-and-reimport workflow**
+
+When a transaction in the plaintext file carries a `guid:` metadata field that matches
+an existing transaction in the book, `--strategy update` modifies that transaction
+in-place — description, date, amounts, splits, notes, doc_link — without destroying
+or recreating it. Because the GnuCash object itself is never replaced, its GUID is
+preserved. This makes the workflow stable across multiple runs:
+
+```
+export → edit plaintext → re-import --strategy update → export again …
+```
+
+Each re-import finds the same GUID and updates the same transaction. No phantom
+duplicates are created regardless of how many times you repeat the cycle.
+
+Transactions in the plaintext file that have no `guid:` field, or whose GUID is not
+found in the book, follow normal duplicate/conflict detection as usual.
 
 **How conflicts are detected:**
 

--- a/cli/import_cmd.py
+++ b/cli/import_cmd.py
@@ -20,9 +20,10 @@ from use_cases.import_transactions import ImportTransactionsUseCase
 @click.option('-f', '--file', 'plaintext_file', type=click.Path(), help='Plaintext transactions file')
 @click.option(
     '--strategy',
-    type=click.Choice(['skip', 'keep-existing', 'keep-incoming'], case_sensitive=False),
+    type=click.Choice(['skip', 'keep-existing', 'keep-incoming', 'update'], case_sensitive=False),
     default='skip',
-    help='Conflict resolution strategy (default: skip)'
+    help='Conflict resolution strategy (default: skip). '
+         'update: modify existing transactions in-place when a GUID match is found, preserving their GUID.'
 )
 @click.option(
     '--dry-run',
@@ -94,7 +95,8 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
     strategy_map = {
         'skip': ResolutionStrategy.SKIP,
         'keep-existing': ResolutionStrategy.KEEP_EXISTING,
-        'keep-incoming': ResolutionStrategy.KEEP_INCOMING
+        'keep-incoming': ResolutionStrategy.KEEP_INCOMING,
+        'update': ResolutionStrategy.UPDATE,
     }
     resolution_strategy = strategy_map[strategy]
 
@@ -136,6 +138,7 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
             click.echo("Import Summary:")
             click.echo("=" * 50)
             click.echo(f"  Transactions: {result.imported_count}")
+            click.echo(f"  Updated:      {result.updated_count}")
             click.echo(f"  Accounts:     {result.accounts_created}")
             click.echo(f"  Skipped:      {result.skipped_count} (duplicates)")
             click.echo(f"  Conflicts:    {len(result.conflicts)}")
@@ -157,7 +160,7 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
                         click.echo(f"  - {str(error)}")
 
             # Save if not dry run and something was imported
-            has_changes = result.imported_count > 0 or result.accounts_created > 0
+            has_changes = result.imported_count > 0 or result.updated_count > 0 or result.accounts_created > 0
             if not dry_run and has_changes:
                 click.echo("")
                 click.echo("Saving changes...")

--- a/services/conflict_resolver.py
+++ b/services/conflict_resolver.py
@@ -17,6 +17,7 @@ class ResolutionStrategy(Enum):
     KEEP_INCOMING = "keep_incoming"
     SKIP = "skip"
     MANUAL = "manual"
+    UPDATE = "update"  # Update existing transaction in-place by GUID (preserves GUID)
 
 
 class ConflictInfo:

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -28,7 +28,7 @@ from gnucash.gnucash_core_c import (
     gncTaxTableEntrySetAccount,
 )
 
-from infrastructure.gnucash.utils import find_account, string_to_gnc_numeric
+from infrastructure.gnucash.utils import find_account, get_account_full_name, string_to_gnc_numeric
 from services.plaintext_parser import DirectiveType, PlaintextDirective
 
 
@@ -275,6 +275,134 @@ class GnuCashImporter:
         transaction.CommitEdit()
         logging.debug(f"Created transaction on {date_str}")
         return True
+
+    @staticmethod
+    def update_transaction(existing_tx, directive: PlaintextDirective, book: Book) -> None:
+        """
+        Update an existing GnuCash transaction in-place from a plaintext directive.
+
+        The transaction's GUID is preserved — the transaction object is modified,
+        not replaced. This makes the export→edit-plaintext→re-import cycle stable
+        across multiple runs: the same GUID is always present, so subsequent imports
+        with UPDATE strategy will keep updating the same transaction instead of
+        creating duplicates.
+
+        All scalar fields (description, date, num, doc_link, notes, currency) and
+        splits are updated to match the directive. Split matching is by account
+        full-name. Splits for accounts absent from the directive are removed; splits
+        for new accounts are created.
+
+        Note: When two splits in the directive share the same account (rare but valid),
+        the last directive entry for that account wins — consistent with create_transaction.
+
+        Args:
+            existing_tx: GnuCash Transaction object to update
+            directive:   PlaintextDirective of type TRANSACTION containing new values
+            book:        GnuCash Book (required to create new Split objects)
+
+        Raises:
+            ValueError: If a split account named in the directive cannot be found
+        """
+        if directive.type != DirectiveType.TRANSACTION:
+            raise ValueError(f"Expected TRANSACTION but got {directive.type}")
+
+        root_account = book.get_root_account()
+        commodity_table = book.get_table()
+
+        existing_tx.BeginEdit()
+        try:
+            # Update transaction-level scalar fields
+            date_str = directive.props['date']
+            date = datetime.strptime(date_str, '%Y-%m-%d')
+            existing_tx.SetDatePostedSecsNormalized(date)
+
+            tx_num = directive.props.get('tx_num')
+            tx_desc = directive.props.get('tx_desc')
+            if tx_num is not None:
+                existing_tx.SetNum(tx_num)
+            if tx_desc is not None:
+                existing_tx.SetDescription(tx_desc)
+
+            if 'doc_link' in directive.metadata:
+                try:
+                    existing_tx.SetDocLink(directive.metadata['doc_link'])
+                except AttributeError:
+                    existing_tx.SetAssociation(directive.metadata['doc_link'])
+
+            if 'notes' in directive.metadata:
+                existing_tx.SetNotes(directive.metadata['notes'])
+
+            # Update currency if specified
+            namespace = directive.metadata.get('currency.namespace', 'CURRENCY')
+            if 'currency.mnemonic' in directive.metadata:
+                mnemonic = directive.metadata['currency.mnemonic']
+                commodity = commodity_table.lookup(namespace, mnemonic)
+                if commodity is not None:
+                    existing_tx.SetCurrency(commodity)
+
+            tx_currency = existing_tx.GetCurrency()
+
+            # Build account-name → split maps for existing and desired splits
+            existing_splits_by_account = {}
+            for split in existing_tx.GetSplitList():
+                acct_name = get_account_full_name(split.GetAccount())
+                existing_splits_by_account[acct_name] = split
+
+            desired_by_account = {}
+            for child in directive.children:
+                desired_by_account[child.props['account']] = child
+
+            # Validate all desired accounts exist before making any changes
+            for acct_name in desired_by_account:
+                if find_account(root_account, acct_name) is None:
+                    raise ValueError(f"Account not found: {acct_name}")
+
+            # Remove splits for accounts no longer in the directive
+            for acct_name, split in list(existing_splits_by_account.items()):
+                if acct_name not in desired_by_account:
+                    split.Destroy()
+
+            # Update existing splits or create new ones
+            for acct_name, split_directive in desired_by_account.items():
+                split_account = find_account(root_account, acct_name)
+                split_account_currency = split_account.GetCommodity()
+                amount = string_to_gnc_numeric(split_directive.props['amount'], split_account_currency)
+
+                if 'value' in split_directive.metadata:
+                    value = string_to_gnc_numeric(split_directive.metadata['value'], tx_currency)
+                else:
+                    value = amount
+
+                if acct_name in existing_splits_by_account:
+                    split = existing_splits_by_account[acct_name]
+                else:
+                    split = Split(book)
+                    split.SetParent(existing_tx)
+                    split.SetAccount(split_account)
+
+                split.SetAmount(amount)
+                split.SetValue(value)
+
+                if 'share_price' in split_directive.metadata:
+                    share_price = string_to_gnc_numeric(split_directive.metadata['share_price'], tx_currency)
+                    split.SetSharePrice(share_price)
+
+                if 'action' in split_directive.metadata:
+                    action = split_directive.metadata['action']
+                    if action is not None:
+                        split.SetAction(action)
+
+                if 'memo' in split_directive.metadata:
+                    memo = split_directive.metadata['memo']
+                    if memo is not None:
+                        split.SetMemo(memo)
+
+            existing_tx.CommitEdit()
+            logging.debug(f"Updated transaction on {date_str}")
+
+        except Exception:
+            existing_tx.RollbackEdit()
+            raise
 
     @staticmethod
     def import_customer(directive: PlaintextDirective, book: Book):

--- a/tests/unit/services/test_update_transaction.py
+++ b/tests/unit/services/test_update_transaction.py
@@ -1,0 +1,554 @@
+"""
+Unit tests for GnuCashImporter.update_transaction()
+
+These tests use real GnuCash files (no mocks), created in Docker.
+Each test verifies that update_transaction() modifies the existing transaction
+in-place and — critically — leaves the GUID unchanged.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_session(path):
+    """Open a new GnuCash session at *path* (SESSION_NEW_STORE)."""
+    from gnucash import Session
+    try:
+        from gnucash import SessionOpenMode
+        return Session(f'xml://{path}', SessionOpenMode.SESSION_NEW_STORE)
+    except ImportError:
+        return Session(f'xml://{path}', is_new=True)
+
+
+def _open_session(path):
+    """Open an existing GnuCash session at *path*."""
+    from gnucash import Session
+    try:
+        from gnucash import SessionOpenMode
+        return Session(f'xml://{path}', SessionOpenMode.SESSION_NORMAL_OPEN)
+    except ImportError:
+        return Session(f'xml://{path}')
+
+
+def _build_directive(date_str, tx_desc, splits, metadata=None):
+    """
+    Construct a minimal PlaintextDirective for a TRANSACTION with the given splits.
+
+    *splits* is a list of dicts: {'account': str, 'amount': str, ...optional metadata...}
+    """
+    from services.plaintext_parser import DirectiveType, PlaintextDirective
+
+    tx_dir = PlaintextDirective(DirectiveType.TRANSACTION, level=0, line='')
+    tx_dir.props = {'date': date_str, 'tx_num': None, 'tx_desc': tx_desc}
+    tx_dir.metadata = metadata or {}
+
+    for s in splits:
+        split_dir = PlaintextDirective(DirectiveType.SPLIT, level=1, line='')
+        split_dir.props = {'account': s['account'], 'amount': s['amount']}
+        split_dir.metadata = {k: v for k, v in s.items() if k not in ('account', 'amount')}
+        tx_dir.children.append(split_dir)
+
+    return tx_dir
+
+
+@pytest.fixture
+def gnucash_with_one_transaction():
+    """
+    Temp GnuCash file with one CAD transaction:
+      2024-03-01  Grocery shopping
+        Expenses:Groceries   50.00 CAD
+        Assets:Bank:Checking -50.00 CAD
+
+    Yields (path, guid_string).
+    """
+    fd, path = tempfile.mkstemp(suffix='.gnucash')
+    os.close(fd)
+    os.unlink(path)
+
+    try:
+        import gnucash
+        from gnucash import Account, GncNumeric, Split, Transaction
+
+        session = _make_session(path)
+        book = session.book
+        root = book.get_root_account()
+        commod_table = book.get_table()
+        cad = commod_table.lookup('CURRENCY', 'CAD')
+
+        assets = Account(book)
+        assets.SetName('Assets')
+        assets.SetType(gnucash.ACCT_TYPE_ASSET)
+        assets.SetCommodity(cad)
+        root.append_child(assets)
+
+        bank = Account(book)
+        bank.SetName('Bank')
+        bank.SetType(gnucash.ACCT_TYPE_BANK)
+        bank.SetCommodity(cad)
+        assets.append_child(bank)
+
+        checking = Account(book)
+        checking.SetName('Checking')
+        checking.SetType(gnucash.ACCT_TYPE_BANK)
+        checking.SetCommodity(cad)
+        bank.append_child(checking)
+
+        expenses = Account(book)
+        expenses.SetName('Expenses')
+        expenses.SetType(gnucash.ACCT_TYPE_EXPENSE)
+        expenses.SetCommodity(cad)
+        root.append_child(expenses)
+
+        groceries = Account(book)
+        groceries.SetName('Groceries')
+        groceries.SetType(gnucash.ACCT_TYPE_EXPENSE)
+        groceries.SetCommodity(cad)
+        expenses.append_child(groceries)
+
+        dining = Account(book)
+        dining.SetName('Dining')
+        dining.SetType(gnucash.ACCT_TYPE_EXPENSE)
+        dining.SetCommodity(cad)
+        expenses.append_child(dining)
+
+        tx = Transaction(book)
+        tx.BeginEdit()
+        tx.SetCurrency(cad)
+        tx.SetDate(1, 3, 2024)
+        tx.SetDescription("Grocery shopping")
+
+        s1 = Split(book)
+        s1.SetParent(tx)
+        s1.SetAccount(groceries)
+        s1.SetValue(GncNumeric(5000, 100))
+
+        s2 = Split(book)
+        s2.SetParent(tx)
+        s2.SetAccount(checking)
+        s2.SetValue(GncNumeric(-5000, 100))
+
+        tx.CommitEdit()
+        guid = tx.GetGUID().to_string()
+
+        session.save()
+        session.end()
+
+        yield path, guid
+
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+        lock = path + '.LCK'
+        if os.path.exists(lock):
+            os.unlink(lock)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestUpdateTransactionDescription:
+    def test_description_changes(self, gnucash_with_one_transaction):
+        """update_transaction changes the description."""
+        from gnucash import Query, Transaction
+
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = gnucash_with_one_transaction
+        session = _open_session(path)
+        book = session.book
+
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        directive = _build_directive('2024-03-01', 'Updated description', [
+            {'account': 'Expenses:Groceries', 'amount': '50.00'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-50.00'},
+        ])
+
+        GnuCashImporter.update_transaction(existing_tx, directive, book)
+        session.save()
+        session.end()
+
+        # Re-open and verify
+        session2 = _open_session(path)
+        book2 = session2.book
+        q2 = Query()
+        q2.search_for('Trans')
+        q2.set_book(book2)
+        txs2 = [Transaction(instance=t) for t in q2.run()]
+        updated = next(t for t in txs2 if t.GetGUID().to_string() == guid)
+        assert updated.GetDescription() == 'Updated description'
+        session2.end()
+
+    def test_guid_preserved_after_description_update(self, gnucash_with_one_transaction):
+        """GUID must not change when description is updated."""
+        from gnucash import Query, Transaction
+
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = gnucash_with_one_transaction
+        session = _open_session(path)
+        book = session.book
+
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        directive = _build_directive('2024-03-01', 'New description', [
+            {'account': 'Expenses:Groceries', 'amount': '50.00'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-50.00'},
+        ])
+
+        GnuCashImporter.update_transaction(existing_tx, directive, book)
+        assert existing_tx.GetGUID().to_string() == guid
+        session.save()
+        session.end()
+
+        # GUID must still be found after reload
+        session2 = _open_session(path)
+        book2 = session2.book
+        q2 = Query()
+        q2.search_for('Trans')
+        q2.set_book(book2)
+        txs2 = [Transaction(instance=t) for t in q2.run()]
+        guids = [t.GetGUID().to_string() for t in txs2]
+        assert guid in guids
+        session2.end()
+
+
+class TestUpdateTransactionAmounts:
+    def test_split_amounts_change(self, gnucash_with_one_transaction):
+        """update_transaction changes split amounts."""
+        from gnucash import Query, Transaction
+
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = gnucash_with_one_transaction
+        session = _open_session(path)
+        book = session.book
+
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        directive = _build_directive('2024-03-01', 'Grocery shopping', [
+            {'account': 'Expenses:Groceries', 'amount': '75.00'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-75.00'},
+        ])
+
+        GnuCashImporter.update_transaction(existing_tx, directive, book)
+        session.save()
+        session.end()
+
+        session2 = _open_session(path)
+        book2 = session2.book
+        q2 = Query()
+        q2.search_for('Trans')
+        q2.set_book(book2)
+        txs2 = [Transaction(instance=t) for t in q2.run()]
+        updated = next(t for t in txs2 if t.GetGUID().to_string() == guid)
+
+        amounts = {
+            split.GetAccount().GetName(): split.GetValue()
+            for split in updated.GetSplitList()
+        }
+        assert amounts['Groceries'].num() == 7500
+        assert amounts['Groceries'].denom() == 100
+        assert amounts['Checking'].num() == -7500
+        session2.end()
+
+    def test_guid_preserved_after_amount_update(self, gnucash_with_one_transaction):
+        """GUID must not change when amounts are updated."""
+        from gnucash import Query, Transaction
+
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = gnucash_with_one_transaction
+        session = _open_session(path)
+        book = session.book
+
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        directive = _build_directive('2024-03-01', 'Grocery shopping', [
+            {'account': 'Expenses:Groceries', 'amount': '99.00'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-99.00'},
+        ])
+
+        GnuCashImporter.update_transaction(existing_tx, directive, book)
+        assert existing_tx.GetGUID().to_string() == guid
+        session.save()
+        session.end()
+
+
+class TestUpdateTransactionDate:
+    def test_date_changes(self, gnucash_with_one_transaction):
+        """update_transaction changes the posted date."""
+        from gnucash import Query, Transaction
+
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = gnucash_with_one_transaction
+        session = _open_session(path)
+        book = session.book
+
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        directive = _build_directive('2024-04-15', 'Grocery shopping', [
+            {'account': 'Expenses:Groceries', 'amount': '50.00'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-50.00'},
+        ])
+
+        GnuCashImporter.update_transaction(existing_tx, directive, book)
+        session.save()
+        session.end()
+
+        session2 = _open_session(path)
+        book2 = session2.book
+        q2 = Query()
+        q2.search_for('Trans')
+        q2.set_book(book2)
+        txs2 = [Transaction(instance=t) for t in q2.run()]
+        updated = next(t for t in txs2 if t.GetGUID().to_string() == guid)
+        d = updated.GetDate()
+        assert d.year == 2024
+        assert d.month == 4
+        assert d.day == 15
+        session2.end()
+
+
+class TestUpdateTransactionSplitStructure:
+    def test_add_new_split(self, gnucash_with_one_transaction):
+        """update_transaction can add a new split (2→3 splits)."""
+        from gnucash import Query, Transaction
+
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = gnucash_with_one_transaction
+        session = _open_session(path)
+        book = session.book
+
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        # Change from 2-split to 3-split: split Groceries into Groceries + Dining
+        directive = _build_directive('2024-03-01', 'Mixed shopping', [
+            {'account': 'Expenses:Groceries', 'amount': '30.00'},
+            {'account': 'Expenses:Dining', 'amount': '20.00'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-50.00'},
+        ])
+
+        GnuCashImporter.update_transaction(existing_tx, directive, book)
+        session.save()
+        session.end()
+
+        session2 = _open_session(path)
+        book2 = session2.book
+        q2 = Query()
+        q2.search_for('Trans')
+        q2.set_book(book2)
+        txs2 = [Transaction(instance=t) for t in q2.run()]
+        updated = next(t for t in txs2 if t.GetGUID().to_string() == guid)
+        account_names = {s.GetAccount().GetName() for s in updated.GetSplitList()}
+        assert 'Groceries' in account_names
+        assert 'Dining' in account_names
+        assert 'Checking' in account_names
+        session2.end()
+
+    def test_remove_split(self, gnucash_with_one_transaction):
+        """update_transaction can remove a split (2→1 splits, partial update scenario)."""
+        from gnucash import Query, Transaction
+
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = gnucash_with_one_transaction
+
+        # Add a third Dining split first
+        session = _open_session(path)
+        book = session.book
+        import gnucash as gnc
+        from gnucash import GncNumeric, Split
+
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        # Find Dining account
+        root = book.get_root_account()
+        from infrastructure.gnucash.utils import find_account
+        dining = find_account(root, 'Expenses:Dining')
+
+        existing_tx.BeginEdit()
+        extra = Split(book)
+        extra.SetParent(existing_tx)
+        extra.SetAccount(dining)
+        extra.SetValue(GncNumeric(2000, 100))
+        existing_tx.CommitEdit()
+        session.save()
+        session.end()
+
+        import time
+        time.sleep(1)  # GnuCash backup filenames include a timestamp; avoid collision
+
+        # Now update: remove Dining split
+        session2 = _open_session(path)
+        book2 = session2.book
+        q2 = Query()
+        q2.search_for('Trans')
+        q2.set_book(book2)
+        txs2 = [Transaction(instance=t) for t in q2.run()]
+        existing_tx2 = next(t for t in txs2 if t.GetGUID().to_string() == guid)
+
+        directive = _build_directive('2024-03-01', 'Grocery shopping', [
+            {'account': 'Expenses:Groceries', 'amount': '50.00'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-50.00'},
+        ])
+
+        from services.gnucash_importer import GnuCashImporter
+        GnuCashImporter.update_transaction(existing_tx2, directive, book2)
+        session2.save()
+        session2.end()
+
+        session3 = _open_session(path)
+        book3 = session3.book
+        q3 = Query()
+        q3.search_for('Trans')
+        q3.set_book(book3)
+        txs3 = [Transaction(instance=t) for t in q3.run()]
+        updated = next(t for t in txs3 if t.GetGUID().to_string() == guid)
+        account_names = {s.GetAccount().GetName() for s in updated.GetSplitList()}
+        assert 'Dining' not in account_names
+        assert 'Groceries' in account_names
+        session3.end()
+
+
+class TestUpdateTransactionMetadata:
+    def test_notes_updated(self, gnucash_with_one_transaction):
+        """update_transaction sets notes metadata."""
+        from gnucash import Query, Transaction
+
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = gnucash_with_one_transaction
+        session = _open_session(path)
+        book = session.book
+
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        directive = _build_directive('2024-03-01', 'Grocery shopping', [
+            {'account': 'Expenses:Groceries', 'amount': '50.00'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-50.00'},
+        ], metadata={'notes': 'receipt #1234'})
+
+        GnuCashImporter.update_transaction(existing_tx, directive, book)
+        session.save()
+        session.end()
+
+        session2 = _open_session(path)
+        book2 = session2.book
+        q2 = Query()
+        q2.search_for('Trans')
+        q2.set_book(book2)
+        txs2 = [Transaction(instance=t) for t in q2.run()]
+        updated = next(t for t in txs2 if t.GetGUID().to_string() == guid)
+        assert updated.GetNotes() == 'receipt #1234'
+        session2.end()
+
+    def test_split_memo_updated(self, gnucash_with_one_transaction):
+        """update_transaction sets split-level memo."""
+        from gnucash import Query, Transaction
+
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = gnucash_with_one_transaction
+        session = _open_session(path)
+        book = session.book
+
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        directive = _build_directive('2024-03-01', 'Grocery shopping', [
+            {'account': 'Expenses:Groceries', 'amount': '50.00', 'memo': 'organic section'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-50.00'},
+        ])
+
+        GnuCashImporter.update_transaction(existing_tx, directive, book)
+        session.save()
+        session.end()
+
+        session2 = _open_session(path)
+        book2 = session2.book
+        q2 = Query()
+        q2.search_for('Trans')
+        q2.set_book(book2)
+        txs2 = [Transaction(instance=t) for t in q2.run()]
+        updated = next(t for t in txs2 if t.GetGUID().to_string() == guid)
+
+        groceries_split = next(
+            s for s in updated.GetSplitList()
+            if s.GetAccount().GetName() == 'Groceries'
+        )
+        assert groceries_split.GetMemo() == 'organic section'
+        session2.end()
+
+
+class TestUpdateTransactionErrorHandling:
+    def test_invalid_account_raises_and_does_not_corrupt(self, gnucash_with_one_transaction):
+        """update_transaction raises ValueError for unknown account and leaves transaction intact."""
+        from gnucash import Query, Transaction
+
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = gnucash_with_one_transaction
+        session = _open_session(path)
+        book = session.book
+
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        directive = _build_directive('2024-03-01', 'Bad transaction', [
+            {'account': 'Expenses:DoesNotExist', 'amount': '50.00'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-50.00'},
+        ])
+
+        with pytest.raises(ValueError, match="Account not found"):
+            GnuCashImporter.update_transaction(existing_tx, directive, book)
+
+        # Original description must be intact
+        assert existing_tx.GetDescription() == 'Grocery shopping'
+        session.end()

--- a/tests/unit/use_cases/test_import_update.py
+++ b/tests/unit/use_cases/test_import_update.py
@@ -1,0 +1,473 @@
+"""
+Tests for ImportTransactionsUseCase with ResolutionStrategy.UPDATE
+
+Verifies the full import_from_file() flow when UPDATE strategy is used:
+- Transactions matched by GUID are updated in-place (GUID preserved)
+- Transactions without a GUID in the plaintext follow normal conflict detection
+- Transactions with a GUID not present in the book are created as new
+- Stable roundtrip: export → re-import with UPDATE → no phantom duplicates
+
+These tests use real GnuCash files (no mocks), running in Docker.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _open_session(path):
+    from gnucash import Session
+    try:
+        from gnucash import SessionOpenMode
+        return Session(f'xml://{path}', SessionOpenMode.SESSION_NORMAL_OPEN)
+    except ImportError:
+        return Session(f'xml://{path}')
+
+
+@pytest.fixture
+def gnucash_with_exportable_transaction():
+    """
+    GnuCash file with one CAD transaction.  Returns (gnucash_path, guid).
+
+    The transaction is:
+      2024-05-10  Lunch
+        Expenses:Dining      25.00 CAD
+        Assets:Bank:Checking -25.00 CAD
+    """
+    fd, path = tempfile.mkstemp(suffix='.gnucash')
+    os.close(fd)
+    os.unlink(path)
+
+    try:
+        import gnucash
+        from gnucash import Account, GncNumeric, Session, Split, Transaction
+
+        try:
+            from gnucash import SessionOpenMode
+            session = Session(f'xml://{path}', SessionOpenMode.SESSION_NEW_STORE)
+        except ImportError:
+            session = Session(f'xml://{path}', is_new=True)
+
+        book = session.book
+        root = book.get_root_account()
+        commod_table = book.get_table()
+        cad = commod_table.lookup('CURRENCY', 'CAD')
+
+        assets = Account(book)
+        assets.SetName('Assets')
+        assets.SetType(gnucash.ACCT_TYPE_ASSET)
+        assets.SetCommodity(cad)
+        root.append_child(assets)
+
+        bank = Account(book)
+        bank.SetName('Bank')
+        bank.SetType(gnucash.ACCT_TYPE_BANK)
+        bank.SetCommodity(cad)
+        assets.append_child(bank)
+
+        checking = Account(book)
+        checking.SetName('Checking')
+        checking.SetType(gnucash.ACCT_TYPE_BANK)
+        checking.SetCommodity(cad)
+        bank.append_child(checking)
+
+        expenses = Account(book)
+        expenses.SetName('Expenses')
+        expenses.SetType(gnucash.ACCT_TYPE_EXPENSE)
+        expenses.SetCommodity(cad)
+        root.append_child(expenses)
+
+        groceries = Account(book)
+        groceries.SetName('Groceries')
+        groceries.SetType(gnucash.ACCT_TYPE_EXPENSE)
+        groceries.SetCommodity(cad)
+        expenses.append_child(groceries)
+
+        dining = Account(book)
+        dining.SetName('Dining')
+        dining.SetType(gnucash.ACCT_TYPE_EXPENSE)
+        dining.SetCommodity(cad)
+        expenses.append_child(dining)
+
+        tx = Transaction(book)
+        tx.BeginEdit()
+        tx.SetCurrency(cad)
+        tx.SetDate(10, 5, 2024)
+        tx.SetDescription('Lunch')
+
+        s1 = Split(book)
+        s1.SetParent(tx)
+        s1.SetAccount(dining)
+        s1.SetValue(GncNumeric(2500, 100))
+
+        s2 = Split(book)
+        s2.SetParent(tx)
+        s2.SetAccount(checking)
+        s2.SetValue(GncNumeric(-2500, 100))
+
+        tx.CommitEdit()
+        guid = tx.GetGUID().to_string()
+        session.save()
+        session.end()
+
+        yield path, guid
+
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+        lock = path + '.LCK'
+        if os.path.exists(lock):
+            os.unlink(lock)
+
+
+def _write_plaintext_file(content: str) -> str:
+    """Write *content* to a temp file and return the path."""
+    fd, path = tempfile.mkstemp(suffix='.txt')
+    with os.fdopen(fd, 'w') as f:
+        f.write(content)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestImportUpdateByGuid:
+    def test_update_changes_description(self, gnucash_with_exportable_transaction):
+        """
+        Plaintext with GUID + changed description → description updated, GUID preserved.
+        """
+        from gnucash import Query, Transaction
+
+        from repositories.gnucash_repository import GnuCashRepository
+        from services.conflict_resolver import ResolutionStrategy
+        from use_cases.import_transactions import ImportTransactionsUseCase
+
+        path, guid = gnucash_with_exportable_transaction
+
+        plaintext = (
+            '2024-05-10 commodity CAD\n'
+            '\tmnemonic: "CAD"\n'
+            '\tfullname: "Canadian Dollar"\n'
+            '\tnamespace: "CURRENCY"\n'
+            '\tfraction: 100\n'
+            f'2024-05-10 * "Updated lunch description"\n'
+            f'\tguid: "{guid}"\n'
+            '\tExpenses:Dining 25.00 CAD\n'
+            '\tAssets:Bank:Checking -25.00 CAD\n'
+        )
+        pt_path = _write_plaintext_file(plaintext)
+        try:
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                uc = ImportTransactionsUseCase(repo)
+                result = uc.import_from_file(pt_path, ResolutionStrategy.UPDATE)
+                repo.save()
+            finally:
+                repo.close()
+        finally:
+            os.unlink(pt_path)
+
+        assert result.updated_count == 1
+        assert result.imported_count == 0
+        assert result.skipped_count == 0
+        assert result.error_count == 0
+
+        # Verify description changed and GUID still present
+        session = _open_session(path)
+        book = session.book
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        guids = [t.GetGUID().to_string() for t in txs]
+        assert guid in guids, "GUID must be preserved after update"
+        updated_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+        assert updated_tx.GetDescription() == 'Updated lunch description'
+        session.end()
+
+    def test_update_changes_amount(self, gnucash_with_exportable_transaction):
+        """
+        Plaintext with GUID + changed amount → split amounts updated, GUID preserved.
+        """
+        from gnucash import Query, Transaction
+
+        from repositories.gnucash_repository import GnuCashRepository
+        from services.conflict_resolver import ResolutionStrategy
+        from use_cases.import_transactions import ImportTransactionsUseCase
+
+        path, guid = gnucash_with_exportable_transaction
+
+        plaintext = (
+            '2024-05-10 commodity CAD\n'
+            '\tmnemonic: "CAD"\n'
+            '\tfullname: "Canadian Dollar"\n'
+            '\tnamespace: "CURRENCY"\n'
+            '\tfraction: 100\n'
+            f'2024-05-10 * "Lunch"\n'
+            f'\tguid: "{guid}"\n'
+            '\tExpenses:Dining 40.00 CAD\n'
+            '\tAssets:Bank:Checking -40.00 CAD\n'
+        )
+        pt_path = _write_plaintext_file(plaintext)
+        try:
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                uc = ImportTransactionsUseCase(repo)
+                result = uc.import_from_file(pt_path, ResolutionStrategy.UPDATE)
+                repo.save()
+            finally:
+                repo.close()
+        finally:
+            os.unlink(pt_path)
+
+        assert result.updated_count == 1
+
+        session = _open_session(path)
+        book = session.book
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        updated_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+        amounts = {s.GetAccount().GetName(): s.GetValue() for s in updated_tx.GetSplitList()}
+        assert amounts['Dining'].num() == 4000
+        assert amounts['Checking'].num() == -4000
+        session.end()
+
+    def test_skip_strategy_does_not_update(self, gnucash_with_exportable_transaction):
+        """
+        With SKIP strategy, a GUID-matched transaction is skipped, not updated.
+        """
+        from repositories.gnucash_repository import GnuCashRepository
+        from services.conflict_resolver import ResolutionStrategy
+        from use_cases.import_transactions import ImportTransactionsUseCase
+
+        path, guid = gnucash_with_exportable_transaction
+
+        plaintext = (
+            '2024-05-10 commodity CAD\n'
+            '\tmnemonic: "CAD"\n'
+            '\tfullname: "Canadian Dollar"\n'
+            '\tnamespace: "CURRENCY"\n'
+            '\tfraction: 100\n'
+            f'2024-05-10 * "Should not appear"\n'
+            f'\tguid: "{guid}"\n'
+            '\tExpenses:Dining 99.00 CAD\n'
+            '\tAssets:Bank:Checking -99.00 CAD\n'
+        )
+        pt_path = _write_plaintext_file(plaintext)
+        try:
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                uc = ImportTransactionsUseCase(repo)
+                result = uc.import_from_file(pt_path, ResolutionStrategy.SKIP)
+            finally:
+                repo.close()
+        finally:
+            os.unlink(pt_path)
+
+        assert result.updated_count == 0
+        assert result.skipped_count == 1
+        assert result.imported_count == 0
+
+    def test_unknown_guid_creates_new_transaction(self, gnucash_with_exportable_transaction):
+        """
+        A GUID in the plaintext that does not exist in the book creates a new transaction.
+        """
+        from gnucash import Query, Transaction
+
+        from repositories.gnucash_repository import GnuCashRepository
+        from services.conflict_resolver import ResolutionStrategy
+        from use_cases.import_transactions import ImportTransactionsUseCase
+
+        path, _existing_guid = gnucash_with_exportable_transaction
+
+        # Use a fabricated GUID that does not exist in the book
+        fake_guid = 'a' * 32
+
+        plaintext = (
+            '2024-06-01 commodity CAD\n'
+            '\tmnemonic: "CAD"\n'
+            '\tfullname: "Canadian Dollar"\n'
+            '\tnamespace: "CURRENCY"\n'
+            '\tfraction: 100\n'
+            f'2024-06-01 * "New transaction"\n'
+            f'\tguid: "{fake_guid}"\n'
+            '\tExpenses:Groceries 30.00 CAD\n'
+            '\tAssets:Bank:Checking -30.00 CAD\n'
+        )
+        pt_path = _write_plaintext_file(plaintext)
+        try:
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                uc = ImportTransactionsUseCase(repo)
+                result = uc.import_from_file(pt_path, ResolutionStrategy.UPDATE)
+                repo.save()
+            finally:
+                repo.close()
+        finally:
+            os.unlink(pt_path)
+
+        assert result.imported_count == 1
+        assert result.updated_count == 0
+
+        session = _open_session(path)
+        book = session.book
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        assert len(txs) == 2  # original + new
+        session.end()
+
+    def test_no_guid_in_plaintext_uses_signature_matching(self, gnucash_with_exportable_transaction):
+        """
+        Without a GUID in the plaintext, normal signature-based duplicate detection applies.
+        Same date+accounts+amounts → duplicate (skipped).
+        """
+        from repositories.gnucash_repository import GnuCashRepository
+        from services.conflict_resolver import ResolutionStrategy
+        from use_cases.import_transactions import ImportTransactionsUseCase
+
+        path, _guid = gnucash_with_exportable_transaction
+
+        # Plaintext with no guid: matches existing by date+accounts+amounts
+        plaintext = (
+            '2024-05-10 commodity CAD\n'
+            '\tmnemonic: "CAD"\n'
+            '\tfullname: "Canadian Dollar"\n'
+            '\tnamespace: "CURRENCY"\n'
+            '\tfraction: 100\n'
+            '2024-05-10 * "Lunch"\n'
+            '\tExpenses:Dining 25.00 CAD\n'
+            '\tAssets:Bank:Checking -25.00 CAD\n'
+        )
+        pt_path = _write_plaintext_file(plaintext)
+        try:
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                uc = ImportTransactionsUseCase(repo)
+                result = uc.import_from_file(pt_path, ResolutionStrategy.UPDATE)
+            finally:
+                repo.close()
+        finally:
+            os.unlink(pt_path)
+
+        # Signature match, no guid → goes through normal duplicate detection → skipped
+        assert result.imported_count == 0
+        assert result.updated_count == 0
+        assert result.skipped_count == 1
+
+
+class TestStableRoundtrip:
+    def test_import_update_import_no_duplicates(self, gnucash_with_exportable_transaction):
+        """
+        Stable roundtrip: update once, then re-import the same plaintext again.
+        The second import must not create new transactions (GUID still matches → skip or update).
+        """
+        from gnucash import Query, Transaction
+
+        from repositories.gnucash_repository import GnuCashRepository
+        from services.conflict_resolver import ResolutionStrategy
+        from use_cases.import_transactions import ImportTransactionsUseCase
+
+        path, guid = gnucash_with_exportable_transaction
+
+        plaintext = (
+            '2024-05-10 commodity CAD\n'
+            '\tmnemonic: "CAD"\n'
+            '\tfullname: "Canadian Dollar"\n'
+            '\tnamespace: "CURRENCY"\n'
+            '\tfraction: 100\n'
+            f'2024-05-10 * "Lunch v2"\n'
+            f'\tguid: "{guid}"\n'
+            '\tExpenses:Dining 25.00 CAD\n'
+            '\tAssets:Bank:Checking -25.00 CAD\n'
+        )
+        pt_path = _write_plaintext_file(plaintext)
+        try:
+            # First import (update)
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                uc = ImportTransactionsUseCase(repo)
+                r1 = uc.import_from_file(pt_path, ResolutionStrategy.UPDATE)
+                repo.save()
+            finally:
+                repo.close()
+
+            assert r1.updated_count == 1
+            assert r1.imported_count == 0
+
+            # Second import of the same file (GUID still matches → skip, not duplicate creation)
+            repo2 = GnuCashRepository(path)
+            repo2.open()
+            try:
+                uc2 = ImportTransactionsUseCase(repo2)
+                r2 = uc2.import_from_file(pt_path, ResolutionStrategy.UPDATE)
+            finally:
+                repo2.close()
+
+            assert r2.imported_count == 0
+            assert r2.updated_count == 1  # updates again (idempotent)
+            assert r2.error_count == 0
+
+        finally:
+            os.unlink(pt_path)
+
+        # Exactly one transaction must exist (no duplicates)
+        session = _open_session(path)
+        book = session.book
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        assert len(txs) == 1
+        assert txs[0].GetGUID().to_string() == guid
+        session.end()
+
+
+class TestImportResultSummary:
+    def test_summary_includes_updated_count(self, gnucash_with_exportable_transaction):
+        """get_summary() must include the Updated line."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from services.conflict_resolver import ResolutionStrategy
+        from use_cases.import_transactions import ImportTransactionsUseCase
+
+        path, guid = gnucash_with_exportable_transaction
+
+        plaintext = (
+            '2024-05-10 commodity CAD\n'
+            '\tmnemonic: "CAD"\n'
+            '\tfullname: "Canadian Dollar"\n'
+            '\tnamespace: "CURRENCY"\n'
+            '\tfraction: 100\n'
+            f'2024-05-10 * "Changed"\n'
+            f'\tguid: "{guid}"\n'
+            '\tExpenses:Dining 25.00 CAD\n'
+            '\tAssets:Bank:Checking -25.00 CAD\n'
+        )
+        pt_path = _write_plaintext_file(plaintext)
+        try:
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                uc = ImportTransactionsUseCase(repo)
+                result = uc.import_from_file(pt_path, ResolutionStrategy.UPDATE)
+            finally:
+                repo.close()
+        finally:
+            os.unlink(pt_path)
+
+        summary = result.get_summary()
+        assert 'Updated: 1' in summary

--- a/use_cases/import_transactions.py
+++ b/use_cases/import_transactions.py
@@ -25,6 +25,7 @@ class ImportResult:
 
     def __init__(self):
         self.imported_count = 0
+        self.updated_count = 0
         self.accounts_created = 0
         self.skipped_count = 0
         self.error_count = 0
@@ -36,6 +37,7 @@ class ImportResult:
         """Get summary string"""
         lines = []
         lines.append(f"Imported: {self.imported_count}")
+        lines.append(f"Updated: {self.updated_count}")
         lines.append(f"Accounts created: {self.accounts_created}")
         lines.append(f"Skipped: {self.skipped_count} (duplicates)")
         lines.append(f"Conflicts: {len(self.conflicts)}")
@@ -276,17 +278,21 @@ class ImportTransactionsUseCase:
         for child in parser.root_directive.children:
             if child.type == DirectiveType.TRANSACTION:
                 try:
-                    # Check for duplicate by GUID if present
+                    # Check for match by GUID if present
                     if 'guid' in child.metadata:
                         guid = child.metadata['guid']
-                        # Check if transaction with this GUID already exists
-                        is_duplicate = any(
-                            tx.GetGUID().to_string() == guid
-                            for tx in existing_transactions
+                        existing_tx = next(
+                            (tx for tx in existing_transactions
+                             if tx.GetGUID().to_string() == guid),
+                            None
                         )
-                        if is_duplicate:
-                            logging.info(f"Skipping duplicate transaction with GUID {guid}")
-                            result.skipped_count += 1
+                        if existing_tx is not None:
+                            if resolution_strategy == ResolutionStrategy.UPDATE:
+                                importer.update_transaction(existing_tx, child, book)
+                                result.updated_count += 1
+                            else:
+                                logging.info(f"Skipping duplicate transaction with GUID {guid}")
+                                result.skipped_count += 1
                             continue
 
                     # Check for duplicate by date/accounts signature


### PR DESCRIPTION
Previously, importing a plaintext file with a guid: metadata field that matched an existing transaction would always skip it.  This made the export→edit-plaintext→re-import workflow unusable: any attempt to correct a transaction required manual deletion inside GnuCash first.

This commit implements a stable, GUID-preserving update path:

Core changes
- services/conflict_resolver.py Add ResolutionStrategy.UPDATE enum value.  The new value signals that a GUID-matched transaction should be updated in-place rather than skipped or replaced.

- services/gnucash_importer.py Add GnuCashImporter.update_transaction(existing_tx, directive, book). Uses BeginEdit()/CommitEdit() to modify the transaction in-place:
  * Updates all scalar fields: date, description, num, doc_link, notes, currency.
  * Reconciles splits by account full-name: removes splits for accounts absent from the directive, updates amounts/value/memo/action for existing splits, creates Split objects for new accounts.
  * On any error, calls RollbackEdit() so the transaction is never left in a partially-modified state.
  * Imports get_account_full_name from infrastructure.gnucash.utils (was already used by other services; this avoids a local copy). The GUID is untouched because the Transaction object itself is never destroyed or recreated.

- use_cases/import_transactions.py In import_from_file(), the GUID-match block now distinguishes between UPDATE (calls update_transaction, increments updated_count) and all other strategies (original skip behaviour, unchanged). ImportResult gains an updated_count field and get_summary() includes an "Updated:" line.

- cli/import_cmd.py --strategy now accepts 'update' as a fourth choice.  The summary output includes the "Updated:" line.  has_changes includes updated_count so the file is saved when updates occur.

Tests (run in Docker with real GnuCash files, no mocks)
- tests/unit/services/test_update_transaction.py  (new) Direct unit tests for GnuCashImporter.update_transaction(): description change, GUID preserved after description update, amount change, GUID preserved after amount update, date change, add split (2→3), remove split (3→2), notes update, split memo update, invalid account raises ValueError without corrupting the transaction.

- tests/unit/use_cases/test_import_update.py  (new) End-to-end use-case tests via import_from_file(): update changes description, update changes amount, SKIP strategy does not update, unknown GUID creates new transaction, no-GUID plaintext uses signature-based duplicate detection, stable roundtrip (import→update→re-import produces exactly one transaction with the original GUID), get_summary() includes "Updated:" line.