### PR TITLE
Add delete-transaction-by-guid command

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,48 @@ gnucash-plaintext export-transaction mybook.gnucash --guid 317c8ae6e0084c33951d0
 
 `--guid` is required. Omitting it prints an error with usage guidance.
 
+### Delete a transaction by GUID
+
+Delete a single transaction permanently. The transaction is exported to plaintext **before** deletion so you always have a backup copy:
+
+```bash
+# Delete and print backup to stdout
+gnucash-plaintext delete-transaction-by-guid mybook.gnucash 317c8ae6e0084c33951d052b9f1b9f23
+
+# Delete and save backup to a file
+gnucash-plaintext delete-transaction-by-guid mybook.gnucash 317c8ae6e0084c33951d052b9f1b9f23 -o backup.txt
+```
+
+The command fails immediately (non-zero exit) if the GUID is not found — it will never silently do nothing.
+
+The backup plaintext is self-contained (commodity + account declarations + transaction) and looks like this:
+
+```
+2024-06-15 commodity CAD
+	mnemonic: "CAD"
+	fullname: "Canadian Dollar"
+	namespace: "CURRENCY"
+	fraction: 100
+2024-06-15 account Assets:Checking
+	commodity: "CAD"
+	type: "BANK"
+2024-06-15 account Expenses:Dining
+	commodity: "CAD"
+	type: "EXPENSE"
+2024-06-15 * "Dinner out"
+	guid: "317c8ae6e0084c33951d052b9f1b9f23"
+	Assets:Checking  -45.00 CAD
+	Expenses:Dining  45.00 CAD
+```
+
+**Undo:** re-import the backup plaintext to restore the transaction:
+
+```bash
+gnucash-plaintext import mybook.gnucash -f backup.txt
+```
+
+Only transactions are deleted. Accounts and commodities are not affected.
+
 ### Export GnuCash to GnuCash-Beancount format
 
 Export to [GnuCash-Beancount](docs/gnucash-beancount-format.md) format:
@@ -449,8 +491,11 @@ export → edit plaintext → re-import --strategy update → export again …
 Each re-import finds the same GUID and updates the same transaction. No phantom
 duplicates are created regardless of how many times you repeat the cycle.
 
-Transactions in the plaintext file that have no `guid:` field, or whose GUID is not
-found in the book, follow normal duplicate/conflict detection as usual.
+**`--strategy update` is strict:** every transaction in the plaintext file must have a
+`guid:` field, and every GUID must match an existing transaction in the book. The command
+fails immediately if either condition is not met — it will never silently create a new
+transaction. All GUIDs are validated before any changes are applied, so a file with one
+bad GUID leaves the book untouched.
 
 **How conflicts are detected:**
 

--- a/cli/delete_transaction_cmd.py
+++ b/cli/delete_transaction_cmd.py
@@ -1,0 +1,85 @@
+"""
+CLI command for deleting a GnuCash transaction by GUID.
+
+The transaction is exported to plaintext before deletion so the user has a
+copy they can re-import to undo the operation:
+
+    gnucash-plaintext delete-transaction-by-guid ledger.gnucash <GUID> -o backup.txt
+    # ... inspect backup.txt ...
+    gnucash-plaintext import ledger.gnucash -f backup.txt
+
+Without -o, the plaintext backup is written to stdout before the confirmation
+message, so it can be piped or redirected independently.
+"""
+
+import sys
+
+import click
+
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from use_cases.delete_transaction import DeleteTransactionUseCase
+
+
+@click.command("delete-transaction-by-guid")
+@click.argument("gnucash_file", type=click.Path(exists=True))
+@click.argument("guid")
+@click.option(
+    "-o", "--output",
+    "output_file",
+    default=None,
+    type=click.Path(),
+    help="Save the pre-deletion plaintext backup to this file instead of stdout.",
+)
+def delete_transaction_by_guid(gnucash_file, guid, output_file):
+    """
+    Delete a transaction by GUID, exporting it first as a plaintext backup.
+
+    GUID must match an existing transaction in the book; the command fails
+    immediately if it does not. Only transactions are deleted — accounts and
+    commodities are not affected.
+
+    The deleted transaction is written as plaintext (to -o FILE or stdout)
+    before deletion so you can restore it with:
+
+    \b
+        gnucash-plaintext import GNUCASH_FILE -f BACKUP_FILE
+
+    \b
+    Examples:
+
+        Delete and print backup to stdout:
+          gnucash-plaintext delete-transaction-by-guid ledger.gnucash 317c8ae6e0084c33951d052b9f1b9f23
+
+        Delete and save backup to file:
+          gnucash-plaintext delete-transaction-by-guid ledger.gnucash 317c8ae6e0084c33951d052b9f1b9f23 -o backup.txt
+    """
+    repo = GnuCashRepository(gnucash_file)
+    repo.open(mode=SessionMode.NORMAL)
+    try:
+        use_case = DeleteTransactionUseCase(repo)
+        try:
+            result = use_case.execute(guid)
+        except ValueError as e:
+            raise click.ClickException(str(e)) from e
+
+        # Write backup before saving so the user always has it even on save error
+        if output_file:
+            with open(output_file, "w", encoding="utf-8") as f:
+                f.write(result.plaintext)
+            click.echo(f"Backup written to {output_file}")
+        else:
+            sys.stdout.write(result.plaintext)
+
+        try:
+            repo.save()
+        except Exception as e:
+            if "ERR_FILEIO_BACKUP_ERROR" not in str(e):
+                raise click.ClickException(f"Failed to save: {e}") from e
+
+        click.echo(
+            f"Deleted transaction {result.guid} "
+            f"({result.date} \"{result.description}\")",
+            err=True,
+        )
+    finally:
+        repo.close()

