### PR TITLE
Add export-transaction command for single-transaction export by GUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,22 @@ gnucash-plaintext export mybook.gnucash transactions.txt \
   --account "Assets:Bank"
 ```
 
+### Export a single transaction by GUID
+
+Export one specific transaction to plaintext (useful for AI-assisted editing or review):
+
+```bash
+gnucash-plaintext export-transaction mybook.gnucash --guid 317c8ae6e0084c33951d052b9f1b9f23
+```
+
+The output is self-contained — it includes the commodity and account declarations needed to re-import or process the transaction independently. Output goes to stdout by default; use `-o` to write to a file:
+
+```bash
+gnucash-plaintext export-transaction mybook.gnucash --guid 317c8ae6e0084c33951d052b9f1b9f23 -o tx.txt
+```
+
+`--guid` is required. Omitting it prints an error with usage guidance.
+
 ### Export GnuCash to GnuCash-Beancount format
 
 Export to [GnuCash-Beancount](docs/gnucash-beancount-format.md) format:

--- a/cli/export_transaction_cmd.py
+++ b/cli/export_transaction_cmd.py
@@ -1,0 +1,72 @@
+"""
+CLI command for exporting a single GnuCash transaction by GUID to plaintext.
+"""
+
+import os
+import sys
+
+import click
+
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from use_cases.export_transactions import ExportTransactionsUseCase
+
+
+@click.command()
+@click.argument('gnucash_file', required=False, type=click.Path())
+@click.option('-i', '--input', 'input_file', type=click.Path(), help='Input GnuCash XML file')
+@click.option('--guid', required=False, default=None, help='GUID of the transaction to export (32-character hex)')
+@click.option('-o', '--output', 'output_path', type=click.Path(), help='Output file (defaults to stdout)')
+def export_transaction(gnucash_file, input_file, guid, output_path):
+    """
+    Export a single transaction from a GnuCash file to plaintext format.
+
+    --guid is required. The output includes the commodity and account
+    declarations needed to make the block self-contained for import or
+    AI processing.
+
+    \b
+    Examples:
+
+        gnucash-plaintext export-transaction mybook.gnucash --guid 317c8ae6e0084c33951d052b9f1b9f23
+
+        gnucash-plaintext export-transaction -i mybook.gnucash --guid 317c8ae6e0084c33951d052b9f1b9f23 -o tx.txt
+    """
+    gnucash_file = input_file or gnucash_file
+
+    if not gnucash_file:
+        raise click.UsageError("Missing input file. Use positional argument or -i/--input flag.")
+
+    if not guid:
+        raise click.UsageError(
+            "Missing --guid. export-transaction requires a transaction GUID.\n"
+            "Example: gnucash-plaintext export-transaction mybook.gnucash --guid <32-char-hex>"
+        )
+
+    if not os.path.exists(gnucash_file):
+        raise click.UsageError(f"Input file does not exist: {gnucash_file}")
+
+    try:
+        repo = GnuCashRepository(gnucash_file)
+        repo.open(mode=SessionMode.READ_ONLY)
+
+        try:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute_by_guid(guid)
+            plaintext = use_case.format_as_plaintext(result)
+
+            if output_path:
+                with open(output_path, 'w') as f:
+                    f.write(plaintext)
+                click.echo(f"✓ Transaction {guid} exported to {output_path}")
+            else:
+                sys.stdout.write(plaintext)
+
+        finally:
+            repo.close()
+
+    except ValueError as e:
+        click.echo(f"✗ {str(e)}", err=True)
+        raise SystemExit(1) from e
+    except Exception as e:
+        click.echo(f"✗ Error: {str(e)}", err=True)
+        raise SystemExit(1) from e

--- a/cli/main.py
+++ b/cli/main.py
@@ -10,6 +10,7 @@ import click
 from cli.close_books_cmd import close_books
 from cli.export_beancount_cmd import export_beancount
 from cli.export_cmd import export_transactions
+from cli.export_transaction_cmd import export_transaction
 from cli.import_beancount_cmd import import_beancount
 from cli.import_cmd import import_transactions
 from cli.income_statement_cmd import income_statement
@@ -56,6 +57,7 @@ cli.add_command(validate_ledger, name='validate')
 cli.add_command(export_beancount, name='export-beancount')
 cli.add_command(import_beancount, name='import-beancount')
 cli.add_command(close_books, name='close-books')
+cli.add_command(export_transaction, name='export-transaction')
 cli.add_command(income_statement, name='income-statement')
 cli.add_command(print_invoice, name='print-invoice')
 

--- a/tests/integration/test_cli_export_transaction.py
+++ b/tests/integration/test_cli_export_transaction.py
@@ -1,0 +1,153 @@
+"""
+Integration tests for the export-transaction CLI command.
+"""
+
+import pytest
+from click.testing import CliRunner
+
+from cli.export_transaction_cmd import export_transaction
+
+
+class TestExportTransactionCLI:
+    """Test export-transaction CLI command"""
+
+    def test_missing_guid_prints_error(self, temp_gnucash_with_transactions):
+        """Invoking without --guid must exit non-zero with a helpful message"""
+        runner = CliRunner()
+        result = runner.invoke(export_transaction, [temp_gnucash_with_transactions])
+
+        assert result.exit_code != 0
+        assert "--guid" in result.output
+
+    def test_missing_gnucash_file_prints_error(self):
+        """Invoking without a GnuCash file must exit non-zero"""
+        runner = CliRunner()
+        result = runner.invoke(export_transaction, ['--guid', 'deadbeefdeadbeefdeadbeefdeadbeef'])
+
+        assert result.exit_code != 0
+        assert "Missing input file" in result.output
+
+    def test_nonexistent_gnucash_file_prints_error(self):
+        """Invoking with a non-existent GnuCash file must exit non-zero"""
+        runner = CliRunner()
+        result = runner.invoke(export_transaction, [
+            '/nonexistent/file.gnucash',
+            '--guid', 'deadbeefdeadbeefdeadbeefdeadbeef'
+        ])
+
+        assert result.exit_code != 0
+
+    def test_invalid_guid_format_prints_error(self, temp_gnucash_with_transactions):
+        """A malformed GUID string must exit non-zero with an error message"""
+        runner = CliRunner()
+        result = runner.invoke(export_transaction, [
+            temp_gnucash_with_transactions,
+            '--guid', 'not-a-guid'
+        ])
+
+        assert result.exit_code != 0
+        assert "Invalid GUID" in result.output
+
+    def test_nonexistent_guid_prints_error(self, temp_gnucash_with_transactions):
+        """A well-formed GUID that matches no transaction must exit non-zero"""
+        runner = CliRunner()
+        result = runner.invoke(export_transaction, [
+            temp_gnucash_with_transactions,
+            '--guid', 'deadbeefdeadbeefdeadbeefdeadbeef'
+        ])
+
+        assert result.exit_code != 0
+        assert "No transaction found" in result.output
+
+    def test_valid_guid_outputs_plaintext_to_stdout(self, temp_gnucash_with_transactions):
+        """A valid GUID prints self-contained plaintext to stdout"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            all_result = use_case.execute()
+            guid = all_result.transactions[0].GetGUID().to_string()
+
+        runner = CliRunner()
+        result = runner.invoke(export_transaction, [
+            temp_gnucash_with_transactions,
+            '--guid', guid
+        ])
+
+        assert result.exit_code == 0
+        assert f'guid: "{guid}"' in result.output
+        assert "commodity" in result.output
+        assert "open " in result.output
+
+    def test_valid_guid_with_flag_style_input(self, temp_gnucash_with_transactions):
+        """--input flag works the same as positional argument"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            all_result = use_case.execute()
+            guid = all_result.transactions[0].GetGUID().to_string()
+
+        runner = CliRunner()
+        result = runner.invoke(export_transaction, [
+            '-i', temp_gnucash_with_transactions,
+            '--guid', guid
+        ])
+
+        assert result.exit_code == 0
+        assert f'guid: "{guid}"' in result.output
+
+    def test_valid_guid_with_output_file(self, temp_gnucash_with_transactions, tmp_path):
+        """When -o is given, output is written to file and confirmation printed"""
+        import os
+
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            all_result = use_case.execute()
+            guid = all_result.transactions[0].GetGUID().to_string()
+
+        output_path = str(tmp_path / "tx.txt")
+
+        runner = CliRunner()
+        result = runner.invoke(export_transaction, [
+            temp_gnucash_with_transactions,
+            '--guid', guid,
+            '-o', output_path
+        ])
+
+        assert result.exit_code == 0
+        assert "exported to" in result.output
+        assert os.path.exists(output_path)
+
+        with open(output_path) as f:
+            content = f.read()
+        assert f'guid: "{guid}"' in content
+        assert "commodity" in content
+
+    def test_output_contains_only_one_transaction_block(self, temp_gnucash_with_transactions):
+        """Output contains exactly one transaction (not all 3 from the fixture)"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            all_result = use_case.execute()
+            guid = all_result.transactions[0].GetGUID().to_string()
+
+        runner = CliRunner()
+        result = runner.invoke(export_transaction, [
+            temp_gnucash_with_transactions,
+            '--guid', guid
+        ])
+
+        assert result.exit_code == 0
+        tx_headers = [
+            line for line in result.output.splitlines()
+            if line and not line.startswith('\t') and ' * ' in line
+        ]
+        assert len(tx_headers) == 1

--- a/tests/unit/use_cases/test_export_transactions.py
+++ b/tests/unit/use_cases/test_export_transactions.py
@@ -184,3 +184,79 @@ class TestExportTransactions:
 
             # Should be sorted
             assert dates == sorted(dates)
+
+
+class TestExportByGuid:
+    """Test execute_by_guid — single-transaction export"""
+
+    def test_export_known_guid_returns_one_transaction(self, temp_gnucash_with_transactions):
+        """execute_by_guid returns exactly one transaction matching the given GUID"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+
+            all_result = use_case.execute()
+            target_guid = all_result.transactions[0].GetGUID().to_string()
+
+            result = use_case.execute_by_guid(target_guid)
+
+            assert len(result.transactions) == 1
+            assert result.transactions[0].GetGUID().to_string() == target_guid
+
+    def test_export_by_guid_includes_commodities_and_accounts(self, temp_gnucash_with_transactions):
+        """execute_by_guid result includes commodity and account declarations"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+
+            all_result = use_case.execute()
+            guid = all_result.transactions[0].GetGUID().to_string()
+
+            result = use_case.execute_by_guid(guid)
+
+            assert len(result.commodities) > 0
+            assert len(result.accounts) > 0
+
+    def test_export_by_guid_plaintext_is_self_contained(self, temp_gnucash_with_transactions):
+        """format_as_plaintext on a single-transaction result is self-contained"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+
+            all_result = use_case.execute()
+            guid = all_result.transactions[0].GetGUID().to_string()
+
+            result = use_case.execute_by_guid(guid)
+            plaintext = use_case.format_as_plaintext(result)
+
+            assert "commodity" in plaintext
+            assert "open " in plaintext
+            assert f'guid: "{guid}"' in plaintext
+
+    def test_export_by_guid_invalid_guid_raises_value_error(self, temp_gnucash_with_transactions):
+        """execute_by_guid raises ValueError for a malformed GUID string"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+
+            with pytest.raises(ValueError, match="Invalid GUID format"):
+                use_case.execute_by_guid("not-a-valid-guid")
+
+    def test_export_by_guid_nonexistent_guid_raises_value_error(self, temp_gnucash_with_transactions):
+        """execute_by_guid raises ValueError when no transaction has the given GUID"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+
+            with pytest.raises(ValueError, match="No transaction found"):
+                use_case.execute_by_guid("deadbeefdeadbeefdeadbeefdeadbeef")

--- a/use_cases/export_transactions.py
+++ b/use_cases/export_transactions.py
@@ -9,7 +9,13 @@ import datetime
 import os
 from typing import Optional
 
-from gnucash.gnucash_core_c import xaccAccountGetTypeStr
+from gnucash import Transaction
+from gnucash.gnucash_core_c import (
+    GncGUID,
+    string_to_guid,
+    xaccAccountGetTypeStr,
+    xaccTransLookup,
+)
 
 from infrastructure.gnucash.utils import (
     encode_value_as_string,
@@ -366,6 +372,38 @@ class ExportTransactionsUseCase:
 
         if memo and memo != "":
             lines.append(f'\t\tmemo:{encode_value_as_string(memo)}')
+
+    def execute_by_guid(self, guid: str) -> ExportResult:
+        """
+        Export a single transaction identified by its GUID.
+
+        Uses xaccTransLookup for O(1) direct lookup — no scan of all
+        transactions. The result includes the commodity and account
+        declarations for that transaction so the output is self-contained.
+
+        Args:
+            guid: 32-character hex GUID string of the transaction to export
+
+        Returns:
+            ExportResult containing the single transaction plus its
+            commodities and accounts
+
+        Raises:
+            ValueError: if the GUID string is malformed or no transaction
+                        with that GUID exists
+        """
+        gnc_guid = GncGUID()
+        if not string_to_guid(guid, gnc_guid):
+            raise ValueError(f"Invalid GUID format: {guid}")
+
+        raw = xaccTransLookup(gnc_guid, self.repository.book.instance)
+        if raw is None:
+            raise ValueError(f"No transaction found with GUID: {guid}")
+
+        target = Transaction(instance=raw)
+        result = ExportResult()
+        self._collect_transaction_data(target, result)
+        return result
 
     def export_to_file(
         self,


### PR DESCRIPTION
Adds a new CLI command `export-transaction` that exports exactly one transaction from a GnuCash file to plaintext format, identified by its GUID. This is useful for AI-assisted workflows where a single transaction needs to be inspected or edited without loading the full ledger.

Changes:
- cli/export_transaction_cmd.py: new Click command; --guid is required, omitting it exits with a usage error. Output goes to stdout by default; -o writes to a file. Positional and -i flag-style input both supported.
- use_cases/export_transactions.py: new execute_by_guid() method using xaccTransLookup(GncGUID, book.instance) for O(1) direct lookup — no for-loop over all transactions. string_to_guid() validates the format upfront. The result includes the commodity and account declarations for that transaction so the output is self-contained.
- cli/main.py: registers the new command as 'export-transaction'.
- README.md: documents the new command with examples.

Implementation note: xaccTransLookup from gnucash_core_c requires book.instance (the raw SwigPyObject) rather than the gnucash.Book SWIG wrapper. Passing the wrapper directly raises a TypeError due to a type mismatch across SWIG module boundaries.

Tests (328 passing, +14 new):
- TestExportByGuid (5 unit tests): valid GUID lookup, commodities/accounts included, plaintext is self-contained, invalid format raises ValueError, non-existent GUID raises ValueError.
- TestExportTransactionCLI (9 integration tests): missing --guid error, missing/nonexistent file errors, invalid GUID format, nonexistent GUID, stdout output, -i flag, -o file output, single transaction block in output.