### PR TITLE
fix: None-check split account before GetCommodity; improve skip logging

### DIFF
--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -198,6 +198,9 @@ class GnuCashImporter:
             split_directive: PlaintextDirective = directive.children[0]
             split_account_name = split_directive.props['account']
             split_account = find_account(root_account, split_account_name)
+            if split_account is None:
+                raise Exception(f'Account {split_account_name!r} not found '
+                              f'when trying to determine currency for transaction {directive.line}')
             commodity = split_account.GetCommodity()
             mnemonic = commodity.get_mnemonic()
 
@@ -237,11 +240,12 @@ class GnuCashImporter:
             split_directive: PlaintextDirective = child
             split_account_str = split_directive.props['account']
             split_account = find_account(root_account, split_account_str)
-            split_account_currency = split_account.GetCommodity()
 
             if split_account is None:
-                raise Exception(f'Account {split_account_str} not found '
+                raise Exception(f'Account {split_account_str!r} not found '
                               f'when trying to create transaction split {directive.line}')
+
+            split_account_currency = split_account.GetCommodity()
 
             split_amount_str = split_directive.props['amount']
             amount = string_to_gnc_numeric(split_amount_str, split_account_currency)
@@ -449,7 +453,10 @@ class GnuCashImporter:
             # A taxtable must have at least one entry
             return
 
-        account = find_account(book.get_root_account(), first_entry_directive.metadata['account'])
+        acct_name = first_entry_directive.metadata['account']
+        account = find_account(book.get_root_account(), acct_name)
+        if account is None:
+            raise Exception(f'Account {acct_name!r} not found when creating tax table {directive.props["name"]}')
         rate_str = first_entry_directive.metadata['rate']
         rate = float(rate_str.replace("%", ""))
         first_entry = create_tax_table_entry(book, account, rate)
@@ -458,7 +465,10 @@ class GnuCashImporter:
 
         for entry_directive in directive.children[1:]:
             if entry_directive.type == DirectiveType.TAXTABLE_ENTRY:
-                account = find_account(book.get_root_account(), entry_directive.metadata['account'])
+                acct_name = entry_directive.metadata['account']
+                account = find_account(book.get_root_account(), acct_name)
+                if account is None:
+                    raise Exception(f'Account {acct_name!r} not found when creating tax table {directive.props["name"]}')
                 rate_str = entry_directive.metadata['rate']
                 rate = float(rate_str.replace("%", ""))
                 entry = create_tax_table_entry(book, account, rate)
@@ -487,7 +497,11 @@ class GnuCashImporter:
                 entry.SetDate(datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d"))
                 entry.SetDescription(entry_directive.metadata['description'])
                 entry.SetAction(entry_directive.metadata['action'])
-                entry.SetInvAccount(find_account(book.get_root_account(), entry_directive.metadata['account']))
+                inv_acct_name = entry_directive.metadata['account']
+                inv_acct = find_account(book.get_root_account(), inv_acct_name)
+                if inv_acct is None:
+                    raise Exception(f'Account {inv_acct_name!r} not found when creating invoice entry')
+                entry.SetInvAccount(inv_acct)
                 entry.SetQuantity(string_to_gnc_numeric_quantity(entry_directive.metadata['quantity']))
                 entry.SetInvPrice(string_to_gnc_numeric_quantity(entry_directive.metadata['price']))
                 entry.SetInvTaxable(entry_directive.metadata['taxable'] == 'true')
@@ -499,7 +513,10 @@ class GnuCashImporter:
                 invoice.AddEntry(entry)
                 entry.CommitEdit()
             elif entry_directive.type == DirectiveType.POSTED:
-                ar_account = find_account(book.get_root_account(), entry_directive.metadata['ar_account'])
+                ar_acct_name = entry_directive.metadata['ar_account']
+                ar_account = find_account(book.get_root_account(), ar_acct_name)
+                if ar_account is None:
+                    raise Exception(f'AR account {ar_acct_name!r} not found when posting invoice {directive.props["id"]}')
                 post_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
                 due_date = datetime.strptime(entry_directive.metadata['due'], "%Y-%m-%d")
                 memo = entry_directive.metadata['memo']
@@ -514,7 +531,10 @@ class GnuCashImporter:
                     posting_txn.SetNotes("business_generated: true")
                     posting_txn.CommitEdit()
             elif entry_directive.type == DirectiveType.PAYMENT:
-                bank_account = find_account(book.get_root_account(), entry_directive.metadata['bank_account'])
+                bank_acct_name = entry_directive.metadata['bank_account']
+                bank_account = find_account(book.get_root_account(), bank_acct_name)
+                if bank_account is None:
+                    raise Exception(f'Bank account {bank_acct_name!r} not found when applying invoice payment')
                 pay_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
                 amount = string_to_gnc_numeric_quantity(entry_directive.metadata['amount'])
                 memo = entry_directive.metadata['memo']
@@ -541,7 +561,11 @@ class GnuCashImporter:
                 entry.BeginEdit()
                 entry.SetDate(datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d"))
                 entry.SetDescription(entry_directive.metadata['description'])
-                entry.SetInvAccount(find_account(book.get_root_account(), entry_directive.metadata['account']))
+                bill_acct_name = entry_directive.metadata['account']
+                bill_acct = find_account(book.get_root_account(), bill_acct_name)
+                if bill_acct is None:
+                    raise Exception(f'Account {bill_acct_name!r} not found when creating bill entry')
+                entry.SetInvAccount(bill_acct)
                 entry.SetQuantity(string_to_gnc_numeric_quantity(entry_directive.metadata['quantity']))
                 entry.SetInvPrice(string_to_gnc_numeric_quantity(entry_directive.metadata['price']))
                 entry.SetInvTaxable(entry_directive.metadata['taxable'] == 'true')
@@ -552,7 +576,10 @@ class GnuCashImporter:
                 bill.AddEntry(entry)
                 entry.CommitEdit()
             elif entry_directive.type == DirectiveType.POSTED:
-                ap_account = find_account(book.get_root_account(), entry_directive.metadata['ap_account'])
+                ap_acct_name = entry_directive.metadata['ap_account']
+                ap_account = find_account(book.get_root_account(), ap_acct_name)
+                if ap_account is None:
+                    raise Exception(f'AP account {ap_acct_name!r} not found when posting bill {directive.props["id"]}')
                 post_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
                 due_date = datetime.strptime(entry_directive.metadata['due'], "%Y-%m-%d")
                 memo = entry_directive.metadata['memo']
@@ -567,7 +594,10 @@ class GnuCashImporter:
                     posting_txn.SetNotes("business_generated: true")
                     posting_txn.CommitEdit()
             elif entry_directive.type == DirectiveType.PAYMENT:
-                bank_account = find_account(book.get_root_account(), entry_directive.metadata['bank_account'])
+                bank_acct_name = entry_directive.metadata['bank_account']
+                bank_account = find_account(book.get_root_account(), bank_acct_name)
+                if bank_account is None:
+                    raise Exception(f'Bank account {bank_acct_name!r} not found when applying bill payment')
                 pay_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
                 amount = string_to_gnc_numeric_quantity(entry_directive.metadata['amount'])
                 memo = entry_directive.metadata['memo']

--- a/tests/unit/services/test_gnucash_importer_errors.py
+++ b/tests/unit/services/test_gnucash_importer_errors.py
@@ -1,0 +1,870 @@
+"""
+Error-path tests for GnuCashImporter.
+
+These tests verify that every code path that calls find_account() raises a
+clear, descriptive Exception (not AttributeError) when the account name does
+not exist in the book.
+
+Before the fix, these paths crashed with:
+    AttributeError: 'NoneType' object has no attribute 'GetCommodity'
+    (or similar method calls on None)
+
+After the fix, every path raises Exception with the missing account name
+in the message.
+
+Coverage:
+- create_transaction: first split account missing (currency-derivation path)
+- create_transaction: non-first split account missing (split-loop path)
+- update_transaction: desired split account missing
+- import_taxtable: first entry account missing
+- import_taxtable: subsequent entry account missing
+- import_invoice: invoice entry account (income account) missing
+- import_invoice: AR account missing on POSTED directive
+- import_invoice: bank account missing on PAYMENT directive
+- import_bill: bill entry account (expense account) missing
+- import_bill: AP account missing on POSTED directive
+- import_bill: bank account missing on PAYMENT directive
+- import_from_file integration: first-split unknown account → error_count==1
+- import_from_file integration: second-split unknown account → error_count==1
+"""
+
+import os
+import tempfile
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_book():
+    """
+    Create a minimal GnuCash session with CAD accounts.
+
+    Returns (session, book) — caller is responsible for session.end().
+
+    Account hierarchy:
+        Assets:Bank:Checking  CAD
+        Expenses:Dining       CAD
+        Income:Sales          CAD
+        Liabilities:CreditCard CAD
+        Equity:Opening        CAD
+    """
+    import gnucash
+    from gnucash import Account, Session
+
+    fd, path = tempfile.mkstemp(suffix='.gnucash')
+    os.close(fd)
+    os.unlink(path)
+
+    try:
+        from gnucash import SessionOpenMode
+        session = Session(f'xml://{path}', SessionOpenMode.SESSION_NEW_STORE)
+    except ImportError:
+        session = Session(f'xml://{path}', is_new=True)
+
+    book = session.book
+    root = book.get_root_account()
+    cad = book.get_table().lookup('CURRENCY', 'CAD')
+
+    def _acct(name, acct_type, parent, commodity=None):
+        a = Account(book)
+        a.SetName(name)
+        a.SetType(acct_type)
+        a.SetCommodity(commodity or cad)
+        parent.append_child(a)
+        return a
+
+    assets = _acct('Assets', gnucash.ACCT_TYPE_ASSET, root)
+    bank = _acct('Bank', gnucash.ACCT_TYPE_BANK, assets)
+    _acct('Checking', gnucash.ACCT_TYPE_BANK, bank)
+
+    expenses = _acct('Expenses', gnucash.ACCT_TYPE_EXPENSE, root)
+    _acct('Dining', gnucash.ACCT_TYPE_EXPENSE, expenses)
+
+    income = _acct('Income', gnucash.ACCT_TYPE_INCOME, root)
+    _acct('Sales', gnucash.ACCT_TYPE_INCOME, income)
+
+    liabilities = _acct('Liabilities', gnucash.ACCT_TYPE_LIABILITY, root)
+    _acct('CreditCard', gnucash.ACCT_TYPE_CREDIT, liabilities)
+
+    equity = _acct('Equity', gnucash.ACCT_TYPE_EQUITY, root)
+    _acct('Opening', gnucash.ACCT_TYPE_EQUITY, equity)
+
+    return session, book, path
+
+
+def _split_directive(account_name, amount_str):
+    """Build a minimal SPLIT PlaintextDirective."""
+    from services.plaintext_parser import DirectiveType, PlaintextDirective
+    d = PlaintextDirective(DirectiveType.SPLIT, 1, '')
+    d.props = {'account': account_name, 'amount': amount_str}
+    d.metadata = {}
+    return d
+
+
+def _tx_directive_with_currency(splits, date='2024-06-15', desc='Test', currency_mnemonic='CAD'):
+    """
+    Build a TRANSACTION directive that carries explicit currency metadata.
+
+    This exercises the split-loop path (currency already known).
+    """
+    from services.plaintext_parser import DirectiveType, PlaintextDirective
+    d = PlaintextDirective(DirectiveType.TRANSACTION, 0, '2024-06-15')
+    d.props = {'date': date, 'tx_num': None, 'tx_desc': desc}
+    d.metadata = {'currency.namespace': 'CURRENCY', 'currency.mnemonic': currency_mnemonic}
+    d.children = splits
+    return d
+
+
+def _tx_directive_without_currency(splits, date='2024-06-15', desc='Test'):
+    """
+    Build a TRANSACTION directive WITHOUT currency metadata.
+
+    The importer will try to derive currency from the first split account.
+    This exercises the currency-detection path.
+    """
+    from services.plaintext_parser import DirectiveType, PlaintextDirective
+    d = PlaintextDirective(DirectiveType.TRANSACTION, 0, '2024-06-15')
+    d.props = {'date': date, 'tx_num': None, 'tx_desc': desc}
+    d.metadata = {}
+    d.children = splits
+    return d
+
+
+# ---------------------------------------------------------------------------
+# create_transaction — first split unknown (currency-derivation path)
+# ---------------------------------------------------------------------------
+
+class TestCreateTransactionErrors:
+
+    def test_first_split_unknown_account_raises_exception(self):
+        """
+        When currency.mnemonic is absent, importer derives currency from the
+        first split's account.  A missing account must raise Exception with
+        the account name — not AttributeError on NoneType.
+        """
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            splits = [
+                _split_directive('Assets:DoesNotExist', '50.00'),
+                _split_directive('Expenses:Dining', '-50.00'),
+            ]
+            directive = _tx_directive_without_currency(splits)
+
+            with pytest.raises(Exception, match="Assets:DoesNotExist"):
+                GnuCashImporter.create_transaction(directive, book)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_first_split_unknown_account_is_not_attribute_error(self):
+        """Error must be a descriptive Exception, not the raw AttributeError from None."""
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            splits = [
+                _split_directive('Expenses:Ghost', '10.00'),
+                _split_directive('Assets:Bank:Checking', '-10.00'),
+            ]
+            directive = _tx_directive_without_currency(splits)
+
+            with pytest.raises(Exception) as exc_info:
+                GnuCashImporter.create_transaction(directive, book)
+
+            assert not isinstance(exc_info.value, AttributeError), (
+                "Must not propagate raw AttributeError from NoneType")
+            assert 'Expenses:Ghost' in str(exc_info.value)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_non_first_split_unknown_account_raises_exception(self):
+        """
+        When currency is provided explicitly, the importer still looks up each
+        split account.  A missing account in the split loop must raise Exception.
+        """
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            splits = [
+                _split_directive('Expenses:Dining', '30.00'),
+                _split_directive('Assets:Bank:NoSuchAccount', '-30.00'),  # bad
+            ]
+            directive = _tx_directive_with_currency(splits)
+
+            with pytest.raises(Exception, match="Assets:Bank:NoSuchAccount"):
+                GnuCashImporter.create_transaction(directive, book)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_non_first_split_unknown_account_is_not_attribute_error(self):
+        """Same 'not AttributeError' check for the split-loop path."""
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            splits = [
+                _split_directive('Expenses:Dining', '30.00'),
+                _split_directive('Assets:Phantom', '-30.00'),
+            ]
+            directive = _tx_directive_with_currency(splits)
+
+            with pytest.raises(Exception) as exc_info:
+                GnuCashImporter.create_transaction(directive, book)
+
+            assert not isinstance(exc_info.value, AttributeError)
+            assert 'Assets:Phantom' in str(exc_info.value)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_valid_accounts_succeed(self):
+        """Sanity-check: a transaction with valid accounts must not raise."""
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            splits = [
+                _split_directive('Expenses:Dining', '30.00'),
+                _split_directive('Assets:Bank:Checking', '-30.00'),
+            ]
+            directive = _tx_directive_with_currency(splits)
+
+            result = GnuCashImporter.create_transaction(directive, book)
+            assert result is True
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# update_transaction — unknown split account
+# ---------------------------------------------------------------------------
+
+class TestUpdateTransactionErrors:
+
+    def _make_book_with_transaction(self):
+        """Create book + one transaction; returns (session, book, tx, path)."""
+        import gnucash
+        from gnucash import Account, GncNumeric, Session, Split, Transaction
+
+        fd, path = tempfile.mkstemp(suffix='.gnucash')
+        os.close(fd)
+        os.unlink(path)
+
+        try:
+            from gnucash import SessionOpenMode
+            session = Session(f'xml://{path}', SessionOpenMode.SESSION_NEW_STORE)
+        except ImportError:
+            session = Session(f'xml://{path}', is_new=True)
+
+        book = session.book
+        root = book.get_root_account()
+        cad = book.get_table().lookup('CURRENCY', 'CAD')
+
+        def _acct(name, acct_type, parent):
+            a = Account(book)
+            a.SetName(name)
+            a.SetType(acct_type)
+            a.SetCommodity(cad)
+            parent.append_child(a)
+            return a
+
+        assets = _acct('Assets', gnucash.ACCT_TYPE_ASSET, root)
+        bank = _acct('Bank', gnucash.ACCT_TYPE_BANK, assets)
+        checking = _acct('Checking', gnucash.ACCT_TYPE_BANK, bank)
+        expenses = _acct('Expenses', gnucash.ACCT_TYPE_EXPENSE, root)
+        dining = _acct('Dining', gnucash.ACCT_TYPE_EXPENSE, expenses)
+
+        tx = Transaction(book)
+        tx.BeginEdit()
+        tx.SetCurrency(cad)
+        tx.SetDate(15, 6, 2024)
+        tx.SetDescription('Dinner')
+
+        s1 = Split(book)
+        s1.SetParent(tx)
+        s1.SetAccount(dining)
+        s1.SetValue(GncNumeric(3000, 100))
+
+        s2 = Split(book)
+        s2.SetParent(tx)
+        s2.SetAccount(checking)
+        s2.SetValue(GncNumeric(-3000, 100))
+
+        tx.CommitEdit()
+        return session, book, tx, path
+
+    def test_unknown_split_account_raises_value_error(self):
+        """update_transaction with a nonexistent split account raises ValueError."""
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, tx, path = self._make_book_with_transaction()
+        try:
+            splits = [
+                _split_directive('Expenses:Dining', '30.00'),
+                _split_directive('Assets:Bank:NoSuchAccount', '-30.00'),
+            ]
+            directive = _tx_directive_with_currency(splits)
+            directive.metadata['guid'] = tx.GetGUID().to_string()
+
+            with pytest.raises(ValueError, match="Account not found"):
+                GnuCashImporter.update_transaction(tx, directive, book)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_unknown_split_account_message_contains_name(self):
+        """ValueError message must include the missing account name."""
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, tx, path = self._make_book_with_transaction()
+        try:
+            splits = [
+                _split_directive('Expenses:Dining', '30.00'),
+                _split_directive('Assets:Bank:Ghost', '-30.00'),
+            ]
+            directive = _tx_directive_with_currency(splits)
+            directive.metadata['guid'] = tx.GetGUID().to_string()
+
+            with pytest.raises(ValueError) as exc_info:
+                GnuCashImporter.update_transaction(tx, directive, book)
+
+            assert 'Assets:Bank:Ghost' in str(exc_info.value)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_transaction_not_left_in_edit_state_after_error(self):
+        """
+        After a ValueError from update_transaction the transaction must not
+        be left in an open BeginEdit() state (RollbackEdit should be called).
+        """
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, tx, path = self._make_book_with_transaction()
+        try:
+            splits = [
+                _split_directive('Expenses:Dining', '30.00'),
+                _split_directive('Assets:Nowhere', '-30.00'),
+            ]
+            directive = _tx_directive_with_currency(splits)
+            directive.metadata['guid'] = tx.GetGUID().to_string()
+
+            with pytest.raises(ValueError):
+                GnuCashImporter.update_transaction(tx, directive, book)
+
+            # If RollbackEdit was called, we can call BeginEdit again without error
+            tx.BeginEdit()
+            tx.RollbackEdit()
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# import_taxtable — unknown entry accounts
+# ---------------------------------------------------------------------------
+
+class TestImportTaxTableErrors:
+
+    def _taxtable_entry_directive(self, account_name, rate='5%'):
+        from services.plaintext_parser import DirectiveType, PlaintextDirective
+        d = PlaintextDirective(DirectiveType.TAXTABLE_ENTRY, 1, '')
+        d.props = {}
+        d.metadata = {'account': account_name, 'rate': rate}
+        return d
+
+    def _taxtable_directive(self, name, entries):
+        from services.plaintext_parser import DirectiveType, PlaintextDirective
+        d = PlaintextDirective(DirectiveType.TAXTABLE, 0, '')
+        d.props = {'name': name}
+        d.metadata = {}
+        d.children = entries
+        return d
+
+    def test_first_entry_unknown_account_raises_exception(self):
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            entries = [self._taxtable_entry_directive('Income:TaxBucket')]
+            directive = self._taxtable_directive('GST', entries)
+
+            with pytest.raises(Exception, match="Income:TaxBucket"):
+                GnuCashImporter.import_taxtable(directive, book)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_subsequent_entry_unknown_account_raises_exception(self):
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            # First entry uses a valid account so taxtable is created
+            entries = [
+                self._taxtable_entry_directive('Income:Sales', '5%'),
+                self._taxtable_entry_directive('Income:GhostAccount', '2%'),  # bad
+            ]
+            directive = self._taxtable_directive('HST', entries)
+
+            with pytest.raises(Exception, match="Income:GhostAccount"):
+                GnuCashImporter.import_taxtable(directive, book)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# import_invoice — unknown accounts
+# ---------------------------------------------------------------------------
+
+class TestImportInvoiceErrors:
+
+    def _make_book_with_customer(self):
+        """Returns (session, book, path) with a customer 'C001' in the book."""
+        import gnucash
+        from gnucash import Account, Session
+        from gnucash.gnucash_business import Customer
+
+        fd, path = tempfile.mkstemp(suffix='.gnucash')
+        os.close(fd)
+        os.unlink(path)
+
+        try:
+            from gnucash import SessionOpenMode
+            session = Session(f'xml://{path}', SessionOpenMode.SESSION_NEW_STORE)
+        except ImportError:
+            session = Session(f'xml://{path}', is_new=True)
+
+        book = session.book
+        root = book.get_root_account()
+        cad = book.get_table().lookup('CURRENCY', 'CAD')
+
+        def _acct(name, acct_type, parent):
+            a = Account(book)
+            a.SetName(name)
+            a.SetType(acct_type)
+            a.SetCommodity(cad)
+            parent.append_child(a)
+            return a
+
+        assets = _acct('Assets', gnucash.ACCT_TYPE_ASSET, root)
+        _acct('Bank', gnucash.ACCT_TYPE_BANK, assets)
+        _acct('AccountsReceivable', gnucash.ACCT_TYPE_RECEIVABLE, assets)
+
+        income = _acct('Income', gnucash.ACCT_TYPE_INCOME, root)
+        _acct('Sales', gnucash.ACCT_TYPE_INCOME, income)
+
+        customer = Customer(book, 'C001', cad)
+        customer.BeginEdit()
+        customer.SetName('Test Customer')
+        customer.CommitEdit()
+
+        return session, book, path
+
+    def _invoice_directive(self, customer_id, entries):
+        from services.plaintext_parser import DirectiveType, PlaintextDirective
+        d = PlaintextDirective(DirectiveType.INVOICE, 0, '')
+        d.props = {'id': 'INV001'}
+        d.metadata = {
+            'currency': 'CAD',
+            'customer_id': customer_id,
+            'date_opened': '2024-06-01',
+        }
+        d.children = entries
+        return d
+
+    def _invoice_entry_directive(self, account_name):
+        from services.plaintext_parser import DirectiveType, PlaintextDirective
+        d = PlaintextDirective(DirectiveType.INVOICE_ENTRY, 1, '')
+        d.props = {}
+        d.metadata = {
+            'date': '2024-06-01',
+            'description': 'Consulting',
+            'action': 'Hours',
+            'account': account_name,
+            'quantity': '1',
+            'price': '100.00',
+            'taxable': 'false',
+            'tax_included': 'false',
+        }
+        return d
+
+    def _posted_directive(self, ar_account_name):
+        from services.plaintext_parser import DirectiveType, PlaintextDirective
+        d = PlaintextDirective(DirectiveType.POSTED, 1, '')
+        d.props = {}
+        d.metadata = {
+            'ar_account': ar_account_name,
+            'date': '2024-06-01',
+            'due': '2024-07-01',
+            'memo': 'Invoice INV001',
+            'accumulate': 'false',
+        }
+        return d
+
+    def _payment_directive(self, bank_account_name):
+        from services.plaintext_parser import DirectiveType, PlaintextDirective
+        d = PlaintextDirective(DirectiveType.PAYMENT, 1, '')
+        d.props = {}
+        d.metadata = {
+            'bank_account': bank_account_name,
+            'date': '2024-06-15',
+            'amount': '100.00',
+            'memo': 'Payment',
+            'num': None,
+        }
+        return d
+
+    def test_invoice_entry_unknown_account_raises_exception(self):
+        """Missing income account on invoice entry must raise Exception."""
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = self._make_book_with_customer()
+        try:
+            entries = [self._invoice_entry_directive('Income:DoesNotExist')]
+            directive = self._invoice_directive('C001', entries)
+
+            with pytest.raises(Exception, match="Income:DoesNotExist"):
+                GnuCashImporter.import_invoice(directive, book)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_invoice_ar_account_not_found_raises_exception(self):
+        """Missing AR account on POSTED directive must raise Exception."""
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = self._make_book_with_customer()
+        try:
+            entries = [
+                self._invoice_entry_directive('Income:Sales'),
+                self._posted_directive('Assets:NoSuchARAccount'),
+            ]
+            directive = self._invoice_directive('C001', entries)
+
+            with pytest.raises(Exception, match="Assets:NoSuchARAccount"):
+                GnuCashImporter.import_invoice(directive, book)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_invoice_payment_bank_not_found_raises_exception(self):
+        """Missing bank account on PAYMENT directive must raise Exception."""
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = self._make_book_with_customer()
+        try:
+            entries = [
+                self._invoice_entry_directive('Income:Sales'),
+                self._posted_directive('Assets:AccountsReceivable'),
+                self._payment_directive('Assets:Bank:NoSuchBank'),
+            ]
+            directive = self._invoice_directive('C001', entries)
+
+            with pytest.raises(Exception, match="Assets:Bank:NoSuchBank"):
+                GnuCashImporter.import_invoice(directive, book)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# import_bill — unknown accounts
+# ---------------------------------------------------------------------------
+
+class TestImportBillErrors:
+
+    def _make_book_with_vendor(self):
+        """Returns (session, book, path) with vendor 'V001' in the book."""
+        import gnucash
+        from gnucash import Account, Session
+        from gnucash.gnucash_business import Vendor
+
+        fd, path = tempfile.mkstemp(suffix='.gnucash')
+        os.close(fd)
+        os.unlink(path)
+
+        try:
+            from gnucash import SessionOpenMode
+            session = Session(f'xml://{path}', SessionOpenMode.SESSION_NEW_STORE)
+        except ImportError:
+            session = Session(f'xml://{path}', is_new=True)
+
+        book = session.book
+        root = book.get_root_account()
+        cad = book.get_table().lookup('CURRENCY', 'CAD')
+
+        def _acct(name, acct_type, parent):
+            a = Account(book)
+            a.SetName(name)
+            a.SetType(acct_type)
+            a.SetCommodity(cad)
+            parent.append_child(a)
+            return a
+
+        assets = _acct('Assets', gnucash.ACCT_TYPE_ASSET, root)
+        _acct('Bank', gnucash.ACCT_TYPE_BANK, assets)
+
+        liabilities = _acct('Liabilities', gnucash.ACCT_TYPE_LIABILITY, root)
+        _acct('AccountsPayable', gnucash.ACCT_TYPE_PAYABLE, liabilities)
+
+        expenses = _acct('Expenses', gnucash.ACCT_TYPE_EXPENSE, root)
+        _acct('Supplies', gnucash.ACCT_TYPE_EXPENSE, expenses)
+
+        vendor = Vendor(book, 'V001', cad)
+        vendor.BeginEdit()
+        vendor.SetName('Test Vendor')
+        vendor.CommitEdit()
+
+        return session, book, path
+
+    def _bill_directive(self, vendor_id, entries):
+        from services.plaintext_parser import DirectiveType, PlaintextDirective
+        d = PlaintextDirective(DirectiveType.BILL, 0, '')
+        d.props = {'id': 'BILL001'}
+        d.metadata = {
+            'currency': 'CAD',
+            'vendor_id': vendor_id,
+            'date_opened': '2024-06-01',
+        }
+        d.children = entries
+        return d
+
+    def _bill_entry_directive(self, account_name):
+        from services.plaintext_parser import DirectiveType, PlaintextDirective
+        d = PlaintextDirective(DirectiveType.BILL_ENTRY, 1, '')
+        d.props = {}
+        d.metadata = {
+            'date': '2024-06-01',
+            'description': 'Office supplies',
+            'account': account_name,
+            'quantity': '1',
+            'price': '50.00',
+            'taxable': 'false',
+        }
+        return d
+
+    def _posted_directive(self, ap_account_name):
+        from services.plaintext_parser import DirectiveType, PlaintextDirective
+        d = PlaintextDirective(DirectiveType.POSTED, 1, '')
+        d.props = {}
+        d.metadata = {
+            'ap_account': ap_account_name,
+            'date': '2024-06-01',
+            'due': '2024-07-01',
+            'memo': 'Bill BILL001',
+            'accumulate': 'false',
+        }
+        return d
+
+    def _payment_directive(self, bank_account_name):
+        from services.plaintext_parser import DirectiveType, PlaintextDirective
+        d = PlaintextDirective(DirectiveType.PAYMENT, 1, '')
+        d.props = {}
+        d.metadata = {
+            'bank_account': bank_account_name,
+            'date': '2024-06-15',
+            'amount': '50.00',
+            'memo': 'Payment',
+            'num': None,
+        }
+        return d
+
+    def test_bill_entry_unknown_account_raises_exception(self):
+        """Missing expense account on bill entry must raise Exception."""
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = self._make_book_with_vendor()
+        try:
+            entries = [self._bill_entry_directive('Expenses:DoesNotExist')]
+            directive = self._bill_directive('V001', entries)
+
+            with pytest.raises(Exception, match="Expenses:DoesNotExist"):
+                GnuCashImporter.import_bill(directive, book)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_bill_ap_account_not_found_raises_exception(self):
+        """Missing AP account on POSTED directive must raise Exception."""
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = self._make_book_with_vendor()
+        try:
+            entries = [
+                self._bill_entry_directive('Expenses:Supplies'),
+                self._posted_directive('Liabilities:NoSuchAPAccount'),
+            ]
+            directive = self._bill_directive('V001', entries)
+
+            with pytest.raises(Exception, match="Liabilities:NoSuchAPAccount"):
+                GnuCashImporter.import_bill(directive, book)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_bill_payment_bank_not_found_raises_exception(self):
+        """Missing bank account on PAYMENT directive must raise Exception."""
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = self._make_book_with_vendor()
+        try:
+            entries = [
+                self._bill_entry_directive('Expenses:Supplies'),
+                self._posted_directive('Liabilities:AccountsPayable'),
+                self._payment_directive('Assets:Bank:NoSuchBank'),
+            ]
+            directive = self._bill_directive('V001', entries)
+
+            with pytest.raises(Exception, match="Assets:Bank:NoSuchBank"):
+                GnuCashImporter.import_bill(directive, book)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Integration: import_from_file with unknown account names
+# ---------------------------------------------------------------------------
+
+class TestImportFromFileUnknownAccount:
+    """
+    End-to-end tests through ImportTransactionsUseCase.import_from_file().
+
+    These exercise the full stack and confirm that unknown accounts in a
+    plaintext file produce error_count==1 rather than an uncaught AttributeError.
+    """
+
+    def _write_plaintext(self, lines):
+        fd, path = tempfile.mkstemp(suffix='.txt')
+        with os.fdopen(fd, 'w') as f:
+            f.write('\n'.join(lines))
+        return path
+
+    def test_first_split_unknown_account_counts_as_error(self, temp_gnucash_file):
+        """
+        Plaintext file where the first split references a nonexistent account.
+        No currency header present, so importer tries to derive currency from
+        first split (the fixed code path).
+        """
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.import_transactions import ImportTransactionsUseCase
+
+        plaintext = self._write_plaintext([
+            '2024-06-15 * "Test"',
+            '\tAssets:NonExistentAccount  50.00 CAD',
+            '\tExpenses:Dining  -50.00 CAD',
+        ])
+        try:
+            with GnuCashRepository(temp_gnucash_file) as repo:
+                uc = ImportTransactionsUseCase(repo)
+                result = uc.import_from_file(plaintext)
+
+            assert result.error_count == 1
+            assert result.imported_count == 0
+        finally:
+            os.unlink(plaintext)
+
+    def test_second_split_unknown_account_counts_as_error(self, temp_gnucash_file):
+        """
+        Plaintext file where the second split references a nonexistent account.
+        Currency header IS present, so currency detection succeeds but the
+        split-loop path (the other fixed code path) raises.
+        """
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.import_transactions import ImportTransactionsUseCase
+
+        plaintext = self._write_plaintext([
+            '2024-06-15 commodity CAD',
+            '\tmnemonic: "CAD"',
+            '\tfullname: "Canadian Dollar"',
+            '\tnamespace: "CURRENCY"',
+            '\tfraction: 100',
+            '2024-06-15 * "Test"',
+            '\tcurrency.namespace: "CURRENCY"',
+            '\tcurrency.mnemonic: "CAD"',
+            '\tExpenses:Dining  50.00 CAD',
+            '\tAssets:Bank:NonExistentAccount  -50.00 CAD',
+        ])
+        try:
+            with GnuCashRepository(temp_gnucash_file) as repo:
+                uc = ImportTransactionsUseCase(repo)
+                result = uc.import_from_file(plaintext)
+
+            assert result.error_count == 1
+            assert result.imported_count == 0
+        finally:
+            os.unlink(plaintext)
+
+    def test_unknown_account_error_message_not_attribute_error(self, temp_gnucash_file):
+        """
+        The errors list must not contain 'AttributeError'.
+        Before the fix, the error was: 'NoneType' object has no attribute 'GetCommodity'.
+        After the fix, it must be a descriptive message with the account name.
+        """
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.import_transactions import ImportTransactionsUseCase
+
+        plaintext = self._write_plaintext([
+            '2024-06-15 * "Test"',
+            '\tAssets:GhostAccount  100.00 CAD',
+            '\tExpenses:Dining  -100.00 CAD',
+        ])
+        try:
+            with GnuCashRepository(temp_gnucash_file) as repo:
+                uc = ImportTransactionsUseCase(repo)
+                result = uc.import_from_file(plaintext)
+
+            assert result.error_count == 1
+            error_text = result.errors[0].get('error', '') if result.errors else ''
+            assert 'AttributeError' not in error_text, (
+                f"Error should not be AttributeError, got: {error_text}")
+            assert 'Assets:GhostAccount' in error_text, (
+                f"Error should name the missing account, got: {error_text}")
+        finally:
+            os.unlink(plaintext)
+
+    def test_valid_import_still_succeeds(self, temp_gnucash_file):
+        """Sanity check: a well-formed file with known accounts still imports."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.import_transactions import ImportTransactionsUseCase
+
+        plaintext = self._write_plaintext([
+            '2024-06-15 * "Valid transaction"',
+            '\tExpenses:Dining  50.00 CAD',
+            '\tAssets:Bank:Checking  -50.00 CAD',
+        ])
+        try:
+            with GnuCashRepository(temp_gnucash_file) as repo:
+                uc = ImportTransactionsUseCase(repo)
+                result = uc.import_from_file(plaintext)
+
+            assert result.imported_count == 1
+            assert result.error_count == 0
+        finally:
+            os.unlink(plaintext)

--- a/use_cases/import_transactions.py
+++ b/use_cases/import_transactions.py
@@ -315,7 +315,17 @@ class ImportTransactionsUseCase:
                     if 'guid' in child.metadata:
                         guid = child.metadata['guid']
                         if guid in existing_guid_map:
-                            logging.info(f"Skipping duplicate transaction with GUID {guid}")
+                            _date = child.props.get('date', '?')
+                            _desc = child.props.get('tx_desc') or '(no description)'
+                            _splits = ', '.join(
+                                f"{s.props.get('account', '?')} {s.props.get('amount', '?')}"
+                                for s in child.children
+                                if s.props.get('account')
+                            )
+                            logging.info(
+                                f"Skipping duplicate (GUID match): {_date} \"{_desc}\" "
+                                f"[{_splits}] guid={guid}"
+                            )
                             result.skipped_count += 1
                             continue
 
@@ -337,7 +347,16 @@ class ImportTransactionsUseCase:
                                 break
 
                     if is_duplicate:
-                        logging.info(f"Skipping duplicate transaction on {date_str}")
+                        _desc = child.props.get('tx_desc') or '(no description)'
+                        _splits = ', '.join(
+                            f"{s.props.get('account', '?')} {s.props.get('amount', '?')}"
+                            for s in child.children
+                            if s.props.get('account')
+                        )
+                        logging.info(
+                            f"Skipping duplicate (signature match): {date_str} \"{_desc}\" "
+                            f"[{_splits}]"
+                        )
                         result.skipped_count += 1
                         continue
 


### PR DESCRIPTION
Three related improvements:

1. Fix AttributeError crash when split account does not exist (gnucash_importer.py)
   - create_transaction: currency-derivation path checked GetCommodity() before None guard
   - create_transaction: split-loop path had the same ordering mistake
   - update_transaction, import_taxtable, import_invoice, import_bill: all find_account() results now checked for None before any method calls, with descriptive error messages that include the missing account name
   - Root cause: find_account() returns None for unknown account names, and callers called .GetCommodity() / setter methods before the None check could run

2. Add error-path tests for all affected code paths (test_gnucash_importer_errors.py)
   - create_transaction: first split unknown (currency-derivation path)
   - create_transaction: non-first split unknown (split-loop path)
   - update_transaction: unknown split account; transaction not left in edit state (update_transaction already raises ValueError with account name via pre-existing validation loop at lines 359-362; tests confirm this behaviour is preserved)
   - import_taxtable: first and subsequent entry with bad account
   - import_invoice: entry account, AR account, payment bank account
   - import_bill: entry account, AP account, payment bank account
   - import_from_file integration: error_count==1, no AttributeError, account name in message (temp_gnucash_file fixture is in tests/conftest.py) These tests would have caught the bug immediately had they existed.

3. Improve duplicate-skip log messages (import_transactions.py)
   - Previously: "Skipping duplicate transaction on 2024-06-15" (no context)
   - Now includes date, description, and all splits with amounts: "Skipping duplicate (signature match): 2024-06-15 "Dinner out" [Expenses:Dining 45.00, Assets:Bank:Checking -45.00]"
   - GUID-match path likewise includes date, description, and split details
   - Split props accessed with .get() to guard against malformed directives
   - Users can identify exactly which transaction was skipped without cross-referencing the GnuCash file manually