--- a/cli/main.py
+++ b/cli/main.py
@@ -9,6 +9,7 @@ import click
 
 from cli.account_balance_cmd import account_balance
 from cli.close_books_cmd import close_books
+from cli.delete_transaction_cmd import delete_transaction_by_guid
 from cli.export_beancount_cmd import export_beancount
 from cli.export_cmd import export_transactions
 from cli.export_transaction_cmd import export_transaction
@@ -62,6 +63,7 @@ cli.add_command(export_transaction, name='export-transaction')
 cli.add_command(income_statement, name='income-statement')
 cli.add_command(print_invoice, name='print-invoice')
 cli.add_command(account_balance, name='account-balance')
+cli.add_command(delete_transaction_by_guid, name='delete-transaction-by-guid')
 
 
 if __name__ == '__main__':

--- a/tests/integration/test_cli_delete_transaction.py
+++ b/tests/integration/test_cli_delete_transaction.py
@@ -1,0 +1,189 @@
+"""
+Integration tests for the delete-transaction-by-guid CLI command.
+
+Verifies:
+- Valid GUID: transaction deleted, backup written to stdout or -o file
+- Unknown GUID: non-zero exit, clear error message
+- Backup plaintext can be re-imported to restore the transaction
+"""
+
+import os
+import tempfile
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+
+def _make_gnucash_with_transaction():
+    """Return (path, guid) for a GnuCash file containing one CAD transaction."""
+    fd, path = tempfile.mkstemp(suffix='.gnucash')
+    os.close(fd)
+    os.unlink(path)
+
+    import gnucash
+    from gnucash import Account, GncNumeric, Session, Split, Transaction
+
+    try:
+        from gnucash import SessionOpenMode
+        session = Session(f'xml://{path}', SessionOpenMode.SESSION_NEW_STORE)
+    except ImportError:
+        session = Session(f'xml://{path}', is_new=True)
+
+    book = session.book
+    root = book.get_root_account()
+    commod_table = book.get_table()
+    cad = commod_table.lookup('CURRENCY', 'CAD')
+
+    assets = Account(book)
+    assets.SetName('Assets')
+    assets.SetType(gnucash.ACCT_TYPE_ASSET)
+    assets.SetCommodity(cad)
+    root.append_child(assets)
+
+    checking = Account(book)
+    checking.SetName('Checking')
+    checking.SetType(gnucash.ACCT_TYPE_BANK)
+    checking.SetCommodity(cad)
+    assets.append_child(checking)
+
+    expenses = Account(book)
+    expenses.SetName('Expenses')
+    expenses.SetType(gnucash.ACCT_TYPE_EXPENSE)
+    expenses.SetCommodity(cad)
+    root.append_child(expenses)
+
+    dining = Account(book)
+    dining.SetName('Dining')
+    dining.SetType(gnucash.ACCT_TYPE_EXPENSE)
+    dining.SetCommodity(cad)
+    expenses.append_child(dining)
+
+    tx = Transaction(book)
+    tx.BeginEdit()
+    tx.SetCurrency(cad)
+    tx.SetDate(15, 6, 2024)
+    tx.SetDescription('Dinner out')
+
+    s1 = Split(book)
+    s1.SetParent(tx)
+    s1.SetAccount(dining)
+    s1.SetValue(GncNumeric(4500, 100))
+
+    s2 = Split(book)
+    s2.SetParent(tx)
+    s2.SetAccount(checking)
+    s2.SetValue(GncNumeric(-4500, 100))
+
+    tx.CommitEdit()
+    guid = tx.GetGUID().to_string()
+    session.save()
+    session.end()
+
+    return path, guid
+
+
+def run_cli(*args):
+    runner = CliRunner()
+    return runner.invoke(cli, ['delete-transaction-by-guid'] + list(args))
+
+
+class TestDeleteTransactionByGuidCli:
+
+    def test_unknown_guid_fails(self):
+        """Non-existent GUID exits non-zero with an error message."""
+        path, _guid = _make_gnucash_with_transaction()
+        try:
+            result = run_cli(path, 'a' * 32)
+            assert result.exit_code != 0
+            assert 'not found in book' in result.output
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_valid_guid_exits_zero(self):
+        """Valid GUID deletes the transaction and exits 0."""
+        path, guid = _make_gnucash_with_transaction()
+        try:
+            result = run_cli(path, guid)
+            assert result.exit_code == 0, result.output
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_backup_contains_guid(self):
+        """Stdout backup includes the transaction GUID."""
+        path, guid = _make_gnucash_with_transaction()
+        try:
+            result = run_cli(path, guid)
+            assert result.exit_code == 0, result.output
+            assert guid in result.output
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_output_file_flag(self, tmp_path):
+        """With -o, backup is written to file and stdout shows the file path."""
+        path, guid = _make_gnucash_with_transaction()
+        backup = str(tmp_path / 'backup.txt')
+        try:
+            result = run_cli(path, guid, '-o', backup)
+            assert result.exit_code == 0, result.output
+            assert 'Backup written to' in result.output
+            with open(backup) as f:
+                content = f.read()
+            assert guid in content
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_backup_is_reimportable(self, tmp_path):
+        """The backup plaintext can be re-imported to restore the deleted transaction."""
+        from gnucash import Query, Transaction
+
+        from repositories.gnucash_repository import GnuCashRepository
+        from services.conflict_resolver import ResolutionStrategy
+        from use_cases.import_transactions import ImportTransactionsUseCase
+
+        path, guid = _make_gnucash_with_transaction()
+        backup = str(tmp_path / 'backup.txt')
+        try:
+            # Delete with backup
+            result = run_cli(path, guid, '-o', backup)
+            assert result.exit_code == 0, result.output
+
+            # Wait 1s so the re-import save gets a different backup filename
+            import time
+            time.sleep(1)
+
+            # Re-import backup
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                uc = ImportTransactionsUseCase(repo)
+                import_result = uc.import_from_file(backup, ResolutionStrategy.SKIP)
+                repo.save()
+            finally:
+                repo.close()
+
+            assert import_result.imported_count == 1
+
+            # Verify transaction is back in the book
+            try:
+                from gnucash import Session, SessionOpenMode
+                session = Session(f'xml://{path}', SessionOpenMode.SESSION_NORMAL_OPEN)
+            except ImportError:
+                from gnucash import Session
+                session = Session(f'xml://{path}')
+            book = session.book
+            q = Query()
+            q.search_for('Trans')
+            q.set_book(book)
+            txs = [Transaction(instance=t) for t in q.run()]
+            assert len(txs) == 1
+            assert txs[0].GetDescription() == 'Dinner out'
+            session.end()
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)

