### PR TITLE
fix: --strategy update fails on missing or unmatched GUID (atomic)

### DIFF
--- a/tests/unit/use_cases/test_import_update.py
+++ b/tests/unit/use_cases/test_import_update.py
@@ -3,8 +3,8 @@ Tests for ImportTransactionsUseCase with ResolutionStrategy.UPDATE
 
 Verifies the full import_from_file() flow when UPDATE strategy is used:
 - Transactions matched by GUID are updated in-place (GUID preserved)
-- Transactions without a GUID in the plaintext follow normal conflict detection
-- Transactions with a GUID not present in the book are created as new
+- Transactions without a GUID in the plaintext raise ValueError immediately
+- Transactions with a GUID not present in the book raise ValueError immediately
 - Stable roundtrip: export → re-import with UPDATE → no phantom duplicates
 
 These tests use real GnuCash files (no mocks), running in Docker.
@@ -278,19 +278,17 @@ class TestImportUpdateByGuid:
         assert result.skipped_count == 1
         assert result.imported_count == 0
 
-    def test_unknown_guid_creates_new_transaction(self, gnucash_with_exportable_transaction):
+    def test_unknown_guid_raises_error(self, gnucash_with_exportable_transaction):
         """
-        A GUID in the plaintext that does not exist in the book creates a new transaction.
+        A GUID in the plaintext that does not exist in the book raises ValueError.
+        --strategy update must not silently create a new transaction.
         """
-        from gnucash import Query, Transaction
-
         from repositories.gnucash_repository import GnuCashRepository
         from services.conflict_resolver import ResolutionStrategy
         from use_cases.import_transactions import ImportTransactionsUseCase
 
         path, _existing_guid = gnucash_with_exportable_transaction
 
