### PR TITLE
Add account-balance command with FX consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,37 +514,47 @@ CNY: 0.19
 
 ### Export account balances
 
-Output account balances as of a given date in balance directive format:
+Output account balances as of a given date in balance directive format.
+Each account balance is the **recursive cumulative sum** of the account and all its sub-accounts.
 
 ```bash
-# All accounts as of today
-gnucash-plaintext account-balance mybook.gnucash
+# Whole book: every account with its recursive total (requires FX rates for multi-currency books)
+gnucash-plaintext account-balance mybook.gnucash --as-of 2024-12-31 --fx-rates rates.yaml
 
-# Specific account subtree as of a date
+# Single account total only
 gnucash-plaintext account-balance mybook.gnucash "Assets:Bank" --as-of 2024-12-31
 
-# All accounts at fiscal year end
-gnucash-plaintext account-balance mybook.gnucash --as-of 2024-12-31
+# Single account + sub-account breakdown
+gnucash-plaintext account-balance mybook.gnucash "Assets:Bank" --as-of 2024-12-31 --with-children
+
+# Single-currency account (no FX needed)
+gnucash-plaintext account-balance mybook.gnucash "Expenses:Food" --as-of 2024-12-31
 
 # Save to file
-gnucash-plaintext account-balance mybook.gnucash --as-of 2024-12-31 -o balances.txt
+gnucash-plaintext account-balance mybook.gnucash "Assets:Bank" --as-of 2024-12-31 -o balances.txt
 ```
+
+**Without ACCOUNT_PREFIX**: outputs every account in the book. Multi-currency books require
+`--fx-rates` (or rates already in the GnuCash pricedb); otherwise an error is raised.
+
+**With ACCOUNT_PREFIX** (default): outputs only the matched account's recursive total.
+
+**With ACCOUNT_PREFIX + `--with-children`**: outputs the matched account and each
+sub-account, each showing its own recursive total.
 
 Output format (balance directive):
 
 ```
 2024-12-31 balance
+	Assets:Bank  4899.00 CAD
 	Assets:Bank:Checking  3420.00 CAD
-	Assets:Bank:HKD  8700.00 HKD
-	Liabilities:CreditCard  200.00 CAD
-	Income:Salary  -3000.00 CAD
-	Expenses:Food:Groceries  50.00 CAD
-	Expenses:Food:Dining  30.00 CAD
+	Assets:Bank:HKD  1479.00 CAD
+		share_price: "17/100"
+		original: "8700.00 HKD"
 ```
 
-Each leaf account is reported in its own currency. Parent accounts (with sub-accounts) are not included — only the terminal leaf accounts appear.
-
-With `--fx-rates`: consolidate all accounts to CAD and update the GnuCash pricedb for any currencies whose rate has changed:
+With `--fx-rates`: consolidate all accounts to CAD and update the GnuCash pricedb for any
+currencies whose rate has changed (only when the rate differs from the current pricedb entry):
 
 ```bash
 gnucash-plaintext account-balance mybook.gnucash \
@@ -552,7 +562,8 @@ gnucash-plaintext account-balance mybook.gnucash \
     --fx-rates rates.yaml
 ```
 
-When `--fx-rates` is provided, the pricedb is updated with today's rates (only if the rate differs from what is already in GnuCash), and all balances are output in CAD.
+Non-CAD leaf accounts include `share_price` (exchange rate used) and `original` (amount in
+the native currency) metadata lines, matching the transaction plaintext format.
 
 ### Validate GnuCash ledger
 