--- a/tests/unit/use_cases/test_delete_transaction.py
+++ b/tests/unit/use_cases/test_delete_transaction.py
@@ -1,0 +1,184 @@
+"""
+Unit tests for DeleteTransactionUseCase.
+
+Verifies:
+- Transaction is deleted by GUID
+- Plaintext backup is included in the result (for undo)
+- Unknown GUID raises ValueError
+- Deletion is confirmed (transaction no longer in book after execute)
+"""
+
+import os
+import tempfile
+
+import pytest
+
+
+def _make_gnucash_with_transaction():
+    """Return (path, guid) for a GnuCash file containing one CAD transaction."""
+    fd, path = tempfile.mkstemp(suffix='.gnucash')
+    os.close(fd)
+    os.unlink(path)
+
+    import gnucash
+    from gnucash import Account, GncNumeric, Session, Split, Transaction
+
+    try:
+        from gnucash import SessionOpenMode
+        session = Session(f'xml://{path}', SessionOpenMode.SESSION_NEW_STORE)
+    except ImportError:
+        session = Session(f'xml://{path}', is_new=True)
+
+    book = session.book
+    root = book.get_root_account()
+    commod_table = book.get_table()
+    cad = commod_table.lookup('CURRENCY', 'CAD')
+
+    assets = Account(book)
+    assets.SetName('Assets')
+    assets.SetType(gnucash.ACCT_TYPE_ASSET)
+    assets.SetCommodity(cad)
+    root.append_child(assets)
+
+    checking = Account(book)
+    checking.SetName('Checking')
+    checking.SetType(gnucash.ACCT_TYPE_BANK)
+    checking.SetCommodity(cad)
+    assets.append_child(checking)
+
+    expenses = Account(book)
+    expenses.SetName('Expenses')
+    expenses.SetType(gnucash.ACCT_TYPE_EXPENSE)
+    expenses.SetCommodity(cad)
+    root.append_child(expenses)
+
+    dining = Account(book)
+    dining.SetName('Dining')
+    dining.SetType(gnucash.ACCT_TYPE_EXPENSE)
+    dining.SetCommodity(cad)
+    expenses.append_child(dining)
+
+    tx = Transaction(book)
+    tx.BeginEdit()
+    tx.SetCurrency(cad)
+    tx.SetDate(15, 6, 2024)
+    tx.SetDescription('Dinner out')
+
+    s1 = Split(book)
+    s1.SetParent(tx)
+    s1.SetAccount(dining)
+    s1.SetValue(GncNumeric(4500, 100))
+
+    s2 = Split(book)
+    s2.SetParent(tx)
+    s2.SetAccount(checking)
+    s2.SetValue(GncNumeric(-4500, 100))
+
+    tx.CommitEdit()
+    guid = tx.GetGUID().to_string()
+    session.save()
+    session.end()
+
+    return path, guid
+
+
+class TestDeleteTransactionUseCase:
+
+    def test_delete_removes_transaction(self):
+        """Transaction is no longer in the book after execute()."""
+        from gnucash import Query, Transaction
+
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.delete_transaction import DeleteTransactionUseCase
+
+        path, guid = _make_gnucash_with_transaction()
+        try:
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                uc = DeleteTransactionUseCase(repo)
+                uc.execute(guid)
+                repo.save()
+            finally:
+                repo.close()
+
+            # Verify transaction is gone
+            try:
+                from gnucash import Session, SessionOpenMode
+                session = Session(f'xml://{path}', SessionOpenMode.SESSION_NORMAL_OPEN)
+            except ImportError:
+                from gnucash import Session
+                session = Session(f'xml://{path}')
+            book = session.book
+            q = Query()
+            q.search_for('Trans')
+            q.set_book(book)
+            txs = [Transaction(instance=t) for t in q.run()]
+            guids = [t.GetGUID().to_string() for t in txs]
+            assert guid not in guids
+            session.end()
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_result_contains_plaintext_backup(self):
+        """Result plaintext contains the GUID and account names (usable for re-import)."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.delete_transaction import DeleteTransactionUseCase
+
+        path, guid = _make_gnucash_with_transaction()
+        try:
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                uc = DeleteTransactionUseCase(repo)
+                result = uc.execute(guid)
+            finally:
+                repo.close()
+
+            assert guid in result.plaintext
+            assert 'Dining' in result.plaintext or 'Expenses' in result.plaintext
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_result_metadata(self):
+        """Result carries description and date of the deleted transaction."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.delete_transaction import DeleteTransactionUseCase
+
+        path, guid = _make_gnucash_with_transaction()
+        try:
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                uc = DeleteTransactionUseCase(repo)
+                result = uc.execute(guid)
+            finally:
+                repo.close()
+
+            assert result.guid == guid
+            assert result.description == 'Dinner out'
+            assert result.date == '2024-06-15'
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_unknown_guid_raises_value_error(self):
+        """Non-existent GUID raises ValueError with the GUID in the message."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.delete_transaction import DeleteTransactionUseCase
+
+        path, _guid = _make_gnucash_with_transaction()
+        try:
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                uc = DeleteTransactionUseCase(repo)
+                with pytest.raises(ValueError, match="not found in book"):
+                    uc.execute('a' * 32)
+            finally:
+                repo.close()
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)

--- a/use_cases/delete_transaction.py
+++ b/use_cases/delete_transaction.py
@@ -1,0 +1,72 @@
+"""
+Use case for deleting a single transaction by its GnuCash GUID.
+
+Before deleting, the transaction is exported to plaintext so the caller can
+present a copy to the user for safe-keeping (undo by re-importing).
+
+Fails immediately with ValueError if the GUID is not found in the book.
+Only transactions can be deleted — not accounts or commodities.
+"""
+
+from dataclasses import dataclass
+
+from repositories.gnucash_repository import GnuCashRepository
+from use_cases.export_transactions import ExportTransactionsUseCase
+
+
+@dataclass
+class DeleteTransactionResult:
+    """Result of the delete-transaction-by-guid use case."""
+    guid: str
+    description: str
+    date: str
+    plaintext: str  # Plaintext export of the deleted transaction (for undo)
+
+
+class DeleteTransactionUseCase:
+    """Delete a single transaction identified by its GnuCash GUID."""
+
+    def __init__(self, repository: GnuCashRepository):
+        self.repository = repository
+
+    def execute(self, guid: str) -> DeleteTransactionResult:
+        """
+        Export then delete the transaction with the given GUID.
+
+        The plaintext export is produced before deletion so the caller can
+        write it to stdout or a file, giving the user a copy they can
+        re-import to undo the deletion.
+
+        Args:
+            guid: GnuCash transaction GUID (32 hex characters).
+
+        Returns:
+            DeleteTransactionResult including the pre-deletion plaintext export.
+
+        Raises:
+            ValueError: If no transaction with the given GUID exists in the book.
+        """
+        transactions = self.repository.get_all_transactions()
+        target = next(
+            (tx for tx in transactions if tx.GetGUID().to_string() == guid),
+            None,
+        )
+        if target is None:
+            raise ValueError(f"Transaction GUID {guid!r} not found in book")
+
+        description = target.GetDescription()
+        date = target.GetDate().strftime("%Y-%m-%d")
+
+        # Export before deletion so the caller has an undo copy
+        exporter = ExportTransactionsUseCase(self.repository)
+        export_result = exporter.execute_by_guid(guid)
+        plaintext = exporter.format_as_plaintext(export_result)
+
+        self.repository.delete_transaction(target)
+
+        return DeleteTransactionResult(
+            guid=guid,
+            description=description,
+            date=date,
+            plaintext=plaintext,
+        )


### PR DESCRIPTION
Adds a CLI command that deletes a single GnuCash transaction identified by its GUID. The transaction is exported to plaintext before deletion so the user always has a backup copy they can re-import to undo.

Design decisions:
- Named delete-transaction-by-guid (not delete or delete-by-guid) to make explicit that only transactions are affected, not accounts or commodities.
- Export-before-delete is unconditional: the plaintext backup is always produced before the book is saved, so the user can never lose a transaction without a recoverable copy.
- Backup goes to stdout by default; -o FILE writes it to a file instead.
- Confirmation message is written to stderr so the plaintext backup on stdout can be piped or redirected independently of status messages.
- Fails immediately (non-zero exit) if the GUID is not found in the book.

New files:
- use_cases/delete_transaction.py: exports via execute_by_guid() then calls repository.delete_transaction(). Returns DeleteTransactionResult with guid, description, date, and the pre-deletion plaintext.
- cli/delete_transaction_cmd.py: click command, -o flag, save with ERR_FILEIO_BACKUP_ERROR suppression (same pattern as other commands).
- cli/main.py: register delete-transaction-by-guid command.
- tests/unit/use_cases/test_delete_transaction.py: verifies deletion, backup content, result metadata, and unknown-GUID ValueError.
- tests/integration/test_cli_delete_transaction.py: CLI tests including unknown GUID error, -o file flag, and a full delete→re-import roundtrip (sleep(1) between saves to avoid same-second backup filename conflict).

README:
- Add delete-transaction-by-guid section with example backup plaintext showing the self-contained commodity+account+transaction output format.
- Update --strategy update section to document strict GUID requirement (every transaction must have guid:, unknown GUIDs fail immediately, all GUIDs validated before any changes are applied).