-        # Use a fabricated GUID that does not exist in the book
         fake_guid = 'a' * 32
 
         plaintext = (
@@ -310,29 +308,17 @@ class TestImportUpdateByGuid:
             repo.open()
             try:
                 uc = ImportTransactionsUseCase(repo)
-                result = uc.import_from_file(pt_path, ResolutionStrategy.UPDATE)
-                repo.save()
+                with pytest.raises(ValueError, match="not found in book"):
+                    uc.import_from_file(pt_path, ResolutionStrategy.UPDATE)
             finally:
                 repo.close()
         finally:
             os.unlink(pt_path)
 
-        assert result.imported_count == 1
-        assert result.updated_count == 0
-
-        session = _open_session(path)
-        book = session.book
-        q = Query()
-        q.search_for('Trans')
-        q.set_book(book)
-        txs = [Transaction(instance=t) for t in q.run()]
-        assert len(txs) == 2  # original + new
-        session.end()
-
-    def test_no_guid_in_plaintext_uses_signature_matching(self, gnucash_with_exportable_transaction):
+    def test_no_guid_in_plaintext_raises_error(self, gnucash_with_exportable_transaction):
         """
-        Without a GUID in the plaintext, normal signature-based duplicate detection applies.
-        Same date+accounts+amounts → duplicate (skipped).
+        --strategy update requires a guid: field on every transaction.
+        Omitting it raises ValueError immediately.
         """
         from repositories.gnucash_repository import GnuCashRepository
         from services.conflict_resolver import ResolutionStrategy
@@ -340,7 +326,6 @@ class TestImportUpdateByGuid:
 
         path, _guid = gnucash_with_exportable_transaction
 
-        # Plaintext with no guid: matches existing by date+accounts+amounts
         plaintext = (
             '2024-05-10 commodity CAD\n'
             '\tmnemonic: "CAD"\n'
@@ -357,16 +342,12 @@ class TestImportUpdateByGuid:
             repo.open()
             try:
                 uc = ImportTransactionsUseCase(repo)
-                result = uc.import_from_file(pt_path, ResolutionStrategy.UPDATE)
+                with pytest.raises(ValueError, match="guid:"):
+                    uc.import_from_file(pt_path, ResolutionStrategy.UPDATE)
             finally:
                 repo.close()
         finally:
             os.unlink(pt_path)
-
-        # Signature match, no guid → goes through normal duplicate detection → skipped
-        assert result.imported_count == 0
-        assert result.updated_count == 0
-        assert result.skipped_count == 1
 
 
 class TestStableRoundtrip:

--- a/use_cases/import_transactions.py
+++ b/use_cases/import_transactions.py
@@ -274,25 +274,49 @@ class ImportTransactionsUseCase:
 
         # Step 3: Import transactions with duplicate detection
         existing_transactions = self.repository.get_all_transactions()
+        existing_guid_map = {tx.GetGUID().to_string(): tx for tx in existing_transactions}
+
+        # UPDATE strategy: validate ALL transactions before applying ANY update.
+        # This ensures atomicity: either the whole file is valid and all updates
+        # are applied, or we fail before touching the book.
+        if resolution_strategy == ResolutionStrategy.UPDATE:
+            tx_directives = [
+                child for child in parser.root_directive.children
+                if child.type == DirectiveType.TRANSACTION
+            ]
+            for child in tx_directives:
+                if 'guid' not in child.metadata:
+                    date_str = child.props.get('date', '?')
+                    desc = child.props.get('description', '?')
+                    raise ValueError(
+                        f"--strategy update requires a guid: field on every transaction "
+                        f"(transaction on {date_str} \"{desc}\" has none)"
+                    )
+                guid = child.metadata['guid']
+                if guid not in existing_guid_map:
+                    raise ValueError(f"Transaction GUID {guid!r} not found in book")
+
+            for child in tx_directives:
+                guid = child.metadata['guid']
+                existing_tx = existing_guid_map[guid]
+                try:
+                    importer.update_transaction(existing_tx, child, book)
+                    result.updated_count += 1
+                except Exception as e:
+                    logging.error(f"Failed to update transaction {guid}: {e}")
+                    result.errors.append({'transaction': child.props, 'error': str(e)})
+                    result.error_count += 1
+            return result
 
         for child in parser.root_directive.children:
             if child.type == DirectiveType.TRANSACTION:
                 try:
-                    # Check for match by GUID if present
+                    # Check for match by GUID if present (non-UPDATE strategies)
                     if 'guid' in child.metadata:
                         guid = child.metadata['guid']
-                        existing_tx = next(
-                            (tx for tx in existing_transactions
-                             if tx.GetGUID().to_string() == guid),
-                            None
-                        )
-                        if existing_tx is not None:
-                            if resolution_strategy == ResolutionStrategy.UPDATE:
-                                importer.update_transaction(existing_tx, child, book)
-                                result.updated_count += 1
-                            else:
-                                logging.info(f"Skipping duplicate transaction with GUID {guid}")
-                                result.skipped_count += 1
+                        if guid in existing_guid_map:
+                            logging.info(f"Skipping duplicate transaction with GUID {guid}")
+                            result.skipped_count += 1
                             continue
 
                     # Check for duplicate by date/accounts signature


### PR DESCRIPTION
Previously, import --strategy update would silently create a new transaction when either:
  1. The incoming transaction had no guid: field, or
  2. The guid: value did not match any existing transaction in the book.

This caused unintended duplicates when users forgot or mistyped the GUID.

Fix — two-pass approach for atomicity:
- Pass 1 (validation): iterate all transaction directives in the file and raise ValueError immediately if any transaction lacks a guid: field or if any GUID is not found in the book. No changes are applied yet.
- Pass 2 (apply): only reached when all GUIDs are valid. Apply all updates and return early. Non-UPDATE strategies are unaffected.

A guid→transaction map (existing_guid_map) is built once from existing transactions, used for O(1) lookups in both the UPDATE validation/apply passes and the non-UPDATE GUID-skip check (replacing the O(n) linear scan for each transaction).

- tests/unit/use_cases/test_import_update.py: update module docstring; test_unknown_guid_raises_error and test_no_guid_in_plaintext_raises_error now assert ValueError is raised (replacing the previous tests that asserted silent-create behaviour).