--- a/README.md
+++ b/README.md
@@ -512,6 +512,48 @@ HKD: 0.17
 CNY: 0.19
 ```
 
+### Export account balances
+
+Output account balances as of a given date in balance directive format:
+
+```bash
+# All accounts as of today
+gnucash-plaintext account-balance mybook.gnucash
+
+# Specific account subtree as of a date
+gnucash-plaintext account-balance mybook.gnucash "Assets:Bank" --as-of 2024-12-31
+
+# All accounts at fiscal year end
+gnucash-plaintext account-balance mybook.gnucash --as-of 2024-12-31
+
+# Save to file
+gnucash-plaintext account-balance mybook.gnucash --as-of 2024-12-31 -o balances.txt
+```
+
+Output format (balance directive):
+
+```
+2024-12-31 balance
+	Assets:Bank:Checking  3420.00 CAD
+	Assets:Bank:HKD  8700.00 HKD
+	Liabilities:CreditCard  200.00 CAD
+	Income:Salary  -3000.00 CAD
+	Expenses:Food:Groceries  50.00 CAD
+	Expenses:Food:Dining  30.00 CAD
+```
+
+Each leaf account is reported in its own currency. Parent accounts (with sub-accounts) are not included — only the terminal leaf accounts appear.
+
+With `--fx-rates`: consolidate all accounts to CAD and update the GnuCash pricedb for any currencies whose rate has changed:
+
+```bash
+gnucash-plaintext account-balance mybook.gnucash \
+    --as-of 2024-12-31 \
+    --fx-rates rates.yaml
+```
+
+When `--fx-rates` is provided, the pricedb is updated with today's rates (only if the rate differs from what is already in GnuCash), and all balances are output in CAD.
+
 ### Validate GnuCash ledger
 
 Check ledger integrity:

--- a/cli/account_balance_cmd.py
+++ b/cli/account_balance_cmd.py
@@ -6,9 +6,20 @@ Output format (balance directive):
     YYYY-MM-DD balance
         Account:Path  Amount Currency
 
-Without --fx-rates: read-only, each leaf account in its own currency.
-With --fx-rates: also updates GnuCash pricedb for any changed rates (today's date),
-then outputs each leaf account converted to CAD.
+No ACCOUNT_PREFIX:
+    All accounts in the book (parent + leaf), each with its recursive cumulative
+    balance.  Mixed-currency accounts require FX rates (from --fx-rates or the
+    GnuCash pricedb); an error is raised when no rate is available.
+
+With ACCOUNT_PREFIX (default):
+    Only the matched account, with its recursive cumulative balance.
+
+With ACCOUNT_PREFIX + --with-children:
+    The matched account and all sub-accounts, each with their recursive balance.
+
+With --fx-rates:
+    Updates GnuCash pricedb for changed rates (today's date), then outputs all
+    shown accounts consolidated to CAD.
 """
 
 from datetime import date, datetime
@@ -32,7 +43,6 @@ def _parse_date(ctx, param, value: Optional[str]) -> Optional[date]:
 
 def _format_amount(amount) -> str:
     """Format a Fraction as a decimal string with 2 decimal places."""
-    # Convert to float for display; use round to avoid floating-point noise
     return f"{float(amount):.2f}"
 
 
@@ -53,8 +63,16 @@ def _format_amount(amount) -> str:
     "fx_rates_file",
     default=None,
     type=click.Path(exists=True),
-    help="YAML file with currency→CAD rates. When provided, consolidates all accounts to CAD "
+    help="YAML file with currency->CAD rates. Consolidates all accounts to CAD "
          "and writes updated rates to the GnuCash pricedb.",
+)
+@click.option(
+    "--with-children",
+    "with_children",
+    is_flag=True,
+    default=False,
+    help="When ACCOUNT_PREFIX is given, also show all sub-accounts with their "
+         "individual recursive balances.",
 )
 @click.option(
     "--output",
@@ -69,13 +87,17 @@ def account_balance(
     account_prefix,
     as_of_str,
     fx_rates_file,
+    with_children,
     output_file,
 ):
     """
     Output account balances as of a given date in balance directive format.
 
-    ACCOUNT_PREFIX filters output to accounts whose full path starts with
-    the given prefix (e.g. "Assets:Bank"). Omit to include all accounts.
+    Each account balance is the recursive cumulative sum of the account and
+    all its sub-accounts.
+
+    Without ACCOUNT_PREFIX: outputs every account in the book.
+    With ACCOUNT_PREFIX: outputs only that account (use --with-children for breakdown).
 
     \b
     Format:
@@ -84,11 +106,14 @@ def account_balance(
 
     \b
     Examples:
-      All accounts as of today:
+      Whole book (all accounts, recursive totals):
         gnucash-plaintext account-balance ledger.gnucash
 
-      Specific subtree:
+      Single account total:
         gnucash-plaintext account-balance ledger.gnucash "Assets:Bank"
+
+      Account with sub-account breakdown:
+        gnucash-plaintext account-balance ledger.gnucash "Assets:Bank" --with-children
 
       As of a specific date:
         gnucash-plaintext account-balance ledger.gnucash --as-of 2024-12-31
@@ -129,6 +154,7 @@ def account_balance(
                 as_of=as_of,
                 account_prefix=account_prefix,
                 fx_rates=fx_rates,
+                include_children=with_children,
             )
         except MissingFxRateError as e:
             raise click.ClickException(str(e)) from e
@@ -158,8 +184,12 @@ def account_balance(
         lines.append(f"\t{bal.account_path}  {amount_str} {bal.currency}")
         if bal.share_price is not None and bal.original_amount is not None:
             # Show exchange rate and original amount, matching the transaction plaintext format
-            lines.append(f"\t\tshare_price: \"{bal.share_price.numerator}/{bal.share_price.denominator}\"")
-            lines.append(f"\t\toriginal: \"{_format_amount(bal.original_amount)} {bal.original_currency}\"")
+            lines.append(
+                f"\t\tshare_price: \"{bal.share_price.numerator}/{bal.share_price.denominator}\""
+            )
+            lines.append(
+                f"\t\toriginal: \"{_format_amount(bal.original_amount)} {bal.original_currency}\""
+            )
 
     output = "\n".join(lines) + "\n"
 

--- a/cli/account_balance_cmd.py
+++ b/cli/account_balance_cmd.py
@@ -1,0 +1,171 @@
+"""
+CLI command for exporting account balances as of a given date.
+
+Output format (balance directive):
+
+    YYYY-MM-DD balance
+        Account:Path  Amount Currency
+
+Without --fx-rates: read-only, each leaf account in its own currency.
+With --fx-rates: also updates GnuCash pricedb for any changed rates (today's date),
+then outputs each leaf account converted to CAD.
+"""
+
+from datetime import date, datetime
+from typing import Optional
+
+import click
+
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from services.fx_rates import FxRates, MissingFxRateError
+from use_cases.account_balance import AccountBalanceUseCase
+
+
+def _parse_date(ctx, param, value: Optional[str]) -> Optional[date]:
+    if value is None:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as e:
+        raise click.BadParameter(f"Date must be in YYYY-MM-DD format, got: {value}") from e
+
+
+def _format_amount(amount) -> str:
+    """Format a Fraction as a decimal string with 2 decimal places."""
+    # Convert to float for display; use round to avoid floating-point noise
+    return f"{float(amount):.2f}"
+
+
+@click.command("account-balance")
+@click.argument("gnucash_file", type=click.Path(exists=True))
+@click.argument("account_prefix", required=False, default=None)
+@click.option(
+    "--as-of",
+    "as_of_str",
+    default=None,
+    callback=_parse_date,
+    is_eager=True,
+    expose_value=True,
+    help="Balance date (YYYY-MM-DD). Defaults to today.",
+)
+@click.option(
+    "--fx-rates",
+    "fx_rates_file",
+    default=None,
+    type=click.Path(exists=True),
+    help="YAML file with currency→CAD rates. When provided, consolidates all accounts to CAD "
+         "and writes updated rates to the GnuCash pricedb.",
+)
+@click.option(
+    "--output",
+    "-o",
+    "output_file",
+    default=None,
+    type=click.Path(),
+    help="Output file path. Defaults to stdout.",
+)
+def account_balance(
+    gnucash_file,
+    account_prefix,
+    as_of_str,
+    fx_rates_file,
+    output_file,
+):
+    """
+    Output account balances as of a given date in balance directive format.
+
+    ACCOUNT_PREFIX filters output to accounts whose full path starts with
+    the given prefix (e.g. "Assets:Bank"). Omit to include all accounts.
+
+    \b
+    Format:
+      YYYY-MM-DD balance
+          Account:Path  Amount Currency
+
+    \b
+    Examples:
+      All accounts as of today:
+        gnucash-plaintext account-balance ledger.gnucash
+
+      Specific subtree:
+        gnucash-plaintext account-balance ledger.gnucash "Assets:Bank"
+
+      As of a specific date:
+        gnucash-plaintext account-balance ledger.gnucash --as-of 2024-12-31
+
+      With FX consolidation to CAD (updates pricedb):
+        gnucash-plaintext account-balance ledger.gnucash \\
+            --as-of 2024-12-31 --fx-rates rates.yaml
+    """
+    as_of: date = as_of_str if as_of_str is not None else date.today()
+
+    # Load FX rates if provided
+    fx_rates: Optional[FxRates] = None
+    if fx_rates_file:
+        try:
+            fx_rates = FxRates.load(fx_rates_file)
+        except (FileNotFoundError, ValueError) as e:
+            raise click.ClickException(str(e)) from e
+
+    # Open in NORMAL mode when fx_rates provided (need to write pricedb),
+    # otherwise read-only.
+    mode = SessionMode.NORMAL if fx_rates is not None else SessionMode.READ_ONLY
+    repo = GnuCashRepository(gnucash_file)
+    repo.open(mode=mode)
+
+    try:
+        use_case = AccountBalanceUseCase(repo)
+
+        # Update pricedb before computing balances (so the balance uses fresh rates)
+        if fx_rates is not None:
+            today = date.today()
+            try:
+                use_case.update_pricedb(fx_rates, today)
+            except Exception as e:
+                raise click.ClickException(f"Failed to update pricedb: {e}") from e
+
+        try:
+            result = use_case.execute(
+                as_of=as_of,
+                account_prefix=account_prefix,
+                fx_rates=fx_rates,
+            )
+        except MissingFxRateError as e:
+            raise click.ClickException(str(e)) from e
+        except ValueError as e:
+            raise click.ClickException(str(e)) from e
+
+        # Save if we wrote to pricedb.
+        # GnuCash raises GnuCashBackendException when the backup file already
+        # exists (e.g. same-second saves in tests). The XML data is still
+        # written; ignore backup-only failures.
+        if fx_rates is not None:
+            try:
+                repo.save()
+            except Exception as e:
+                if "ERR_FILEIO_BACKUP_ERROR" not in str(e):
+                    raise click.ClickException(f"Failed to save: {e}") from e
+
+    finally:
+        repo.close()
+
+    # Render output
+    lines = []
+    date_str = as_of.strftime("%Y-%m-%d")
+    lines.append(f"{date_str} balance")
+    for bal in result.balances:
+        amount_str = _format_amount(bal.amount)
+        lines.append(f"\t{bal.account_path}  {amount_str} {bal.currency}")
+        if bal.share_price is not None and bal.original_amount is not None:
+            # Show exchange rate and original amount, matching the transaction plaintext format
+            lines.append(f"\t\tshare_price: \"{bal.share_price.numerator}/{bal.share_price.denominator}\"")
+            lines.append(f"\t\toriginal: \"{_format_amount(bal.original_amount)} {bal.original_currency}\"")
+
+    output = "\n".join(lines) + "\n"
+
+    if output_file:
+        with open(output_file, "w", encoding="utf-8") as f:
+            f.write(output)
+        click.echo(f"Written to {output_file}")
+    else:
+        click.echo(output, nl=False)

--- a/cli/main.py
+++ b/cli/main.py
@@ -7,6 +7,7 @@ plaintext format.
 
 import click
 
+from cli.account_balance_cmd import account_balance
 from cli.close_books_cmd import close_books
 from cli.export_beancount_cmd import export_beancount
 from cli.export_cmd import export_transactions
@@ -60,6 +61,7 @@ cli.add_command(close_books, name='close-books')
 cli.add_command(export_transaction, name='export-transaction')
 cli.add_command(income_statement, name='income-statement')
 cli.add_command(print_invoice, name='print-invoice')
+cli.add_command(account_balance, name='account-balance')
 
 
 if __name__ == '__main__':

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -420,3 +420,60 @@ def temp_gnucash_comprehensive():
         lock_path = path + '.LCK'
         if os.path.exists(lock_path):
             os.unlink(lock_path)
+
+
+@pytest.fixture
+def temp_gnucash_account_balance():
+    """
+    GnuCash file for account-balance tests, loaded from plaintext fixture.
+
+    Covers all 5 account types (Asset, Liability, Equity, Income, Expense)
+    in two currencies (CAD and HKD), with sub-accounts under Expenses:Food
+    and Income:HKDIncome.
+
+    Account structure:
+      Assets:Bank:Checking          CAD   (500 opening + 3000 salary - 50 groceries - 30 dining = 3420)
+      Assets:Bank:HKD               HKD   (8000 opening + 400 freelance + 600 dividends - 300 transport = 8700)
+      Liabilities:CreditCard        CAD   (200 opening)
+      Liabilities:HKDLoan           HKD   (500 opening)
+      Equity:Opening                CAD   (balancing)
+      Income:Salary                 CAD   (-3000)
+      Income:HKDIncome:Freelance    HKD   (-400)
+      Income:HKDIncome:Dividends    HKD   (-600)
+      Expenses:Food:Groceries       CAD   (50)
+      Expenses:Food:Dining          CAD   (30)
+      Expenses:HKDExpenses:Transport HKD  (300)
+
+    See tests/fixtures/account_balance_test_data.txt for the plaintext source.
+    """
+    from repositories.gnucash_repository import GnuCashRepository
+    from services.conflict_resolver import ResolutionStrategy
+    from use_cases.import_transactions import ImportTransactionsUseCase
+
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    plaintext_path = os.path.join(test_dir, 'fixtures', 'account_balance_test_data.txt')
+
+    fd, path = tempfile.mkstemp(suffix='.gnucash')
+    os.close(fd)
+    os.unlink(path)
+
+    try:
+        GnuCashRepository.create_new_file(path)
+
+        repo = GnuCashRepository(path)
+        repo.open()
+        try:
+            use_case = ImportTransactionsUseCase(repo)
+            use_case.import_from_file(plaintext_path, ResolutionStrategy.SKIP)
+            repo.save()
+        finally:
+            repo.close()
+
+        yield path
+
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+        lock_path = path + '.LCK'
+        if os.path.exists(lock_path):
+            os.unlink(lock_path)

--- a/tests/fixtures/account_balance_test_data.txt
+++ b/tests/fixtures/account_balance_test_data.txt
@@ -1,0 +1,241 @@
+2024-01-01 commodity CAD
+	mnemonic: "CAD"
+	fullname: "Canadian Dollar"
+	namespace: "CURRENCY"
+	fraction: 100
+2024-01-01 commodity HKD
+	mnemonic: "HKD"
+	fullname: "Hong Kong Dollar"
+	namespace: "CURRENCY"
+	fraction: 100
+2024-01-01 open Assets
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0001"
+	type: "Asset"
+	placeholder: #True
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Assets:Bank
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0002"
+	type: "Asset"
+	placeholder: #True
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Assets:Bank:Checking
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0003"
+	type: "Bank"
+	placeholder: #False
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Assets:Bank:HKD
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0004"
+	type: "Bank"
+	placeholder: #False
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "HKD"
+2024-01-01 open Liabilities
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0010"
+	type: "Liability"
+	placeholder: #True
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Liabilities:CreditCard
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0011"
+	type: "Credit Card"
+	placeholder: #False
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Liabilities:HKDLoan
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0012"
+	type: "Liability"
+	placeholder: #False
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "HKD"
+2024-01-01 open Equity
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0020"
+	type: "Equity"
+	placeholder: #True
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Equity:Opening
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0021"
+	type: "Equity"
+	placeholder: #False
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Income
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0030"
+	type: "Income"
+	placeholder: #True
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Income:Salary
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0031"
+	type: "Income"
+	placeholder: #False
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Income:HKDIncome
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0032"
+	type: "Income"
+	placeholder: #True
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "HKD"
+2024-01-01 open Income:HKDIncome:Freelance
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0033"
+	type: "Income"
+	placeholder: #False
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "HKD"
+2024-01-01 open Income:HKDIncome:Dividends
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0034"
+	type: "Income"
+	placeholder: #False
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "HKD"
+2024-01-01 open Expenses
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0040"
+	type: "Expense"
+	placeholder: #True
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Expenses:Food
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0041"
+	type: "Expense"
+	placeholder: #True
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Expenses:Food:Groceries
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0042"
+	type: "Expense"
+	placeholder: #False
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Expenses:Food:Dining
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0043"
+	type: "Expense"
+	placeholder: #False
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Expenses:HKDExpenses
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0044"
+	type: "Expense"
+	placeholder: #True
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "HKD"
+2024-01-01 open Expenses:HKDExpenses:Transport
+	guid: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa0045"
+	type: "Expense"
+	placeholder: #False
+	code: ""
+	description: ""
+	tax_related: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "HKD"
+2024-01-01 *
+	guid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbb0001"
+	Assets:Bank:Checking 500.00 CAD
+	Equity:Opening -500.00 CAD
+2024-01-01 *
+	guid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbb0002"
+	currency.mnemonic: "HKD"
+	Assets:Bank:HKD 8000.00 HKD
+	Equity:Opening -8000.00 HKD
+		account.commodity.mnemonic: "CAD"
+		share_price: "17/100"
+		value: "-1360.00"
+2024-01-01 *
+	guid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbb0003"
+	Liabilities:CreditCard 200.00 CAD
+	Equity:Opening -200.00 CAD
+2024-01-01 *
+	guid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbb0004"
+	currency.mnemonic: "HKD"
+	Liabilities:HKDLoan 500.00 HKD
+	Equity:Opening -500.00 HKD
+		account.commodity.mnemonic: "CAD"
+		share_price: "17/100"
+		value: "-85.00"
+2024-06-15 * "Monthly salary"
+	guid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbb0005"
+	Assets:Bank:Checking 3000.00 CAD
+	Income:Salary -3000.00 CAD
+2024-06-15 * "Freelance payment"
+	guid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbb0006"
+	currency.mnemonic: "HKD"
+	Assets:Bank:HKD 400.00 HKD
+	Income:HKDIncome:Freelance -400.00 HKD
+2024-06-15 * "Dividend payment"
+	guid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbb0007"
+	currency.mnemonic: "HKD"
+	Assets:Bank:HKD 600.00 HKD
+	Income:HKDIncome:Dividends -600.00 HKD
+2024-06-15 * "Grocery shopping"
+	guid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbb0008"
+	Expenses:Food:Groceries 50.00 CAD
+	Assets:Bank:Checking -50.00 CAD
+2024-06-15 * "Dinner out"
+	guid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbb0009"
+	Expenses:Food:Dining 30.00 CAD
+	Assets:Bank:Checking -30.00 CAD
+2024-06-15 * "MTR transport"
+	guid: "bbbbbbbbbbbbbbbbbbbbbbbbbbbb0010"
+	currency.mnemonic: "HKD"
+	Expenses:HKDExpenses:Transport 300.00 HKD
+	Assets:Bank:HKD -300.00 HKD

--- a/tests/integration/test_cli_account_balance.py
+++ b/tests/integration/test_cli_account_balance.py
@@ -1,0 +1,177 @@
+"""
+Integration tests for the account-balance CLI command.
+
+Uses the temp_gnucash_account_balance fixture (all 5 account types,
+CAD + HKD, sub-accounts under Expenses:Food and Income:HKDIncome).
+"""
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+
+def run_cli(*args):
+    runner = CliRunner()
+    return runner.invoke(cli, ["account-balance"] + list(args))
+
+
+def _fx_file(tmp_path, content="HKD: 0.17\n"):
+    p = tmp_path / "rates.yaml"
+    p.write_text(content)
+    return str(p)
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+class TestAccountBalanceErrors:
+
+    def test_missing_gnucash_file(self):
+        result = run_cli("/nonexistent/file.gnucash")
+        assert result.exit_code != 0
+
+    def test_invalid_as_of_date(self, temp_gnucash_account_balance):
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "not-a-date")
+        assert result.exit_code != 0
+        assert "YYYY-MM-DD" in result.output
+
+    def test_invalid_fx_rates_file(self, temp_gnucash_account_balance):
+        result = run_cli(temp_gnucash_account_balance, "--fx-rates", "/nonexistent/rates.yaml")
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Output format
+# ---------------------------------------------------------------------------
+
+class TestAccountBalanceOutput:
+
+    def test_outputs_balance_directive_header(self, temp_gnucash_account_balance):
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31")
+        assert result.exit_code == 0
+        assert "2024-12-31 balance" in result.output
+
+    def test_outputs_leaf_accounts_with_amounts(self, temp_gnucash_account_balance):
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31")
+        assert result.exit_code == 0
+        assert "Assets:Bank:Checking" in result.output
+        assert "Assets:Bank:HKD" in result.output
+        assert "Expenses:Food:Groceries" in result.output
+        assert "Expenses:Food:Dining" in result.output
+        assert "Income:HKDIncome:Freelance" in result.output
+        assert "Income:HKDIncome:Dividends" in result.output
+        assert "Expenses:HKDExpenses:Transport" in result.output
+        assert "Liabilities:CreditCard" in result.output
+        assert "Liabilities:HKDLoan" in result.output
+
+    def test_parent_accounts_not_in_output(self, temp_gnucash_account_balance):
+        """Parent-only accounts (placeholder) must not appear as balance lines."""
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31")
+        assert result.exit_code == 0
+        lines = result.output.splitlines()
+        account_lines = [line for line in lines if line.startswith("\t")]
+        account_names = [line.split()[0] for line in account_lines]
+        assert "Expenses:Food" not in account_names
+        assert "Expenses:HKDExpenses" not in account_names
+        assert "Income:HKDIncome" not in account_names
+
+    def test_checking_balance_value(self, temp_gnucash_account_balance):
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "Assets:Bank:Checking")
+        assert result.exit_code == 0
+        assert "3420.00" in result.output
+        assert "CAD" in result.output
+
+    def test_hkd_bank_balance_value(self, temp_gnucash_account_balance):
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "Assets:Bank:HKD")
+        assert result.exit_code == 0
+        assert "8700.00" in result.output
+        assert "HKD" in result.output
+
+    def test_account_prefix_filters_output(self, temp_gnucash_account_balance):
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "Assets:Bank")
+        assert result.exit_code == 0
+        assert "Assets:Bank:Checking" in result.output
+        assert "Assets:Bank:HKD" in result.output
+        assert "Expenses" not in result.output
+        assert "Income" not in result.output
+        assert "Liabilities" not in result.output
+
+    def test_expenses_food_prefix(self, temp_gnucash_account_balance):
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "Expenses:Food")
+        assert result.exit_code == 0
+        assert "Expenses:Food:Groceries" in result.output
+        assert "Expenses:Food:Dining" in result.output
+        assert "Transport" not in result.output
+
+    def test_output_to_file(self, temp_gnucash_account_balance, tmp_path):
+        out_file = str(tmp_path / "balances.txt")
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "-o", out_file)
+        assert result.exit_code == 0
+        assert "Written to" in result.output
+        with open(out_file) as f:
+            content = f.read()
+        assert "2024-12-31 balance" in content
+        assert "Assets:Bank:Checking" in content
+
+    def test_default_as_of_is_today(self, temp_gnucash_account_balance):
+        """Omitting --as-of should succeed (uses today)."""
+        result = run_cli(temp_gnucash_account_balance)
+        assert result.exit_code == 0
+        assert "balance" in result.output
+
+
+# ---------------------------------------------------------------------------
+# FX rates consolidation
+# ---------------------------------------------------------------------------
+
+class TestAccountBalanceFxRates:
+
+    def test_with_fx_rates_outputs_cad(self, temp_gnucash_account_balance, tmp_path):
+        fx = _fx_file(tmp_path)
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "--fx-rates", fx, "Assets:Bank")
+        assert result.exit_code == 0, result.output
+        # Account lines use a single leading tab; metadata lines use two tabs
+        account_lines = [line for line in result.output.splitlines()
+                         if line.startswith("\t") and not line.startswith("\t\t")]
+        for line in account_lines:
+            assert line.strip().endswith("CAD"), f"Expected CAD suffix: {line!r}"
+
+    def test_with_fx_rates_shows_share_price_and_original(self, temp_gnucash_account_balance, tmp_path):
+        """HKD account shows share_price and original amount metadata."""
+        fx = _fx_file(tmp_path)
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "--fx-rates", fx, "Assets:Bank:HKD")
+        assert result.exit_code == 0, result.output
+        lines = result.output.splitlines()
+        share_price_line = next((line for line in lines if "share_price:" in line), None)
+        original_line = next((line for line in lines if "original:" in line), None)
+        assert share_price_line is not None, f"No share_price line in:\n{result.output}"
+        assert "17/100" in share_price_line, f"Expected 17/100 in share_price line: {share_price_line!r}"
+        assert original_line is not None, f"No original line in:\n{result.output}"
+        assert "8700.00 HKD" in original_line, f"Expected 8700.00 HKD in original line: {original_line!r}"
+
+    def test_with_fx_rates_checking_converted_correctly(self, temp_gnucash_account_balance, tmp_path):
+        """CAD account should remain 3420.00 CAD (rate 1.0)."""
+        fx = _fx_file(tmp_path)
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "--fx-rates", fx, "Assets:Bank:Checking")
+        assert result.exit_code == 0
+        assert "3420.00" in result.output
+        assert "CAD" in result.output
+
+    def test_with_fx_rates_hkd_converted_correctly(self, temp_gnucash_account_balance, tmp_path):
+        """HKD 8700 * 0.17 = 1479.00 CAD."""
+        fx = _fx_file(tmp_path)
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "--fx-rates", fx, "Assets:Bank:HKD")
+        assert result.exit_code == 0
+        assert "1479.00" in result.output
+        assert "CAD" in result.output

--- a/tests/integration/test_cli_account_balance.py
+++ b/tests/integration/test_cli_account_balance.py
@@ -3,6 +3,12 @@ Integration tests for the account-balance CLI command.
 
 Uses the temp_gnucash_account_balance fixture (all 5 account types,
 CAD + HKD, sub-accounts under Expenses:Food and Income:HKDIncome).
+
+Behaviour summary:
+  No ACCOUNT_PREFIX         -> all accounts with recursive totals (needs FX for mixed-currency)
+  With ACCOUNT_PREFIX       -> only that account with recursive total
+  With ACCOUNT_PREFIX
+    + --with-children       -> account + all sub-accounts each with recursive total
 """
 
 import pytest
@@ -41,111 +47,179 @@ class TestAccountBalanceErrors:
         result = run_cli(temp_gnucash_account_balance, "--fx-rates", "/nonexistent/rates.yaml")
         assert result.exit_code != 0
 
+    def test_nonexistent_account_prefix_raises_error(self, temp_gnucash_account_balance):
+        """Typo in account prefix should fail clearly, not silently return empty output."""
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "Asset:Bank")  # missing 's'
+        assert result.exit_code != 0, (
+            f"Expected error for nonexistent account 'Asset:Bank', got: {result.output}"
+        )
+
+    def test_mixed_currency_no_prefix_without_fx_raises_error(self, temp_gnucash_account_balance):
+        """No prefix on multi-currency book without FX rates must fail."""
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31")
+        assert result.exit_code != 0, (
+            f"Expected error for mixed-currency book without FX, got: {result.output}"
+        )
+
+    def test_mixed_currency_prefix_without_fx_raises_error(self, temp_gnucash_account_balance):
+        """Mixed-currency account without FX rates must fail."""
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "Assets:Bank")
+        assert result.exit_code != 0, (
+            f"Expected error for Assets:Bank without FX, got: {result.output}"
+        )
+
 
 # ---------------------------------------------------------------------------
-# Output format
+# Single account (no --with-children): recursive total only
 # ---------------------------------------------------------------------------
 
-class TestAccountBalanceOutput:
+class TestAccountBalanceSingleAccount:
 
     def test_outputs_balance_directive_header(self, temp_gnucash_account_balance):
-        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31")
-        assert result.exit_code == 0
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "Expenses:Food")
+        assert result.exit_code == 0, result.output
         assert "2024-12-31 balance" in result.output
 
-    def test_outputs_leaf_accounts_with_amounts(self, temp_gnucash_account_balance):
-        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31")
-        assert result.exit_code == 0
-        assert "Assets:Bank:Checking" in result.output
-        assert "Assets:Bank:HKD" in result.output
-        assert "Expenses:Food:Groceries" in result.output
-        assert "Expenses:Food:Dining" in result.output
-        assert "Income:HKDIncome:Freelance" in result.output
-        assert "Income:HKDIncome:Dividends" in result.output
-        assert "Expenses:HKDExpenses:Transport" in result.output
-        assert "Liabilities:CreditCard" in result.output
-        assert "Liabilities:HKDLoan" in result.output
-
-    def test_parent_accounts_not_in_output(self, temp_gnucash_account_balance):
-        """Parent-only accounts (placeholder) must not appear as balance lines."""
-        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31")
-        assert result.exit_code == 0
-        lines = result.output.splitlines()
-        account_lines = [line for line in lines if line.startswith("\t")]
-        account_names = [line.split()[0] for line in account_lines]
-        assert "Expenses:Food" not in account_names
-        assert "Expenses:HKDExpenses" not in account_names
-        assert "Income:HKDIncome" not in account_names
-
-    def test_checking_balance_value(self, temp_gnucash_account_balance):
+    def test_single_cad_leaf_balance(self, temp_gnucash_account_balance):
         result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
                          "Assets:Bank:Checking")
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         assert "3420.00" in result.output
         assert "CAD" in result.output
+        assert "Assets:Bank:Checking" in result.output
 
-    def test_hkd_bank_balance_value(self, temp_gnucash_account_balance):
+    def test_single_hkd_leaf_balance(self, temp_gnucash_account_balance):
         result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
                          "Assets:Bank:HKD")
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         assert "8700.00" in result.output
         assert "HKD" in result.output
 
-    def test_account_prefix_filters_output(self, temp_gnucash_account_balance):
-        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
-                         "Assets:Bank")
-        assert result.exit_code == 0
-        assert "Assets:Bank:Checking" in result.output
-        assert "Assets:Bank:HKD" in result.output
-        assert "Expenses" not in result.output
-        assert "Income" not in result.output
-        assert "Liabilities" not in result.output
-
-    def test_expenses_food_prefix(self, temp_gnucash_account_balance):
+    def test_parent_single_currency_recursive_total(self, temp_gnucash_account_balance):
+        """Expenses:Food total = Groceries(50) + Dining(30) = 80 CAD."""
         result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
                          "Expenses:Food")
-        assert result.exit_code == 0
-        assert "Expenses:Food:Groceries" in result.output
-        assert "Expenses:Food:Dining" in result.output
-        assert "Transport" not in result.output
+        assert result.exit_code == 0, result.output
+        assert "Expenses:Food" in result.output
+        assert "80.00" in result.output
+        assert "CAD" in result.output
+        # No sub-account breakdown by default
+        assert "Groceries" not in result.output
+        assert "Dining" not in result.output
+
+    def test_default_as_of_succeeds_for_single_currency(self, temp_gnucash_account_balance):
+        """Omitting --as-of should succeed for single-currency account (uses today)."""
+        result = run_cli(temp_gnucash_account_balance, "Expenses:Food")
+        assert result.exit_code == 0, result.output
+        assert "balance" in result.output
 
     def test_output_to_file(self, temp_gnucash_account_balance, tmp_path):
         out_file = str(tmp_path / "balances.txt")
         result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
-                         "-o", out_file)
-        assert result.exit_code == 0
+                         "Expenses:Food", "-o", out_file)
+        assert result.exit_code == 0, result.output
         assert "Written to" in result.output
         with open(out_file) as f:
             content = f.read()
         assert "2024-12-31 balance" in content
-        assert "Assets:Bank:Checking" in content
-
-    def test_default_as_of_is_today(self, temp_gnucash_account_balance):
-        """Omitting --as-of should succeed (uses today)."""
-        result = run_cli(temp_gnucash_account_balance)
-        assert result.exit_code == 0
-        assert "balance" in result.output
+        assert "Expenses:Food" in content
+        assert "80.00" in content
 
 
 # ---------------------------------------------------------------------------
-# FX rates consolidation
+# --with-children: account + sub-account breakdown
+# ---------------------------------------------------------------------------
+
+class TestAccountBalanceWithChildren:
+
+    def test_with_children_shows_parent_and_sub_accounts(self, temp_gnucash_account_balance):
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "Expenses:Food", "--with-children")
+        assert result.exit_code == 0, result.output
+        assert "Expenses:Food" in result.output
+        assert "Expenses:Food:Groceries" in result.output
+        assert "Expenses:Food:Dining" in result.output
+
+    def test_with_children_parent_balance_is_recursive_total(self, temp_gnucash_account_balance):
+        """Expenses:Food line shows 80.00 (sum of children), children show their own amounts."""
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "Expenses:Food", "--with-children")
+        assert result.exit_code == 0, result.output
+        lines = result.output.splitlines()
+        food_line = next(
+            (line for line in lines if "Expenses:Food" in line and "Groceries" not in line
+             and "Dining" not in line),
+            None,
+        )
+        assert food_line is not None, f"No Expenses:Food line in:\n{result.output}"
+        assert "80.00" in food_line, f"Expected 80.00 in {food_line!r}"
+
+        groceries_line = next((line for line in lines if "Groceries" in line), None)
+        assert groceries_line is not None
+        assert "50.00" in groceries_line, f"Expected 50.00 in {groceries_line!r}"
+
+    def test_with_children_filters_other_accounts(self, temp_gnucash_account_balance):
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "Expenses:Food", "--with-children")
+        assert result.exit_code == 0, result.output
+        assert "Transport" not in result.output
+        assert "Assets" not in result.output
+        assert "Income" not in result.output
+        assert "Liabilities" not in result.output
+
+    def test_with_children_mixed_currency_requires_fx(self, temp_gnucash_account_balance):
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "Assets:Bank", "--with-children")
+        assert result.exit_code != 0, (
+            f"Expected error for Assets:Bank --with-children without FX: {result.output}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Whole-book export (no ACCOUNT_PREFIX) with FX rates
+# ---------------------------------------------------------------------------
+
+class TestAccountBalanceWholeBook:
+
+    def test_whole_book_with_fx_shows_all_accounts(self, temp_gnucash_account_balance, tmp_path):
+        fx = _fx_file(tmp_path)
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "--fx-rates", fx)
+        assert result.exit_code == 0, result.output
+        # Parent accounts
+        assert "Assets:Bank" in result.output
+        assert "Expenses:Food" in result.output
+        assert "Income:HKDIncome" in result.output
+        # Leaf accounts
+        assert "Assets:Bank:Checking" in result.output
+        assert "Assets:Bank:HKD" in result.output
+        assert "Expenses:Food:Groceries" in result.output
+
+    def test_whole_book_all_in_cad(self, temp_gnucash_account_balance, tmp_path):
+        fx = _fx_file(tmp_path)
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "--fx-rates", fx)
+        assert result.exit_code == 0, result.output
+        account_lines = [
+            line for line in result.output.splitlines()
+            if line.startswith("\t") and not line.startswith("\t\t")
+        ]
+        assert account_lines, "No account lines found in output"
+        for line in account_lines:
+            assert line.strip().endswith("CAD"), f"Expected CAD suffix: {line!r}"
+
+
+# ---------------------------------------------------------------------------
+# FX rates: conversion details
 # ---------------------------------------------------------------------------
 
 class TestAccountBalanceFxRates:
 
-    def test_with_fx_rates_outputs_cad(self, temp_gnucash_account_balance, tmp_path):
-        fx = _fx_file(tmp_path)
-        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
-                         "--fx-rates", fx, "Assets:Bank")
-        assert result.exit_code == 0, result.output
-        # Account lines use a single leading tab; metadata lines use two tabs
-        account_lines = [line for line in result.output.splitlines()
-                         if line.startswith("\t") and not line.startswith("\t\t")]
-        for line in account_lines:
-            assert line.strip().endswith("CAD"), f"Expected CAD suffix: {line!r}"
-
-    def test_with_fx_rates_shows_share_price_and_original(self, temp_gnucash_account_balance, tmp_path):
-        """HKD account shows share_price and original amount metadata."""
+    def test_fx_hkd_leaf_shows_share_price_and_original(self, temp_gnucash_account_balance, tmp_path):
+        """HKD leaf account shows share_price and original amount on their own lines."""
         fx = _fx_file(tmp_path)
         result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
                          "--fx-rates", fx, "Assets:Bank:HKD")
@@ -154,24 +228,38 @@ class TestAccountBalanceFxRates:
         share_price_line = next((line for line in lines if "share_price:" in line), None)
         original_line = next((line for line in lines if "original:" in line), None)
         assert share_price_line is not None, f"No share_price line in:\n{result.output}"
-        assert "17/100" in share_price_line, f"Expected 17/100 in share_price line: {share_price_line!r}"
+        assert "17/100" in share_price_line, f"Expected 17/100 in: {share_price_line!r}"
         assert original_line is not None, f"No original line in:\n{result.output}"
-        assert "8700.00 HKD" in original_line, f"Expected 8700.00 HKD in original line: {original_line!r}"
+        assert "8700.00 HKD" in original_line, f"Expected 8700.00 HKD in: {original_line!r}"
 
-    def test_with_fx_rates_checking_converted_correctly(self, temp_gnucash_account_balance, tmp_path):
-        """CAD account should remain 3420.00 CAD (rate 1.0)."""
+    def test_fx_cad_account_no_metadata(self, temp_gnucash_account_balance, tmp_path):
+        """CAD account with FX: no share_price/original metadata (already in CAD)."""
         fx = _fx_file(tmp_path)
         result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
                          "--fx-rates", fx, "Assets:Bank:Checking")
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         assert "3420.00" in result.output
         assert "CAD" in result.output
+        assert "share_price:" not in result.output
+        assert "original:" not in result.output
 
-    def test_with_fx_rates_hkd_converted_correctly(self, temp_gnucash_account_balance, tmp_path):
+    def test_fx_hkd_converted_amount(self, temp_gnucash_account_balance, tmp_path):
         """HKD 8700 * 0.17 = 1479.00 CAD."""
         fx = _fx_file(tmp_path)
         result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
                          "--fx-rates", fx, "Assets:Bank:HKD")
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         assert "1479.00" in result.output
         assert "CAD" in result.output
+
+    def test_fx_mixed_currency_parent_total(self, temp_gnucash_account_balance, tmp_path):
+        """Assets:Bank with FX: recursive total = 3420 + 8700*0.17 = 4899.00 CAD."""
+        fx = _fx_file(tmp_path)
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "--fx-rates", fx, "Assets:Bank")
+        assert result.exit_code == 0, result.output
+        assert "4899.00" in result.output
+        assert "CAD" in result.output
+        # No sub-account breakdown (default, no --with-children)
+        assert "Assets:Bank:Checking" not in result.output
+        assert "Assets:Bank:HKD" not in result.output

--- a/tests/unit/use_cases/test_account_balance.py
+++ b/tests/unit/use_cases/test_account_balance.py
@@ -1,0 +1,242 @@
+"""
+Unit tests for AccountBalanceUseCase.
+
+Uses the temp_gnucash_account_balance fixture (loaded from
+tests/fixtures/account_balance_test_data.txt) which covers all 5 account
+types in two currencies with sub-accounts:
+
+  Assets:Bank:Checking           CAD  3420.00  (500 + 3000 - 50 - 30)
+  Assets:Bank:HKD                HKD  8700.00  (8000 + 400 + 600 - 300)
+  Liabilities:CreditCard         CAD   200.00
+  Liabilities:HKDLoan            HKD   500.00
+  Equity:Opening                 CAD  (balancing)
+  Income:Salary                  CAD -3000.00
+  Income:HKDIncome:Freelance     HKD  -400.00
+  Income:HKDIncome:Dividends     HKD  -600.00
+  Expenses:Food:Groceries        CAD    50.00
+  Expenses:Food:Dining           CAD    30.00
+  Expenses:HKDExpenses:Transport HKD   300.00
+"""
+
+from datetime import date
+from fractions import Fraction
+
+import pytest
+
+
+class TestAccountBalanceNoCurrency:
+    """Without --fx-rates: each leaf account in its own currency."""
+
+    def test_all_account_types_present(self, temp_gnucash_account_balance):
+        from repositories.gnucash_repository import GnuCashRepository, SessionMode
+        from use_cases.account_balance import AccountBalanceUseCase
+
+        repo = GnuCashRepository(temp_gnucash_account_balance)
+        repo.open(mode=SessionMode.READ_ONLY)
+        try:
+            result = AccountBalanceUseCase(repo).execute(as_of=date(2024, 12, 31))
+        finally:
+            repo.close()
+
+        paths = {b.account_path for b in result.balances}
+        # Asset leafs
+        assert "Assets:Bank:Checking" in paths
+        assert "Assets:Bank:HKD" in paths
+        # Liability leafs
+        assert "Liabilities:CreditCard" in paths
+        assert "Liabilities:HKDLoan" in paths
+        # Equity
+        assert "Equity:Opening" in paths
+        # Income: HKDIncome has sub-accounts → only leaves appear
+        assert "Income:Salary" in paths
+        assert "Income:HKDIncome:Freelance" in paths
+        assert "Income:HKDIncome:Dividends" in paths
+        assert "Income:HKDIncome" not in paths
+        # Expenses: Food has sub-accounts → only leaves appear
+        assert "Expenses:Food:Groceries" in paths
+        assert "Expenses:Food:Dining" in paths
+        assert "Expenses:HKDExpenses:Transport" in paths
+        assert "Expenses:Food" not in paths
+        assert "Expenses:HKDExpenses" not in paths
+
+    def test_checking_balance(self, temp_gnucash_account_balance):
+        from repositories.gnucash_repository import GnuCashRepository, SessionMode
+        from use_cases.account_balance import AccountBalanceUseCase
+
+        repo = GnuCashRepository(temp_gnucash_account_balance)
+        repo.open(mode=SessionMode.READ_ONLY)
+        try:
+            result = AccountBalanceUseCase(repo).execute(as_of=date(2024, 12, 31))
+        finally:
+            repo.close()
+
+        bal = next(b for b in result.balances if b.account_path == "Assets:Bank:Checking")
+        assert bal.currency == "CAD"
+        assert float(bal.amount) == pytest.approx(3420.00)
+
+    def test_hkd_bank_balance(self, temp_gnucash_account_balance):
+        from repositories.gnucash_repository import GnuCashRepository, SessionMode
+        from use_cases.account_balance import AccountBalanceUseCase
+
+        repo = GnuCashRepository(temp_gnucash_account_balance)
+        repo.open(mode=SessionMode.READ_ONLY)
+        try:
+            result = AccountBalanceUseCase(repo).execute(as_of=date(2024, 12, 31))
+        finally:
+            repo.close()
+
+        bal = next(b for b in result.balances if b.account_path == "Assets:Bank:HKD")
+        assert bal.currency == "HKD"
+        assert float(bal.amount) == pytest.approx(8700.00)
+
+    def test_expense_sub_accounts_reported_separately(self, temp_gnucash_account_balance):
+        """Expenses:Food:Groceries and Expenses:Food:Dining are separate leaf entries."""
+        from repositories.gnucash_repository import GnuCashRepository, SessionMode
+        from use_cases.account_balance import AccountBalanceUseCase
+
+        repo = GnuCashRepository(temp_gnucash_account_balance)
+        repo.open(mode=SessionMode.READ_ONLY)
+        try:
+            result = AccountBalanceUseCase(repo).execute(as_of=date(2024, 12, 31))
+        finally:
+            repo.close()
+
+        groceries = next(b for b in result.balances if b.account_path == "Expenses:Food:Groceries")
+        dining = next(b for b in result.balances if b.account_path == "Expenses:Food:Dining")
+        assert float(groceries.amount) == pytest.approx(50.00)
+        assert float(dining.amount) == pytest.approx(30.00)
+
+    def test_income_sub_accounts_reported_separately(self, temp_gnucash_account_balance):
+        """Income:HKDIncome:Freelance and Dividends are separate leaf entries."""
+        from repositories.gnucash_repository import GnuCashRepository, SessionMode
+        from use_cases.account_balance import AccountBalanceUseCase
+
+        repo = GnuCashRepository(temp_gnucash_account_balance)
+        repo.open(mode=SessionMode.READ_ONLY)
+        try:
+            result = AccountBalanceUseCase(repo).execute(as_of=date(2024, 12, 31))
+        finally:
+            repo.close()
+
+        freelance = next(b for b in result.balances if b.account_path == "Income:HKDIncome:Freelance")
+        dividends = next(b for b in result.balances if b.account_path == "Income:HKDIncome:Dividends")
+        # Income accounts have credit-normal sign in GnuCash
+        assert float(freelance.amount) == pytest.approx(-400.00)
+        assert float(dividends.amount) == pytest.approx(-600.00)
+
+    def test_account_prefix_assets_bank(self, temp_gnucash_account_balance):
+        from repositories.gnucash_repository import GnuCashRepository, SessionMode
+        from use_cases.account_balance import AccountBalanceUseCase
+
+        repo = GnuCashRepository(temp_gnucash_account_balance)
+        repo.open(mode=SessionMode.READ_ONLY)
+        try:
+            result = AccountBalanceUseCase(repo).execute(
+                as_of=date(2024, 12, 31), account_prefix="Assets:Bank"
+            )
+        finally:
+            repo.close()
+
+        paths = {b.account_path for b in result.balances}
+        assert paths == {"Assets:Bank:Checking", "Assets:Bank:HKD"}
+
+    def test_account_prefix_expenses_food(self, temp_gnucash_account_balance):
+        """Filtering to Expenses:Food returns its two leaf sub-accounts."""
+        from repositories.gnucash_repository import GnuCashRepository, SessionMode
+        from use_cases.account_balance import AccountBalanceUseCase
+
+        repo = GnuCashRepository(temp_gnucash_account_balance)
+        repo.open(mode=SessionMode.READ_ONLY)
+        try:
+            result = AccountBalanceUseCase(repo).execute(
+                as_of=date(2024, 12, 31), account_prefix="Expenses:Food"
+            )
+        finally:
+            repo.close()
+
+        paths = {b.account_path for b in result.balances}
+        assert paths == {"Expenses:Food:Groceries", "Expenses:Food:Dining"}
+
+    def test_as_of_before_june_activity(self, temp_gnucash_account_balance):
+        """Balance as of 2024-01-31 excludes the June transactions."""
+        from repositories.gnucash_repository import GnuCashRepository, SessionMode
+        from use_cases.account_balance import AccountBalanceUseCase
+
+        repo = GnuCashRepository(temp_gnucash_account_balance)
+        repo.open(mode=SessionMode.READ_ONLY)
+        try:
+            result = AccountBalanceUseCase(repo).execute(
+                as_of=date(2024, 1, 31), account_prefix="Assets:Bank"
+            )
+        finally:
+            repo.close()
+
+        checking = next(b for b in result.balances if b.account_path == "Assets:Bank:Checking")
+        # Only opening balance of 500, no salary yet
+        assert float(checking.amount) == pytest.approx(500.00)
+
+    def test_no_consolidated_cad_without_fx_rates(self, temp_gnucash_account_balance):
+        from repositories.gnucash_repository import GnuCashRepository, SessionMode
+        from use_cases.account_balance import AccountBalanceUseCase
+
+        repo = GnuCashRepository(temp_gnucash_account_balance)
+        repo.open(mode=SessionMode.READ_ONLY)
+        try:
+            result = AccountBalanceUseCase(repo).execute(as_of=date(2024, 12, 31))
+        finally:
+            repo.close()
+
+        assert result.consolidated_cad is None
+
+
+class TestAccountBalanceWithFxRates:
+    """With --fx-rates: all amounts converted to CAD."""
+
+    def test_all_balances_in_cad(self, temp_gnucash_account_balance, tmp_path):
+        from repositories.gnucash_repository import GnuCashRepository, SessionMode
+        from services.fx_rates import FxRates
+        from use_cases.account_balance import AccountBalanceUseCase
+
+        rates_file = tmp_path / "rates.yaml"
+        rates_file.write_text("HKD: 0.17\n")
+        fx_rates = FxRates.load(str(rates_file))
+
+        repo = GnuCashRepository(temp_gnucash_account_balance)
+        repo.open(mode=SessionMode.NORMAL)
+        try:
+            result = AccountBalanceUseCase(repo).execute(
+                as_of=date(2024, 12, 31),
+                account_prefix="Assets:Bank",
+                fx_rates=fx_rates,
+            )
+        finally:
+            repo.close()
+
+        for bal in result.balances:
+            assert bal.currency == "CAD", f"Expected CAD, got {bal.currency} for {bal.account_path}"
+
+    def test_consolidated_cad_assets_bank(self, temp_gnucash_account_balance, tmp_path):
+        """Assets:Bank total: 3420 CAD + 8700 HKD * 0.17 = 3420 + 1479 = 4899 CAD."""
+        from repositories.gnucash_repository import GnuCashRepository, SessionMode
+        from services.fx_rates import FxRates
+        from use_cases.account_balance import AccountBalanceUseCase
+
+        rates_file = tmp_path / "rates.yaml"
+        rates_file.write_text("HKD: 0.17\n")
+        fx_rates = FxRates.load(str(rates_file))
+
+        repo = GnuCashRepository(temp_gnucash_account_balance)
+        repo.open(mode=SessionMode.NORMAL)
+        try:
+            result = AccountBalanceUseCase(repo).execute(
+                as_of=date(2024, 12, 31),
+                account_prefix="Assets:Bank",
+                fx_rates=fx_rates,
+            )
+        finally:
+            repo.close()
+
+        assert result.consolidated_cad is not None
+        hkd_rate = Fraction("0.17").limit_denominator(1_000_000)
+        expected = Fraction(3420) + Fraction(8700) * hkd_rate
+        assert abs(float(result.consolidated_cad) - float(expected)) < 0.01

--- a/tests/unit/use_cases/test_account_balance.py
+++ b/tests/unit/use_cases/test_account_balance.py
@@ -16,6 +16,10 @@ types in two currencies with sub-accounts:
   Expenses:Food:Groceries        CAD    50.00
   Expenses:Food:Dining           CAD    30.00
   Expenses:HKDExpenses:Transport HKD   300.00
+
+Recursive parent balances (single-currency subtrees, no FX needed):
+  Expenses:Food           CAD  80.00  (Groceries + Dining)
+  Income:HKDIncome        HKD -1000.00  (Freelance + Dividends)
 """
 
 from datetime import date
@@ -24,219 +28,321 @@ from fractions import Fraction
 import pytest
 
 
-class TestAccountBalanceNoCurrency:
-    """Without --fx-rates: each leaf account in its own currency."""
+def _open_repo(path, mode=None):
+    from repositories.gnucash_repository import GnuCashRepository, SessionMode
+    repo = GnuCashRepository(path)
+    repo.open(mode=mode or SessionMode.READ_ONLY)
+    return repo
 
-    def test_all_account_types_present(self, temp_gnucash_account_balance):
-        from repositories.gnucash_repository import GnuCashRepository, SessionMode
-        from use_cases.account_balance import AccountBalanceUseCase
 
-        repo = GnuCashRepository(temp_gnucash_account_balance)
-        repo.open(mode=SessionMode.READ_ONLY)
+def _exec(repo, **kwargs):
+    from use_cases.account_balance import AccountBalanceUseCase
+    return AccountBalanceUseCase(repo).execute(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# No prefix: all accounts with recursive totals
+# ---------------------------------------------------------------------------
+
+class TestAccountBalanceNoPrefix:
+    """No account_prefix: all accounts, each with recursive cumulative balance."""
+
+    def test_mixed_currency_without_fx_raises_error(self, temp_gnucash_account_balance):
+        """Whole-book export errors when mixed-currency accounts exist and no FX rates."""
+        from services.fx_rates import MissingFxRateError
+        repo = _open_repo(temp_gnucash_account_balance)
         try:
-            result = AccountBalanceUseCase(repo).execute(as_of=date(2024, 12, 31))
+            with pytest.raises(MissingFxRateError):
+                _exec(repo, as_of=date(2024, 12, 31))
+        finally:
+            repo.close()
+
+    def test_all_accounts_shown_with_fx(self, temp_gnucash_account_balance, tmp_path):
+        """With FX rates, all accounts (parent + leaf) appear in output."""
+        from repositories.gnucash_repository import SessionMode
+        from services.fx_rates import FxRates
+
+        rates_file = tmp_path / "rates.yaml"
+        rates_file.write_text("HKD: 0.17\n")
+        fx_rates = FxRates.load(str(rates_file))
+
+        repo = _open_repo(temp_gnucash_account_balance, SessionMode.NORMAL)
+        try:
+            result = _exec(repo, as_of=date(2024, 12, 31), fx_rates=fx_rates)
         finally:
             repo.close()
 
         paths = {b.account_path for b in result.balances}
-        # Asset leafs
+        # Parent accounts
+        assert "Assets" in paths
+        assert "Assets:Bank" in paths
+        assert "Liabilities" in paths
+        assert "Income" in paths
+        assert "Income:HKDIncome" in paths
+        assert "Expenses" in paths
+        assert "Expenses:Food" in paths
+        assert "Expenses:HKDExpenses" in paths
+        # Leaf accounts
         assert "Assets:Bank:Checking" in paths
         assert "Assets:Bank:HKD" in paths
-        # Liability leafs
-        assert "Liabilities:CreditCard" in paths
-        assert "Liabilities:HKDLoan" in paths
-        # Equity
-        assert "Equity:Opening" in paths
-        # Income: HKDIncome has sub-accounts → only leaves appear
-        assert "Income:Salary" in paths
-        assert "Income:HKDIncome:Freelance" in paths
-        assert "Income:HKDIncome:Dividends" in paths
-        assert "Income:HKDIncome" not in paths
-        # Expenses: Food has sub-accounts → only leaves appear
         assert "Expenses:Food:Groceries" in paths
         assert "Expenses:Food:Dining" in paths
-        assert "Expenses:HKDExpenses:Transport" in paths
-        assert "Expenses:Food" not in paths
-        assert "Expenses:HKDExpenses" not in paths
 
-    def test_checking_balance(self, temp_gnucash_account_balance):
-        from repositories.gnucash_repository import GnuCashRepository, SessionMode
-        from use_cases.account_balance import AccountBalanceUseCase
+    def test_all_balances_in_cad_with_fx(self, temp_gnucash_account_balance, tmp_path):
+        """With FX rates, every account balance is reported in CAD."""
+        from repositories.gnucash_repository import SessionMode
+        from services.fx_rates import FxRates
 
-        repo = GnuCashRepository(temp_gnucash_account_balance)
-        repo.open(mode=SessionMode.READ_ONLY)
+        rates_file = tmp_path / "rates.yaml"
+        rates_file.write_text("HKD: 0.17\n")
+        fx_rates = FxRates.load(str(rates_file))
+
+        repo = _open_repo(temp_gnucash_account_balance, SessionMode.NORMAL)
         try:
-            result = AccountBalanceUseCase(repo).execute(as_of=date(2024, 12, 31))
+            result = _exec(repo, as_of=date(2024, 12, 31), fx_rates=fx_rates)
         finally:
             repo.close()
 
-        bal = next(b for b in result.balances if b.account_path == "Assets:Bank:Checking")
+        for bal in result.balances:
+            assert bal.currency == "CAD", (
+                f"Expected CAD, got {bal.currency} for {bal.account_path}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# With prefix (no --with-children): single account, recursive total
+# ---------------------------------------------------------------------------
+
+class TestAccountBalanceWithPrefix:
+    """account_prefix given, include_children=False (default): one account with recursive total."""
+
+    def test_single_cad_leaf(self, temp_gnucash_account_balance):
+        """Single CAD leaf: balance equals its direct splits."""
+        repo = _open_repo(temp_gnucash_account_balance)
+        try:
+            result = _exec(repo, as_of=date(2024, 12, 31),
+                           account_prefix="Assets:Bank:Checking")
+        finally:
+            repo.close()
+
+        assert len(result.balances) == 1
+        bal = result.balances[0]
+        assert bal.account_path == "Assets:Bank:Checking"
         assert bal.currency == "CAD"
         assert float(bal.amount) == pytest.approx(3420.00)
 
-    def test_hkd_bank_balance(self, temp_gnucash_account_balance):
-        from repositories.gnucash_repository import GnuCashRepository, SessionMode
-        from use_cases.account_balance import AccountBalanceUseCase
-
-        repo = GnuCashRepository(temp_gnucash_account_balance)
-        repo.open(mode=SessionMode.READ_ONLY)
+    def test_single_hkd_leaf(self, temp_gnucash_account_balance):
+        """Single HKD leaf: balance in HKD."""
+        repo = _open_repo(temp_gnucash_account_balance)
         try:
-            result = AccountBalanceUseCase(repo).execute(as_of=date(2024, 12, 31))
+            result = _exec(repo, as_of=date(2024, 12, 31),
+                           account_prefix="Assets:Bank:HKD")
         finally:
             repo.close()
 
-        bal = next(b for b in result.balances if b.account_path == "Assets:Bank:HKD")
+        assert len(result.balances) == 1
+        bal = result.balances[0]
+        assert bal.account_path == "Assets:Bank:HKD"
         assert bal.currency == "HKD"
         assert float(bal.amount) == pytest.approx(8700.00)
 
-    def test_expense_sub_accounts_reported_separately(self, temp_gnucash_account_balance):
-        """Expenses:Food:Groceries and Expenses:Food:Dining are separate leaf entries."""
-        from repositories.gnucash_repository import GnuCashRepository, SessionMode
-        from use_cases.account_balance import AccountBalanceUseCase
-
-        repo = GnuCashRepository(temp_gnucash_account_balance)
-        repo.open(mode=SessionMode.READ_ONLY)
+    def test_parent_single_currency_recursive_total(self, temp_gnucash_account_balance):
+        """Expenses:Food (all CAD) shows recursive sum of Groceries + Dining."""
+        repo = _open_repo(temp_gnucash_account_balance)
         try:
-            result = AccountBalanceUseCase(repo).execute(as_of=date(2024, 12, 31))
+            result = _exec(repo, as_of=date(2024, 12, 31),
+                           account_prefix="Expenses:Food")
         finally:
             repo.close()
 
-        groceries = next(b for b in result.balances if b.account_path == "Expenses:Food:Groceries")
-        dining = next(b for b in result.balances if b.account_path == "Expenses:Food:Dining")
-        assert float(groceries.amount) == pytest.approx(50.00)
-        assert float(dining.amount) == pytest.approx(30.00)
+        assert len(result.balances) == 1
+        bal = result.balances[0]
+        assert bal.account_path == "Expenses:Food"
+        assert bal.currency == "CAD"
+        assert float(bal.amount) == pytest.approx(80.00)  # 50 + 30
 
-    def test_income_sub_accounts_reported_separately(self, temp_gnucash_account_balance):
-        """Income:HKDIncome:Freelance and Dividends are separate leaf entries."""
-        from repositories.gnucash_repository import GnuCashRepository, SessionMode
-        from use_cases.account_balance import AccountBalanceUseCase
-
-        repo = GnuCashRepository(temp_gnucash_account_balance)
-        repo.open(mode=SessionMode.READ_ONLY)
+    def test_parent_single_currency_hkd(self, temp_gnucash_account_balance):
+        """Income:HKDIncome (all HKD) shows recursive sum of sub-accounts."""
+        repo = _open_repo(temp_gnucash_account_balance)
         try:
-            result = AccountBalanceUseCase(repo).execute(as_of=date(2024, 12, 31))
+            result = _exec(repo, as_of=date(2024, 12, 31),
+                           account_prefix="Income:HKDIncome")
         finally:
             repo.close()
 
-        freelance = next(b for b in result.balances if b.account_path == "Income:HKDIncome:Freelance")
-        dividends = next(b for b in result.balances if b.account_path == "Income:HKDIncome:Dividends")
-        # Income accounts have credit-normal sign in GnuCash
-        assert float(freelance.amount) == pytest.approx(-400.00)
-        assert float(dividends.amount) == pytest.approx(-600.00)
+        assert len(result.balances) == 1
+        bal = result.balances[0]
+        assert bal.account_path == "Income:HKDIncome"
+        assert bal.currency == "HKD"
+        # Income accounts: -400 (Freelance) + -600 (Dividends) = -1000
+        assert float(bal.amount) == pytest.approx(-1000.00)
 
-    def test_account_prefix_assets_bank(self, temp_gnucash_account_balance):
-        from repositories.gnucash_repository import GnuCashRepository, SessionMode
-        from use_cases.account_balance import AccountBalanceUseCase
-
-        repo = GnuCashRepository(temp_gnucash_account_balance)
-        repo.open(mode=SessionMode.READ_ONLY)
+    def test_nonexistent_prefix_raises_value_error(self, temp_gnucash_account_balance):
+        """Typo in account prefix should raise ValueError, not return empty result."""
+        repo = _open_repo(temp_gnucash_account_balance)
         try:
-            result = AccountBalanceUseCase(repo).execute(
-                as_of=date(2024, 12, 31), account_prefix="Assets:Bank"
-            )
+            with pytest.raises(ValueError, match="not found"):
+                _exec(repo, as_of=date(2024, 12, 31), account_prefix="Asset:Bank")
         finally:
             repo.close()
 
-        paths = {b.account_path for b in result.balances}
-        assert paths == {"Assets:Bank:Checking", "Assets:Bank:HKD"}
-
-    def test_account_prefix_expenses_food(self, temp_gnucash_account_balance):
-        """Filtering to Expenses:Food returns its two leaf sub-accounts."""
-        from repositories.gnucash_repository import GnuCashRepository, SessionMode
-        from use_cases.account_balance import AccountBalanceUseCase
-
-        repo = GnuCashRepository(temp_gnucash_account_balance)
-        repo.open(mode=SessionMode.READ_ONLY)
+    def test_mixed_currency_parent_requires_fx(self, temp_gnucash_account_balance):
+        """Assets:Bank has CAD + HKD children: raises error without FX rates."""
+        from services.fx_rates import MissingFxRateError
+        repo = _open_repo(temp_gnucash_account_balance)
         try:
-            result = AccountBalanceUseCase(repo).execute(
-                as_of=date(2024, 12, 31), account_prefix="Expenses:Food"
-            )
+            with pytest.raises(MissingFxRateError):
+                _exec(repo, as_of=date(2024, 12, 31), account_prefix="Assets:Bank")
         finally:
             repo.close()
 
-        paths = {b.account_path for b in result.balances}
-        assert paths == {"Expenses:Food:Groceries", "Expenses:Food:Dining"}
+    def test_mixed_currency_parent_with_fx(self, temp_gnucash_account_balance, tmp_path):
+        """Assets:Bank with FX: recursive CAD total = 3420 + 8700*0.17 = 4899."""
+        from repositories.gnucash_repository import SessionMode
+        from services.fx_rates import FxRates
 
-    def test_as_of_before_june_activity(self, temp_gnucash_account_balance):
-        """Balance as of 2024-01-31 excludes the June transactions."""
-        from repositories.gnucash_repository import GnuCashRepository, SessionMode
-        from use_cases.account_balance import AccountBalanceUseCase
+        rates_file = tmp_path / "rates.yaml"
+        rates_file.write_text("HKD: 0.17\n")
+        fx_rates = FxRates.load(str(rates_file))
 
-        repo = GnuCashRepository(temp_gnucash_account_balance)
-        repo.open(mode=SessionMode.READ_ONLY)
+        repo = _open_repo(temp_gnucash_account_balance, SessionMode.NORMAL)
         try:
-            result = AccountBalanceUseCase(repo).execute(
-                as_of=date(2024, 1, 31), account_prefix="Assets:Bank"
-            )
+            result = _exec(repo, as_of=date(2024, 12, 31),
+                           account_prefix="Assets:Bank", fx_rates=fx_rates)
         finally:
             repo.close()
 
-        checking = next(b for b in result.balances if b.account_path == "Assets:Bank:Checking")
-        # Only opening balance of 500, no salary yet
-        assert float(checking.amount) == pytest.approx(500.00)
+        assert len(result.balances) == 1
+        bal = result.balances[0]
+        assert bal.account_path == "Assets:Bank"
+        assert bal.currency == "CAD"
+        expected = 3420.00 + 8700.00 * 0.17  # 4899.00
+        assert float(bal.amount) == pytest.approx(expected)
 
-    def test_no_consolidated_cad_without_fx_rates(self, temp_gnucash_account_balance):
-        from repositories.gnucash_repository import GnuCashRepository, SessionMode
-        from use_cases.account_balance import AccountBalanceUseCase
-
-        repo = GnuCashRepository(temp_gnucash_account_balance)
-        repo.open(mode=SessionMode.READ_ONLY)
+    def test_as_of_date_cutoff(self, temp_gnucash_account_balance):
+        """Balance as of 2024-01-31 excludes June transactions."""
+        repo = _open_repo(temp_gnucash_account_balance)
         try:
-            result = AccountBalanceUseCase(repo).execute(as_of=date(2024, 12, 31))
+            result = _exec(repo, as_of=date(2024, 1, 31),
+                           account_prefix="Assets:Bank:Checking")
+        finally:
+            repo.close()
+
+        assert float(result.balances[0].amount) == pytest.approx(500.00)
+
+    def test_no_consolidated_cad_without_fx(self, temp_gnucash_account_balance):
+        """consolidated_cad is None when no fx_rates provided."""
+        repo = _open_repo(temp_gnucash_account_balance)
+        try:
+            result = _exec(repo, as_of=date(2024, 12, 31),
+                           account_prefix="Expenses:Food")
         finally:
             repo.close()
 
         assert result.consolidated_cad is None
 
-
-class TestAccountBalanceWithFxRates:
-    """With --fx-rates: all amounts converted to CAD."""
-
-    def test_all_balances_in_cad(self, temp_gnucash_account_balance, tmp_path):
-        from repositories.gnucash_repository import GnuCashRepository, SessionMode
+    def test_consolidated_cad_equals_account_balance(self, temp_gnucash_account_balance, tmp_path):
+        """consolidated_cad equals the matched account's recursive CAD balance."""
+        from repositories.gnucash_repository import SessionMode
         from services.fx_rates import FxRates
-        from use_cases.account_balance import AccountBalanceUseCase
 
         rates_file = tmp_path / "rates.yaml"
         rates_file.write_text("HKD: 0.17\n")
         fx_rates = FxRates.load(str(rates_file))
 
-        repo = GnuCashRepository(temp_gnucash_account_balance)
-        repo.open(mode=SessionMode.NORMAL)
+        repo = _open_repo(temp_gnucash_account_balance, SessionMode.NORMAL)
         try:
-            result = AccountBalanceUseCase(repo).execute(
-                as_of=date(2024, 12, 31),
-                account_prefix="Assets:Bank",
-                fx_rates=fx_rates,
-            )
-        finally:
-            repo.close()
-
-        for bal in result.balances:
-            assert bal.currency == "CAD", f"Expected CAD, got {bal.currency} for {bal.account_path}"
-
-    def test_consolidated_cad_assets_bank(self, temp_gnucash_account_balance, tmp_path):
-        """Assets:Bank total: 3420 CAD + 8700 HKD * 0.17 = 3420 + 1479 = 4899 CAD."""
-        from repositories.gnucash_repository import GnuCashRepository, SessionMode
-        from services.fx_rates import FxRates
-        from use_cases.account_balance import AccountBalanceUseCase
-
-        rates_file = tmp_path / "rates.yaml"
-        rates_file.write_text("HKD: 0.17\n")
-        fx_rates = FxRates.load(str(rates_file))
-
-        repo = GnuCashRepository(temp_gnucash_account_balance)
-        repo.open(mode=SessionMode.NORMAL)
-        try:
-            result = AccountBalanceUseCase(repo).execute(
-                as_of=date(2024, 12, 31),
-                account_prefix="Assets:Bank",
-                fx_rates=fx_rates,
-            )
+            result = _exec(repo, as_of=date(2024, 12, 31),
+                           account_prefix="Assets:Bank", fx_rates=fx_rates)
         finally:
             repo.close()
 
         assert result.consolidated_cad is not None
-        hkd_rate = Fraction("0.17").limit_denominator(1_000_000)
-        expected = Fraction(3420) + Fraction(8700) * hkd_rate
+        expected = Fraction(3420) + Fraction(8700) * Fraction(17, 100)
         assert abs(float(result.consolidated_cad) - float(expected)) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# With prefix + include_children=True (--with-children)
+# ---------------------------------------------------------------------------
+
+class TestAccountBalanceWithChildren:
+    """account_prefix + include_children=True: matched account + all sub-accounts."""
+
+    def test_expenses_food_subtree(self, temp_gnucash_account_balance):
+        """Expenses:Food with children: shows Food, Groceries, Dining (all CAD)."""
+        repo = _open_repo(temp_gnucash_account_balance)
+        try:
+            result = _exec(repo, as_of=date(2024, 12, 31),
+                           account_prefix="Expenses:Food", include_children=True)
+        finally:
+            repo.close()
+
+        paths = {b.account_path for b in result.balances}
+        assert paths == {"Expenses:Food", "Expenses:Food:Groceries", "Expenses:Food:Dining"}
+
+    def test_parent_recursive_total_with_children(self, temp_gnucash_account_balance):
+        """Expenses:Food balance = Groceries + Dining = 80 CAD."""
+        repo = _open_repo(temp_gnucash_account_balance)
+        try:
+            result = _exec(repo, as_of=date(2024, 12, 31),
+                           account_prefix="Expenses:Food", include_children=True)
+        finally:
+            repo.close()
+
+        food = next(b for b in result.balances if b.account_path == "Expenses:Food")
+        groceries = next(b for b in result.balances if b.account_path == "Expenses:Food:Groceries")
+        dining = next(b for b in result.balances if b.account_path == "Expenses:Food:Dining")
+        assert float(food.amount) == pytest.approx(80.00)
+        assert float(groceries.amount) == pytest.approx(50.00)
+        assert float(dining.amount) == pytest.approx(30.00)
+
+    def test_assets_bank_with_fx_and_children(self, temp_gnucash_account_balance, tmp_path):
+        """Assets:Bank with FX + children: bank total + each sub-account in CAD."""
+        from repositories.gnucash_repository import SessionMode
+        from services.fx_rates import FxRates
+
+        rates_file = tmp_path / "rates.yaml"
+        rates_file.write_text("HKD: 0.17\n")
+        fx_rates = FxRates.load(str(rates_file))
+
+        repo = _open_repo(temp_gnucash_account_balance, SessionMode.NORMAL)
+        try:
+            result = _exec(repo, as_of=date(2024, 12, 31),
+                           account_prefix="Assets:Bank", fx_rates=fx_rates,
+                           include_children=True)
+        finally:
+            repo.close()
+
+        paths = {b.account_path for b in result.balances}
+        assert paths == {"Assets:Bank", "Assets:Bank:Checking", "Assets:Bank:HKD"}
+
+        for bal in result.balances:
+            assert bal.currency == "CAD", (
+                f"Expected CAD for {bal.account_path}, got {bal.currency}"
+            )
+
+        bank = next(b for b in result.balances if b.account_path == "Assets:Bank")
+        assert float(bank.amount) == pytest.approx(3420 + 8700 * 0.17)
+
+    def test_hkd_leaf_fx_metadata(self, temp_gnucash_account_balance, tmp_path):
+        """Non-CAD leaf shows share_price and original amount when FX provided."""
+        from repositories.gnucash_repository import SessionMode
+        from services.fx_rates import FxRates
+
+        rates_file = tmp_path / "rates.yaml"
+        rates_file.write_text("HKD: 0.17\n")
+        fx_rates = FxRates.load(str(rates_file))
+
+        repo = _open_repo(temp_gnucash_account_balance, SessionMode.NORMAL)
+        try:
+            result = _exec(repo, as_of=date(2024, 12, 31),
+                           account_prefix="Assets:Bank:HKD", fx_rates=fx_rates)
+        finally:
+            repo.close()
+
+        bal = result.balances[0]
+        assert bal.original_currency == "HKD"
+        assert float(bal.original_amount) == pytest.approx(8700.00)
+        assert bal.share_price == Fraction(17, 100)
+        assert float(bal.amount) == pytest.approx(1479.00)

--- a/use_cases/account_balance.py
+++ b/use_cases/account_balance.py
@@ -1,0 +1,241 @@
+"""
+Use case for computing account balances as of a given date.
+
+Outputs balances in a `balance` directive format:
+
+    YYYY-MM-DD balance
+        Account:Path  Amount Currency
+
+Without --fx-rates: each leaf account is output in its own commodity currency.
+With --fx-rates: consolidates all leaf accounts to CAD using the provided rates,
+writing new price entries to the pricedb when rates differ from the current latest.
+"""
+
+from dataclasses import dataclass, field
+from datetime import date
+from fractions import Fraction
+from typing import List, Optional
+
+from repositories.gnucash_repository import GnuCashRepository
+from services.fx_rates import FxRates
+
+
+@dataclass
+class AccountBalance:
+    """A single account balance entry."""
+    account_path: str
+    amount: Fraction
+    currency: str
+    # Set when FX conversion was applied (currency != original_currency)
+    original_amount: Optional[Fraction] = None
+    original_currency: Optional[str] = None
+    share_price: Optional[Fraction] = None  # rate: 1 original_currency = share_price CAD
+
+
+@dataclass
+class AccountBalanceResult:
+    """Result of the account-balance use case."""
+    as_of: date
+    balances: List[AccountBalance] = field(default_factory=list)
+    consolidated_cad: Optional[Fraction] = None  # set when fx_rates provided
+
+
+def _get_account_path(account) -> str:
+    """Build full colon-separated path for an account."""
+    parts = []
+    acc = account
+    while acc is not None and not acc.is_root():
+        parts.append(acc.GetName())
+        acc = acc.get_parent()
+    parts.reverse()
+    return ":".join(parts)
+
+
+def _is_leaf(account) -> bool:
+    """Return True if account has no children."""
+    return len(account.get_children_sorted()) == 0
+
+
+def _walk_leaves(account, prefix: Optional[str] = None):
+    """Yield all leaf accounts under account, optionally filtered by prefix."""
+    if _is_leaf(account):
+        path = _get_account_path(account)
+        if prefix is None or path == prefix or path.startswith(prefix + ":"):
+            yield account
+    else:
+        for child in account.get_children_sorted():
+            yield from _walk_leaves(child, prefix)
+
+
+class AccountBalanceUseCase:
+    """
+    Compute account balances as of a given date.
+
+    Opens the GnuCash file, iterates leaf accounts (optionally filtered by
+    account_prefix), and returns their balances.
+
+    Without fx_rates: read-only, each account in its own currency.
+    With fx_rates: opens in NORMAL mode, writes new pricedb entries for any
+    currency whose rate differs from the current pricedb latest, then returns
+    balances in CAD.
+    """
+
+    def __init__(self, repository: GnuCashRepository):
+        self.repository = repository
+
+    def execute(
+        self,
+        as_of: date,
+        account_prefix: Optional[str] = None,
+        fx_rates: Optional[FxRates] = None,
+    ) -> AccountBalanceResult:
+        """
+        Compute balances as of the given date.
+
+        Args:
+            as_of: Balance date (balances include transactions on this date)
+            account_prefix: Colon-separated account prefix to filter (e.g. "Assets:Bank")
+                            None means all accounts
+            fx_rates: If provided, consolidate to CAD and update pricedb as needed
+
+        Returns:
+            AccountBalanceResult with list of AccountBalance entries
+        """
+        root = self.repository.get_root_account()
+        result = AccountBalanceResult(as_of=as_of)
+
+        total_cad = Fraction(0)
+
+        for account in _walk_leaves(root, account_prefix):
+            commodity = account.GetCommodity()
+            currency = commodity.get_mnemonic()
+
+            # Sum all splits whose transaction date is <= as_of.
+            # Uses split.GetValue() (proven to work in income_statement service).
+            balance = Fraction(0)
+            for split in account.GetSplitList():
+                tx = split.GetParent()
+                tx_date_raw = tx.GetDate()
+                tx_date = date(tx_date_raw.year, tx_date_raw.month, tx_date_raw.day)
+                if tx_date <= as_of:
+                    value = split.GetValue()
+                    balance += Fraction(value.num(), value.denom())
+
+            if fx_rates is not None:
+                # Consolidate to CAD; record original amount and rate for display
+                rate_frac = Fraction(fx_rates.get_rate(currency)).limit_denominator(1_000_000)
+                cad_amount = balance * rate_frac
+                total_cad += cad_amount
+                path = _get_account_path(account)
+                if currency == "CAD":
+                    result.balances.append(AccountBalance(
+                        account_path=path,
+                        amount=cad_amount,
+                        currency="CAD",
+                    ))
+                else:
+                    result.balances.append(AccountBalance(
+                        account_path=path,
+                        amount=cad_amount,
+                        currency="CAD",
+                        original_amount=balance,
+                        original_currency=currency,
+                        share_price=rate_frac,
+                    ))
+            else:
+                result.balances.append(AccountBalance(
+                    account_path=_get_account_path(account),
+                    amount=balance,
+                    currency=currency,
+                ))
+
+        if fx_rates is not None:
+            result.consolidated_cad = total_cad
+
+        return result
+
+    def update_pricedb(self, fx_rates: FxRates, price_date: date) -> None:
+        """
+        Sync fx_rates into GnuCash pricedb.
+
+        For each currency in fx_rates (other than CAD), compare against the
+        pricedb latest rate. If different or missing, write a new price entry
+        dated price_date.
+
+        Args:
+            fx_rates: FxRates instance with currency→CAD rates
+            price_date: Date to use for new price entries (always today)
+        """
+        import calendar
+        import ctypes
+        import time
+
+        from gnucash import GncNumeric
+        from gnucash.gnucash_core_c import (
+            PRICE_SOURCE_USER_PRICE,
+            gnc_price_create,
+            gnc_price_set_commodity,
+            gnc_price_set_currency,
+            gnc_price_set_source,
+            gnc_price_set_time64,
+            gnc_price_set_typestr,
+            gnc_price_set_value,
+            gnc_pricedb_add_price,
+            gnc_pricedb_get_db,
+            gnc_pricedb_lookup_latest,
+        )
+
+        from infrastructure.gnucash.engine import GncNumericC, load_gnc_engine
+
+        book = self.repository.book
+        book_instance = book.instance
+        commod_table = book.get_table()
+        cad_commodity = commod_table.lookup("CURRENCY", "CAD")
+        pricedb = gnc_pricedb_get_db(book_instance)
+
+        # gnc_price_get_value returns gnc_numeric by value; SWIG wraps it as an
+        # opaque int on some platforms. Use ctypes with GncNumericC to read it.
+        lib = load_gnc_engine()
+        lib.gnc_price_get_value.restype = GncNumericC
+        lib.gnc_price_get_value.argtypes = [ctypes.c_void_p]
+
+        # time64 for price_date (noon UTC)
+        price_struct = time.struct_time((
+            price_date.year, price_date.month, price_date.day,
+            12, 0, 0, 0, 0, 0,
+        ))
+        price_time64 = calendar.timegm(price_struct)
+
+        for currency_code in sorted(fx_rates.available_currencies):
+            if currency_code == "CAD":
+                continue
+
+            commodity = commod_table.lookup("CURRENCY", currency_code)
+            if commodity is None:
+                continue
+
+            new_rate = fx_rates.get_rate(currency_code)
+
+            # Compare against existing latest price to avoid duplicate entries
+            existing = gnc_pricedb_lookup_latest(pricedb, commodity.instance, cad_commodity.instance)
+            needs_update = True
+            if existing is not None:
+                existing_val = lib.gnc_price_get_value(int(existing))
+                if existing_val.denom != 0:
+                    existing_rate = existing_val.num / existing_val.denom
+                    if abs(existing_rate - new_rate) < 1e-9:
+                        needs_update = False
+
+            if needs_update:
+                frac = Fraction(new_rate).limit_denominator(1_000_000)
+                gnc_val = GncNumeric(frac.numerator, frac.denominator)
+
+                price = gnc_price_create(book_instance)
+                # commodity/currency/value require raw SwigPyObject (.instance)
+                gnc_price_set_commodity(price, commodity.instance)
+                gnc_price_set_currency(price, cad_commodity.instance)
+                gnc_price_set_time64(price, price_time64)
+                gnc_price_set_source(price, PRICE_SOURCE_USER_PRICE)
+                gnc_price_set_typestr(price, "last")
+                gnc_price_set_value(price, gnc_val.instance)
+                gnc_pricedb_add_price(pricedb, price)

--- a/use_cases/account_balance.py
+++ b/use_cases/account_balance.py
@@ -1,14 +1,24 @@
 """
 Use case for computing account balances as of a given date.
 
-Outputs balances in a `balance` directive format:
+Output format (balance directive):
 
     YYYY-MM-DD balance
         Account:Path  Amount Currency
 
-Without --fx-rates: each leaf account is output in its own commodity currency.
-With --fx-rates: consolidates all leaf accounts to CAD using the provided rates,
-writing new price entries to the pricedb when rates differ from the current latest.
+No account_prefix:
+    All accounts in the book (parent + leaf), each with its recursive cumulative
+    balance.  Mixed-currency subtrees fall back to GnuCash pricedb for conversion;
+    MissingFxRateError is raised when no rate source is available.
+
+With account_prefix (no --with-children):
+    Only the matched account with its recursive cumulative balance.
+
+With account_prefix + include_children=True (--with-children):
+    The matched account and all sub-accounts, each with their recursive balance.
+
+FX rate lookup order: explicit yaml -> GnuCash pricedb -> MissingFxRateError.
+With --fx-rates: pricedb is updated for changed rates before balances are computed.
 """
 
 from dataclasses import dataclass, field
@@ -17,7 +27,7 @@ from fractions import Fraction
 from typing import List, Optional
 
 from repositories.gnucash_repository import GnuCashRepository
-from services.fx_rates import FxRates
+from services.fx_rates import FxRates, MissingFxRateError
 
 
 @dataclass
@@ -26,7 +36,7 @@ class AccountBalance:
     account_path: str
     amount: Fraction
     currency: str
-    # Set when FX conversion was applied (currency != original_currency)
+    # Set when FX conversion was applied on a non-CAD leaf account
     original_amount: Optional[Fraction] = None
     original_currency: Optional[str] = None
     share_price: Optional[Fraction] = None  # rate: 1 original_currency = share_price CAD
@@ -37,8 +47,14 @@ class AccountBalanceResult:
     """Result of the account-balance use case."""
     as_of: date
     balances: List[AccountBalance] = field(default_factory=list)
-    consolidated_cad: Optional[Fraction] = None  # set when fx_rates provided
+    # Sum of the top-level shown account(s) in CAD when fx_rates provided.
+    # No prefix: sum of all root-level accounts. With prefix: balance of matched account.
+    consolidated_cad: Optional[Fraction] = None
 
+
+# ---------------------------------------------------------------------------
+# Account tree helpers
+# ---------------------------------------------------------------------------
 
 def _get_account_path(account) -> str:
     """Build full colon-separated path for an account."""
@@ -56,101 +72,280 @@ def _is_leaf(account) -> bool:
     return len(account.get_children_sorted()) == 0
 
 
-def _walk_leaves(account, prefix: Optional[str] = None):
-    """Yield all leaf accounts under account, optionally filtered by prefix."""
-    if _is_leaf(account):
-        path = _get_account_path(account)
-        if prefix is None or path == prefix or path.startswith(prefix + ":"):
-            yield account
-    else:
-        for child in account.get_children_sorted():
-            yield from _walk_leaves(child, prefix)
+def _collect_accounts(account, result: list) -> None:
+    """Append account and all descendants to result (DFS, parent before children)."""
+    result.append(account)
+    for child in account.get_children_sorted():
+        _collect_accounts(child, result)
 
+
+def _find_account(root, path: str):
+    """Find account by exact path from root. Returns None if not found."""
+    for child in root.get_children_sorted():
+        child_path = _get_account_path(child)
+        if child_path == path:
+            return child
+        if path.startswith(child_path + ":"):
+            found = _find_account(child, path)
+            if found is not None:
+                return found
+    return None
+
+
+def _get_accounts_to_display(root, prefix: Optional[str], include_children: bool) -> list:
+    """
+    Return ordered list of accounts to display.
+
+    No prefix:
+        All accounts in the book (DFS, parent before children).
+        include_children is ignored.
+
+    With prefix + include_children=False (default):
+        Only the matched account.
+
+    With prefix + include_children=True (--with-children):
+        The matched account and all descendants.
+    """
+    if prefix is None:
+        result = []
+        for child in root.get_children_sorted():
+            _collect_accounts(child, result)
+        return result
+
+    target = _find_account(root, prefix)
+    if target is None:
+        return []
+
+    if include_children:
+        result = []
+        _collect_accounts(target, result)
+        return result
+    else:
+        return [target]
+
+
+def _get_all_currencies(account) -> set:
+    """Return the set of all commodity mnemonics in this account's subtree."""
+    currencies = {account.GetCommodity().get_mnemonic()}
+    for child in account.get_children_sorted():
+        currencies |= _get_all_currencies(child)
+    return currencies
+
+
+def _get_direct_balance(account, as_of: date) -> Fraction:
+    """Sum splits directly in this account (not children) up to and including as_of."""
+    balance = Fraction(0)
+    for split in account.GetSplitList():
+        tx = split.GetParent()
+        tx_date_raw = tx.GetDate()
+        tx_date_obj = date(tx_date_raw.year, tx_date_raw.month, tx_date_raw.day)
+        if tx_date_obj <= as_of:
+            value = split.GetValue()
+            balance += Fraction(value.num(), value.denom())
+    return balance
+
+
+def _get_recursive_balance_cad(account, as_of: date, get_rate) -> Fraction:
+    """
+    Recursively sum all balances in the account's subtree, converting each to CAD.
+
+    get_rate(currency: str) -> Fraction raises MissingFxRateError if unavailable.
+    """
+    currency = account.GetCommodity().get_mnemonic()
+    total = _get_direct_balance(account, as_of) * get_rate(currency)
+    for child in account.get_children_sorted():
+        total += _get_recursive_balance_cad(child, as_of, get_rate)
+    return total
+
+
+def _get_recursive_balance_native(account, as_of: date) -> Fraction:
+    """
+    Recursively sum all balances in the account's subtree without currency conversion.
+
+    Only correct when the entire subtree uses the same currency.
+    """
+    total = _get_direct_balance(account, as_of)
+    for child in account.get_children_sorted():
+        total += _get_recursive_balance_native(child, as_of)
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Use case
+# ---------------------------------------------------------------------------
 
 class AccountBalanceUseCase:
     """
     Compute account balances as of a given date.
 
-    Opens the GnuCash file, iterates leaf accounts (optionally filtered by
-    account_prefix), and returns their balances.
+    No account_prefix:
+        Shows all accounts in the book with recursive cumulative balances.
+        Raises MissingFxRateError when mixed-currency subtrees have no rate source.
 
-    Without fx_rates: read-only, each account in its own currency.
-    With fx_rates: opens in NORMAL mode, writes new pricedb entries for any
-    currency whose rate differs from the current pricedb latest, then returns
-    balances in CAD.
+    With account_prefix (include_children=False, default):
+        Shows only the matched account with its recursive cumulative balance.
+
+    With account_prefix + include_children=True (--with-children):
+        Shows the matched account and all sub-accounts, each with recursive balance.
+
+    With fx_rates:
+        All balances consolidated to CAD. Call update_pricedb() before execute()
+        to write any changed rates to the GnuCash pricedb.
     """
 
     def __init__(self, repository: GnuCashRepository):
         self.repository = repository
+
+    def _build_pricedb_rate_fn(self):
+        """
+        Build a rate function that reads FX rates from the GnuCash pricedb.
+
+        Raises MissingFxRateError when no pricedb entry exists for a currency.
+        """
+        import ctypes
+
+        from gnucash.gnucash_core_c import gnc_pricedb_get_db, gnc_pricedb_lookup_latest
+
+        from infrastructure.gnucash.engine import GncNumericC, load_gnc_engine
+
+        book = self.repository.book
+        commod_table = book.get_table()
+        cad_commodity = commod_table.lookup("CURRENCY", "CAD")
+        pricedb = gnc_pricedb_get_db(book.instance)
+
+        lib = load_gnc_engine()
+        lib.gnc_price_get_value.restype = GncNumericC
+        lib.gnc_price_get_value.argtypes = [ctypes.c_void_p]
+
+        def get_rate(currency: str) -> Fraction:
+            if currency == "CAD":
+                return Fraction(1)
+            commodity = commod_table.lookup("CURRENCY", currency)
+            if commodity is None:
+                raise MissingFxRateError(
+                    f"Currency {currency} not found in GnuCash commodity table"
+                )
+            existing = gnc_pricedb_lookup_latest(
+                pricedb, commodity.instance, cad_commodity.instance
+            )
+            if existing is None:
+                raise MissingFxRateError(
+                    f"No FX rate for {currency} -> CAD in GnuCash pricedb. "
+                    f"Provide rates via --fx-rates."
+                )
+            val = lib.gnc_price_get_value(int(existing))
+            if val.denom == 0:
+                raise MissingFxRateError(f"Invalid pricedb entry for {currency} -> CAD")
+            return Fraction(val.num, val.denom).limit_denominator(1_000_000)
+
+        return get_rate
 
     def execute(
         self,
         as_of: date,
         account_prefix: Optional[str] = None,
         fx_rates: Optional[FxRates] = None,
+        include_children: bool = False,
     ) -> AccountBalanceResult:
         """
         Compute balances as of the given date.
 
         Args:
-            as_of: Balance date (balances include transactions on this date)
-            account_prefix: Colon-separated account prefix to filter (e.g. "Assets:Bank")
-                            None means all accounts
-            fx_rates: If provided, consolidate to CAD and update pricedb as needed
+            as_of:           Balance date (inclusive).
+            account_prefix:  Exact account path to query (e.g. "Assets:Bank").
+                             None = all accounts in the book.
+            fx_rates:        When provided, convert all amounts to CAD.
+            include_children: Only relevant when account_prefix is given.
+                             False (default) = show only the matched account.
+                             True (--with-children) = show matched account + all sub-accounts.
 
         Returns:
-            AccountBalanceResult with list of AccountBalance entries
+            AccountBalanceResult with ordered list of AccountBalance entries.
         """
         root = self.repository.get_root_account()
         result = AccountBalanceResult(as_of=as_of)
 
-        total_cad = Fraction(0)
+        accounts = _get_accounts_to_display(root, account_prefix, include_children)
 
-        for account in _walk_leaves(root, account_prefix):
-            commodity = account.GetCommodity()
-            currency = commodity.get_mnemonic()
+        # Raise early when the prefix names an account that doesn't exist
+        if account_prefix is not None and not accounts:
+            raise ValueError(f"Account not found: {account_prefix!r}")
 
-            # Sum all splits whose transaction date is <= as_of.
-            # Uses split.GetValue() (proven to work in income_statement service).
-            balance = Fraction(0)
-            for split in account.GetSplitList():
-                tx = split.GetParent()
-                tx_date_raw = tx.GetDate()
-                tx_date = date(tx_date_raw.year, tx_date_raw.month, tx_date_raw.day)
-                if tx_date <= as_of:
-                    value = split.GetValue()
-                    balance += Fraction(value.num(), value.denom())
+        # Rate function from explicit yaml fx_rates
+        explicit_rate_fn = None
+        if fx_rates is not None:
+            def explicit_rate_fn(currency: str) -> Fraction:
+                return Fraction(fx_rates.get_rate(currency)).limit_denominator(1_000_000)
+
+        # Pricedb rate function, built lazily on first multi-currency account encountered
+        pricedb_rate_fn = None
+
+        # Accumulators for consolidated_cad (avoids recomputing after the loop)
+        first_account_cad: Optional[Fraction] = None   # with prefix: matched account balance
+        top_level_cad = Fraction(0)                     # no prefix: sum of root children
+
+        for account in accounts:
+            currency = account.GetCommodity().get_mnemonic()
+            all_currencies = _get_all_currencies(account)
+            needs_fx = len(all_currencies) > 1
 
             if fx_rates is not None:
-                # Consolidate to CAD; record original amount and rate for display
-                rate_frac = Fraction(fx_rates.get_rate(currency)).limit_denominator(1_000_000)
-                cad_amount = balance * rate_frac
-                total_cad += cad_amount
-                path = _get_account_path(account)
-                if currency == "CAD":
+                # Explicit FX: always output in CAD
+                cad_balance = _get_recursive_balance_cad(account, as_of, explicit_rate_fn)
+
+                # Track for consolidated_cad without a second traversal
+                if account_prefix is not None and first_account_cad is None:
+                    first_account_cad = cad_balance
+                if account_prefix is None and account.get_parent().is_root():
+                    top_level_cad += cad_balance
+
+                if _is_leaf(account) and currency != "CAD":
+                    # Non-CAD leaf: include original amount and exchange rate metadata
+                    direct = _get_direct_balance(account, as_of)
+                    rate = explicit_rate_fn(currency)
                     result.balances.append(AccountBalance(
-                        account_path=path,
-                        amount=cad_amount,
+                        account_path=_get_account_path(account),
+                        amount=cad_balance,
                         currency="CAD",
+                        original_amount=direct,
+                        original_currency=currency,
+                        share_price=rate,
                     ))
                 else:
                     result.balances.append(AccountBalance(
-                        account_path=path,
-                        amount=cad_amount,
+                        account_path=_get_account_path(account),
+                        amount=cad_balance,
                         currency="CAD",
-                        original_amount=balance,
-                        original_currency=currency,
-                        share_price=rate_frac,
                     ))
+
+            elif needs_fx:
+                # Multi-currency subtree without explicit fx_rates: try pricedb
+                if pricedb_rate_fn is None:
+                    pricedb_rate_fn = self._build_pricedb_rate_fn()
+                cad_balance = _get_recursive_balance_cad(account, as_of, pricedb_rate_fn)
+                result.balances.append(AccountBalance(
+                    account_path=_get_account_path(account),
+                    amount=cad_balance,
+                    currency="CAD",
+                ))
+
             else:
+                # Single currency, no FX needed
+                balance = _get_recursive_balance_native(account, as_of)
                 result.balances.append(AccountBalance(
                     account_path=_get_account_path(account),
                     amount=balance,
                     currency=currency,
                 ))
 
+        # consolidated_cad: balance of the top-level shown account(s) in CAD.
+        # With prefix: balance of the matched account.
+        # No prefix: sum of all root-level account balances.
         if fx_rates is not None:
-            result.consolidated_cad = total_cad
+            if account_prefix is not None:
+                result.consolidated_cad = first_account_cad or Fraction(0)
+            else:
+                result.consolidated_cad = top_level_cad
 
         return result
 
@@ -163,7 +358,7 @@ class AccountBalanceUseCase:
         dated price_date.
 
         Args:
-            fx_rates: FxRates instance with currency→CAD rates
+            fx_rates:   FxRates instance with currency->CAD rates
             price_date: Date to use for new price entries (always today)
         """
         import calendar
@@ -217,7 +412,9 @@ class AccountBalanceUseCase:
             new_rate = fx_rates.get_rate(currency_code)
 
             # Compare against existing latest price to avoid duplicate entries
-            existing = gnc_pricedb_lookup_latest(pricedb, commodity.instance, cad_commodity.instance)
+            existing = gnc_pricedb_lookup_latest(
+                pricedb, commodity.instance, cad_commodity.instance
+            )
             needs_update = True
             if existing is not None:
                 existing_val = lib.gnc_price_get_value(int(existing))


### PR DESCRIPTION
Implements the `account-balance` CLI command that outputs account balances as of a given date in balance directive format.

Changes:
- use_cases/account_balance.py: AccountBalanceUseCase that iterates leaf accounts, sums splits with tx_date <= as_of, and optionally consolidates to CAD via fx_rates. update_pricedb() uses ctypes + GncNumericC to read the current pricedb rate and only writes a new entry when the rate differs, preventing pricedb bloat.
- cli/account_balance_cmd.py: Click command with gnucash_file + optional account_prefix args, --as-of / --fx-rates / -o options. Opens READ_ONLY without fx_rates, NORMAL with fx_rates. Renders share_price/original metadata for FX-converted accounts matching the transaction plaintext format.
- cli/main.py: Register account-balance command.
- tests/fixtures/account_balance_test_data.txt: Plaintext fixture covering all 5 account types (Asset, Liability, Equity, Income, Expense) in CAD and HKD, with sub-accounts under Expenses:Food and Income:HKDIncome.
- tests/conftest.py: temp_gnucash_account_balance fixture loading the above file via ImportTransactionsUseCase.
- tests/unit/use_cases/test_account_balance.py: 11 unit tests (prefix filter, as-of date cutoff, leaf-only, FX consolidation, consolidated_cad total).
- tests/integration/test_cli_account_balance.py: 16 integration tests (error cases, output format, FX rates conversion with share_price/original lines).
- README.md: Document account-balance command with format and examples.