### PR TITLE
Add KVP metadata support for custom transaction/split tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Right now, GnuCash plaintext supports GnuCash `Account`, `Commodity`, `Transacti
 | Document Link (of a transaction)                  | N/A                                               |
 | N/A                                               | Documents (attached to the journal of an account) |
 | Properties of Account/Commodity/Transaction/Split | Metadata                                          |
+| Custom metadata (KVP slots)                       | Metadata (open-ended key: value pairs)            |
 
 
 
@@ -215,6 +216,103 @@ Formula `value` = `share_price` * Split_Amount, e.g., 3.68 = 368/2170 * 21.70
 		share_price: "1"
 		value: "-3.68"
 ```
+
+### Custom Metadata
+
+GnuCash supports arbitrary key-value pairs (KVP slots) on any transaction or split.
+gnucash-plaintext exposes this as **custom metadata**: any tag in a transaction or
+split block that is not a reserved field (see tables below) is automatically stored
+in the GnuCash KVP layer and round-trips through export/import without loss.
+
+This makes the format directly comparable to beancount's open-ended metadata model.
+
+#### Reserved transaction fields (stored via dedicated GnuCash setters)
+
+| Field | GnuCash field |
+|-------|--------------|
+| `guid` | Transaction GUID |
+| `currency.namespace` | Transaction currency namespace |
+| `currency.mnemonic` | Transaction currency mnemonic |
+| `doc_link` | Document link / association |
+| `notes` | Transaction notes |
+
+#### Reserved split fields (stored via dedicated GnuCash setters)
+
+| Field | GnuCash field |
+|-------|--------------|
+| `share_price` | Share price |
+| `value` | Split value |
+| `action` | Split action |
+| `memo` | Split memo |
+| `account.commodity.mnemonic` | Account commodity mnemonic |
+| `account.commodity.namespace` | Account commodity namespace |
+
+#### Any other key → KVP slot
+
+Any key not in the tables above is stored in GnuCash's KVP slot system as a JSON
+blob under the `plaintext_metadata` slot name. Multiple custom keys on the same
+object are stored together in a single JSON object.
+
+**Key naming rules:**
+- Colons (`:`) are **not allowed** in custom metadata key names. The plaintext
+  format uses `key: value` syntax, so a colon inside a key name would create
+  parsing ambiguity. An error is raised at import time if a colon is found.
+- Use **dots** for hierarchical keys (e.g. `tax.category`, `receipt.id`).
+  Dots are already used by convention in the reserved fields above.
+
+```
+2024-06-15 * "Dinner with client"
+	guid: "317c8ae6e0084c33951d052b9f1b9f23"
+	notes: "Team dinner Q2"
+	tax_category: "meals_entertainment"
+	receipt_id: "RCP-2024-0615"
+	Expenses:Dining 85.00 CAD
+		vendor: "The Keg Steakhouse"
+		approved_by: "Alice"
+	Assets:Bank:Checking -85.00 CAD
+```
+
+In the example above:
+- `guid`, `notes` → stored via dedicated GnuCash API (reserved fields)
+- `tax_category`, `receipt_id` → stored in the transaction's KVP slot
+- `vendor`, `approved_by` → stored in the Dining split's KVP slot
+
+When you export this transaction back to plaintext, all four custom keys will
+appear in the output exactly as written.
+
+#### Update merges custom metadata
+
+When using `--strategy update`, custom metadata is **merged** — new keys are added
+and existing keys are overwritten, but keys not mentioned in the incoming directive
+are preserved from the existing GnuCash object. This means you can add or update
+custom tags without wiping out tags set in a previous pass.
+
+```
+# First import: stores receipt_id and tax_category
+2024-06-15 * "Dinner"
+	guid: "317c8ae6e0084c33951d052b9f1b9f23"
+	receipt_id: "RCP-001"
+	tax_category: "meals"
+	Expenses:Dining 85.00 CAD
+
+# Second import (--strategy update): adds approved_by, preserves receipt_id and tax_category
+2024-06-15 * "Dinner"
+	guid: "317c8ae6e0084c33951d052b9f1b9f23"
+	approved_by: "Alice"
+	Expenses:Dining 85.00 CAD
+```
+
+After the second import the transaction carries all three keys: `receipt_id`,
+`tax_category`, and `approved_by`.
+
+#### Cross-version compatibility
+
+KVP metadata works on all supported GnuCash versions:
+
+| GnuCash version | OS | API used |
+|---|---|---|
+| 4.x+ | Debian 11/12/13, Ubuntu 22/24 | SWIG `KvpFrame.set_slot_path` |
+| 3.8 | Ubuntu 20.04 | ctypes `qof_instance_set_kvp` + GLib `GValue` |
 
 ## Usage
 
@@ -480,8 +578,10 @@ gnucash-plaintext import mybook.gnucash transactions.txt --strategy update
 
 When a transaction in the plaintext file carries a `guid:` metadata field that matches
 an existing transaction in the book, `--strategy update` modifies that transaction
-in-place — description, date, amounts, splits, notes, doc_link — without destroying
-or recreating it. Because the GnuCash object itself is never replaced, its GUID is
+in-place — description, date, amounts, splits, notes, doc_link, and custom KVP
+metadata — without destroying or recreating it. Custom metadata is **merged**: new
+keys are added and existing keys are overwritten, but keys absent from the directive
+are preserved unchanged. Because the GnuCash object itself is never replaced, its GUID is
 preserved. This makes the workflow stable across multiple runs:
 
 ```

--- a/infrastructure/gnucash/kvp.py
+++ b/infrastructure/gnucash/kvp.py
@@ -1,0 +1,321 @@
+"""
+KVP slot utilities for storing custom metadata on GnuCash objects.
+
+Custom metadata is stored as a JSON string in a single 'plaintext_metadata'
+slot to avoid KvpFrame key-enumeration complexity across GnuCash versions.
+
+## Cross-version compatibility
+
+GnuCash 4.x+  (Debian 11/12/13, Ubuntu 22/24):
+    Uses SWIG KvpFrame.set_slot_path / get_slot_path with KvpValue.
+    Transaction and Split objects expose .GetSlots() → KvpFrame.
+
+GnuCash 3.8   (Ubuntu 20.04):
+    Transaction and Split do NOT expose .GetSlots(). The KVP API changed
+    between 3.x and 4.x. Falls back to ctypes qof_instance_set_kvp /
+    qof_instance_get_kvp with a GLib GValue (from libgobject-2.0).
+    These functions are in libgncmod-engine.so (not libgnc-engine.so).
+
+Both paths use the flat slot name 'plaintext_metadata' (no slashes) to
+avoid the difference between flat-key and nested-path semantics.
+"""
+import contextlib
+import ctypes
+import json
+import logging
+from typing import Optional
+
+PT_DATA_SLOT = 'plaintext_metadata'
+
+# Transaction metadata keys that have dedicated GnuCash setters.
+# Any key NOT in this set is treated as custom metadata → KVP slot.
+KNOWN_TX_METADATA_KEYS = frozenset({
+    'guid',
+    'currency.namespace',
+    'currency.mnemonic',
+    'doc_link',
+    'notes',
+})
+
+# Split metadata keys that have dedicated GnuCash setters.
+KNOWN_SPLIT_METADATA_KEYS = frozenset({
+    'share_price',
+    'value',
+    'action',
+    'memo',
+    'account.commodity.mnemonic',
+    'account.commodity.namespace',
+})
+
+
+# ---------------------------------------------------------------------------
+# GLib GValue helper (used for GnuCash 3.8 ctypes path)
+# ---------------------------------------------------------------------------
+
+class _GValue(ctypes.Structure):
+    """
+    GLib GValue struct (64-bit layout):
+        GType g_type  (8 bytes = c_ulong on LP64)
+        union data[2] (2 × 8 bytes = two c_uint64)
+    """
+    _fields_ = [
+        ('g_type', ctypes.c_ulong),
+        ('data', ctypes.c_uint64 * 2),
+    ]
+
+
+_G_TYPE_STRING = 64  # G_TYPE_STRING on all platforms (GLib constant)
+
+_gobj: Optional[ctypes.CDLL] = None
+
+
+def _load_gobject() -> Optional[ctypes.CDLL]:
+    """Load libgobject-2.0 (needed for GValue init/set/get on GnuCash 3.8)."""
+    global _gobj
+    if _gobj is not None:
+        return _gobj
+    with contextlib.suppress(OSError):
+        _gobj = ctypes.CDLL('libgobject-2.0.so.0')
+        return _gobj
+    return None
+
+
+def _load_gnc_engine() -> ctypes.CDLL:
+    """
+    Load libgncmod-engine with RTLD_GLOBAL promotion.
+
+    On Ubuntu (RTLD_LOCAL extension loading), the library must be promoted
+    to RTLD_GLOBAL before CDLL(None) so ctypes and the Python bindings share
+    the same in-memory instance.
+
+    GnuCash 3.8: qof_instance_set_kvp / qof_instance_get_kvp live in
+    libgncmod-engine.so (not libgnc-engine.so).  Promote both paths.
+    """
+    for path in (
+        '/usr/lib/x86_64-linux-gnu/gnucash/gnucash/libgncmod-engine.so',
+        '/usr/lib/x86_64-linux-gnu/gnucash/libgnc-engine.so',
+    ):
+        with contextlib.suppress(OSError):
+            ctypes.CDLL(path, mode=ctypes.RTLD_GLOBAL)
+    return ctypes.CDLL(None)
+
+
+# ---------------------------------------------------------------------------
+# GnuCash 3.8 ctypes path: qof_instance_set/get_kvp + GValue
+# ---------------------------------------------------------------------------
+
+def _set_via_qof_instance(obj_ptr: int, slot_name: str, value: str) -> bool:
+    """
+    GnuCash 3.8: qof_instance_set_kvp(QofInstance*, GValue*, unsigned, ...).
+
+    Sets a single string KVP slot on a QofInstance (Transaction or Split).
+    Available in libgncmod-engine.so from GnuCash 3.8 / Ubuntu 20.
+    """
+    try:
+        gobj = _load_gobject()
+        if gobj is None:
+            logging.debug("libgobject not available; skipping qof_instance_set_kvp")
+            return False
+        lib = _load_gnc_engine()
+
+        gobj.g_value_init.argtypes = [ctypes.POINTER(_GValue), ctypes.c_ulong]
+        gobj.g_value_init.restype = ctypes.POINTER(_GValue)
+        gobj.g_value_set_string.argtypes = [ctypes.POINTER(_GValue), ctypes.c_char_p]
+        gobj.g_value_set_string.restype = None
+        gobj.g_value_unset.argtypes = [ctypes.POINTER(_GValue)]
+        gobj.g_value_unset.restype = None
+
+        lib.qof_instance_set_kvp.restype = None
+        # Note: no argtypes for variadic function — Python ctypes handles
+        # variadic calls with explicit c_void_p / c_uint / c_char_p casts.
+
+        gval = _GValue()
+        gobj.g_value_init(ctypes.byref(gval), _G_TYPE_STRING)
+        gobj.g_value_set_string(ctypes.byref(gval), value.encode('utf-8'))
+
+        lib.qof_instance_set_kvp(
+            ctypes.c_void_p(obj_ptr),
+            ctypes.byref(gval),
+            ctypes.c_uint(1),
+            slot_name.encode('utf-8'),
+        )
+
+        gobj.g_value_unset(ctypes.byref(gval))
+        return True
+    except Exception as e:
+        logging.debug(f"qof_instance_set_kvp failed for {slot_name!r}: {e}")
+        return False
+
+
+def _get_via_qof_instance(obj_ptr: int, slot_name: str) -> Optional[str]:
+    """
+    GnuCash 3.8: qof_instance_get_kvp(QofInstance*, GValue*, unsigned, ...).
+    """
+    try:
+        gobj = _load_gobject()
+        if gobj is None:
+            return None
+        lib = _load_gnc_engine()
+
+        gobj.g_value_init.argtypes = [ctypes.POINTER(_GValue), ctypes.c_ulong]
+        gobj.g_value_init.restype = ctypes.POINTER(_GValue)
+        gobj.g_value_get_string.argtypes = [ctypes.POINTER(_GValue)]
+        gobj.g_value_get_string.restype = ctypes.c_char_p
+        gobj.g_value_unset.argtypes = [ctypes.POINTER(_GValue)]
+        gobj.g_value_unset.restype = None
+
+        lib.qof_instance_get_kvp.restype = None
+
+        gval = _GValue()
+        gobj.g_value_init(ctypes.byref(gval), _G_TYPE_STRING)
+
+        lib.qof_instance_get_kvp(
+            ctypes.c_void_p(obj_ptr),
+            ctypes.byref(gval),
+            ctypes.c_uint(1),
+            slot_name.encode('utf-8'),
+        )
+
+        raw = gobj.g_value_get_string(ctypes.byref(gval))
+        gobj.g_value_unset(ctypes.byref(gval))
+
+        if raw is None:
+            return None
+        return raw.decode('utf-8')
+    except Exception as e:
+        logging.debug(f"qof_instance_get_kvp failed for {slot_name!r}: {e}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Unified set / get (tries SWIG first, falls back to ctypes for 3.8)
+# ---------------------------------------------------------------------------
+
+def _mark_instance_dirty(obj_ptr: int) -> None:
+    """
+    Call qof_instance_set_dirty so the XML backend re-serializes this object.
+
+    Required after any ctypes-based KVP write (including the SWIG path on
+    4.x when modifying an *existing* object loaded from disk).  Without this,
+    the GnuCash dirty-tracking system doesn't know the object has changed and
+    CommitEdit / session.save() may skip re-writing it.
+    """
+    with contextlib.suppress(Exception):
+        lib = _load_gnc_engine()
+        lib.qof_instance_set_dirty.restype = None
+        lib.qof_instance_set_dirty.argtypes = [ctypes.c_void_p]
+        lib.qof_instance_set_dirty(ctypes.c_void_p(obj_ptr))
+
+
+def _set_string_slot(obj, slot_name: str, value: str) -> bool:
+    """Set a string KVP slot on a GnuCash object. Returns True on success."""
+    # --- SWIG path (GnuCash 4.x+: Transaction/Split have .GetSlots()) ---
+    try:
+        from gnucash import KvpValue
+        frame = obj.GetSlots()
+        frame.set_slot_path([slot_name], KvpValue(value))
+        # Verify round-trip (catches silent 3.8 failures if GetSlots existed)
+        kv = frame.get_slot_path([slot_name])
+        if kv is not None:
+            # Mark dirty so the XML backend re-serialises this object on save.
+            _mark_instance_dirty(int(obj.instance))
+            return True
+        logging.debug(
+            f"SWIG set_slot_path for {slot_name!r} appeared to succeed but "
+            f"get_slot_path returned None; trying ctypes fallback."
+        )
+    except AttributeError:
+        # GetSlots() missing → GnuCash 3.8; fall through to ctypes below
+        pass
+    except Exception as e:
+        logging.debug(f"SWIG KvpFrame set failed for {slot_name!r}: {e}")
+
+    # --- ctypes path (GnuCash 3.8 / Ubuntu 20) ---
+    try:
+        obj_ptr = int(obj.instance)
+        if _set_via_qof_instance(obj_ptr, slot_name, value):
+            _mark_instance_dirty(obj_ptr)
+            return True
+    except Exception as e:
+        logging.error(f"Failed to set KVP slot {slot_name!r}: {e}")
+    return False
+
+
+def _get_string_slot(obj, slot_name: str) -> Optional[str]:
+    """Get a string KVP slot from a GnuCash object. Returns None if not found."""
+    # --- SWIG path (GnuCash 4.x+) ---
+    try:
+        frame = obj.GetSlots()
+        if frame is not None:
+            try:
+                kv = frame.get_slot_path([slot_name])
+                if kv is not None:
+                    for method in ('get', 'to_string'):
+                        with contextlib.suppress(Exception):
+                            result = getattr(kv, method)()
+                            if isinstance(result, str):
+                                return result
+                    result = str(kv)
+                    if result and result != 'None':
+                        return result
+            except Exception as e:
+                logging.debug(f"SWIG get_slot_path failed for {slot_name!r}: {e}")
+            return None
+    except AttributeError:
+        # GetSlots() missing → GnuCash 3.8; fall through to ctypes below
+        pass
+    except Exception as e:
+        logging.debug(f"Failed to get KVP slot {slot_name!r}: {e}")
+
+    # --- ctypes path (GnuCash 3.8 / Ubuntu 20) ---
+    try:
+        obj_ptr = int(obj.instance)
+        return _get_via_qof_instance(obj_ptr, slot_name)
+    except Exception as e:
+        logging.debug(f"qof_instance ctypes get failed for {slot_name!r}: {e}")
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def set_custom_metadata(obj, metadata: dict) -> None:
+    """
+    Store custom metadata on a GnuCash Transaction or Split as a KVP slot.
+
+    Serializes metadata as JSON in the 'plaintext_metadata' slot.
+    Any existing custom metadata in that slot is replaced.
+
+    Args:
+        obj:      GnuCash Transaction or Split object (must be in BeginEdit
+                  state if it is a Transaction)
+        metadata: Dict of string key → string/int/float/bool values
+    """
+    if not metadata:
+        return
+    try:
+        json_str = json.dumps(metadata, ensure_ascii=False, sort_keys=True)
+        _set_string_slot(obj, PT_DATA_SLOT, json_str)
+    except Exception as e:
+        logging.error(f"Failed to store custom metadata: {e}")
+
+
+def get_custom_metadata(obj) -> dict:
+    """
+    Read custom metadata from a GnuCash Transaction or Split KVP slot.
+
+    Returns:
+        Dict of custom key-value pairs, or {} if no custom metadata stored.
+    """
+    json_str = _get_string_slot(obj, PT_DATA_SLOT)
+    if not json_str:
+        return {}
+    try:
+        result = json.loads(json_str)
+        if isinstance(result, dict):
+            return result
+        return {}
+    except (json.JSONDecodeError, TypeError) as e:
+        logging.warning(f"Failed to parse custom metadata JSON from KVP: {e}")
+        return {}

--- a/infrastructure/gnucash/kvp.py
+++ b/infrastructure/gnucash/kvp.py
@@ -280,6 +280,27 @@ def _get_string_slot(obj, slot_name: str) -> Optional[str]:
 # Public API
 # ---------------------------------------------------------------------------
 
+def _validate_custom_keys(metadata: dict) -> None:
+    """
+    Reject custom metadata keys that contain a colon.
+
+    Colons are the key/value delimiter in the plaintext format (`key: value`).
+    Allowing colons inside a key name would create parsing ambiguity —
+    the parser cannot tell where the key ends and the value begins.
+    Use dots for hierarchical keys instead (e.g. `tax.category`).
+
+    Raises:
+        ValueError: If any key contains a colon.
+    """
+    bad = [k for k in metadata if ':' in k]
+    if bad:
+        raise ValueError(
+            f"Custom metadata keys must not contain ':' (parsing ambiguity). "
+            f"Use dots for hierarchy instead (e.g. 'tax.category'). "
+            f"Invalid keys: {bad}"
+        )
+
+
 def set_custom_metadata(obj, metadata: dict) -> None:
     """
     Store custom metadata on a GnuCash Transaction or Split as a KVP slot.
@@ -287,13 +308,25 @@ def set_custom_metadata(obj, metadata: dict) -> None:
     Serializes metadata as JSON in the 'plaintext_metadata' slot.
     Any existing custom metadata in that slot is replaced.
 
+    Note on merge workflows: callers that read existing metadata with
+    `get_custom_metadata`, update it, and then call this function must only
+    pass the *merged* dict (not the raw stored one) — `get_custom_metadata`
+    already strips any pre-existing colon keys, so the merged dict will be
+    clean.
+
     Args:
         obj:      GnuCash Transaction or Split object (must be in BeginEdit
                   state if it is a Transaction)
-        metadata: Dict of string key → string/int/float/bool values
+        metadata: Dict of string key → string/int/float/bool values.
+                  Keys must not contain ':' (parsing ambiguity); use dots
+                  for hierarchy (e.g. 'tax.category').
+
+    Raises:
+        ValueError: If any key in *metadata* contains a colon.
     """
     if not metadata:
         return
+    _validate_custom_keys(metadata)
     try:
         json_str = json.dumps(metadata, ensure_ascii=False, sort_keys=True)
         _set_string_slot(obj, PT_DATA_SLOT, json_str)
@@ -305,17 +338,34 @@ def get_custom_metadata(obj) -> dict:
     """
     Read custom metadata from a GnuCash Transaction or Split KVP slot.
 
+    Any stored keys that contain ':' (written by external tools or by an
+    earlier version of this code before the colon restriction was added) are
+    silently dropped with a warning.  This prevents merge operations from
+    failing with a confusing error when the invalid key came from stored data
+    rather than from the current directive.
+
     Returns:
         Dict of custom key-value pairs, or {} if no custom metadata stored.
+        Keys containing ':' are excluded from the returned dict.
     """
     json_str = _get_string_slot(obj, PT_DATA_SLOT)
     if not json_str:
         return {}
     try:
         result = json.loads(json_str)
-        if isinstance(result, dict):
-            return result
-        return {}
+        if not isinstance(result, dict):
+            return {}
+        # Sanitize: drop keys that would now be rejected by _validate_custom_keys.
+        sanitized = {}
+        for k, v in result.items():
+            if ':' in k:
+                logging.warning(
+                    f"Custom metadata key {k!r} contains ':' (written by an "
+                    f"external tool or older version); dropping it on read."
+                )
+            else:
+                sanitized[k] = v
+        return sanitized
     except (json.JSONDecodeError, TypeError) as e:
         logging.warning(f"Failed to parse custom metadata JSON from KVP: {e}")
         return {}

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -28,6 +28,12 @@ from gnucash.gnucash_core_c import (
     gncTaxTableEntrySetAccount,
 )
 
+from infrastructure.gnucash.kvp import (
+    KNOWN_SPLIT_METADATA_KEYS,
+    KNOWN_TX_METADATA_KEYS,
+    get_custom_metadata,
+    set_custom_metadata,
+)
 from infrastructure.gnucash.utils import find_account, get_account_full_name, string_to_gnc_numeric
 from services.plaintext_parser import DirectiveType, PlaintextDirective
 
@@ -276,6 +282,22 @@ class GnuCashImporter:
                 if memo is not None:
                     split.SetMemo(memo)
 
+            # Store any non-standard split metadata as KVP slots
+            custom_split_meta = {
+                k: v for k, v in split_directive.metadata.items()
+                if k not in KNOWN_SPLIT_METADATA_KEYS and v is not None
+            }
+            if custom_split_meta:
+                set_custom_metadata(split, custom_split_meta)
+
+        # Store any non-standard metadata as KVP slots
+        custom_tx_meta = {
+            k: v for k, v in directive.metadata.items()
+            if k not in KNOWN_TX_METADATA_KEYS and v is not None
+        }
+        if custom_tx_meta:
+            set_custom_metadata(transaction, custom_tx_meta)
+
         transaction.CommitEdit()
         logging.debug(f"Created transaction on {date_str}")
         return True
@@ -344,6 +366,16 @@ class GnuCashImporter:
                 if commodity is not None:
                     existing_tx.SetCurrency(commodity)
 
+            # Update transaction-level custom metadata (merge: new values win)
+            custom_tx_meta = {
+                k: v for k, v in directive.metadata.items()
+                if k not in KNOWN_TX_METADATA_KEYS and v is not None
+            }
+            if custom_tx_meta:
+                existing_custom = get_custom_metadata(existing_tx)
+                existing_custom.update(custom_tx_meta)
+                set_custom_metadata(existing_tx, existing_custom)
+
             tx_currency = existing_tx.GetCurrency()
 
             # Build account-name → split maps for existing and desired splits
@@ -400,6 +432,16 @@ class GnuCashImporter:
                     memo = split_directive.metadata['memo']
                     if memo is not None:
                         split.SetMemo(memo)
+
+                # Update split-level custom metadata (merge: new values win)
+                custom_split_meta = {
+                    k: v for k, v in split_directive.metadata.items()
+                    if k not in KNOWN_SPLIT_METADATA_KEYS and v is not None
+                }
+                if custom_split_meta:
+                    existing_split_custom = get_custom_metadata(split)
+                    existing_split_custom.update(custom_split_meta)
+                    set_custom_metadata(split, existing_split_custom)
 
             existing_tx.CommitEdit()
             logging.debug(f"Updated transaction on {date_str}")

--- a/tests/unit/services/test_kvp_metadata.py
+++ b/tests/unit/services/test_kvp_metadata.py
@@ -921,3 +921,201 @@ class TestUpdateTransactionKvpMetadata:
         assert custom.get('split_key') == 'updated'
         assert custom.get('stable') == 'yes'
         session3.end()
+
+
+# ---------------------------------------------------------------------------
+# Tests: key validation — colons disallowed in custom metadata keys
+# ---------------------------------------------------------------------------
+
+class TestCustomMetadataKeyValidation:
+    def test_colon_in_key_raises_value_error(self):
+        """set_custom_metadata raises ValueError when a key contains ':'."""
+        import pytest
+
+        from infrastructure.gnucash.kvp import set_custom_metadata
+
+        session, book, path = _make_book()
+        try:
+            from gnucash import GncNumeric, Split, Transaction
+            cad = book.get_table().lookup('CURRENCY', 'CAD')
+            root = book.get_root_account()
+            checking = root.lookup_by_name('Assets').lookup_by_name('Bank').lookup_by_name('Checking')
+            dining = root.lookup_by_name('Expenses').lookup_by_name('Dining')
+
+            tx = Transaction(book)
+            tx.BeginEdit()
+            tx.SetCurrency(cad)
+            tx.SetDate(1, 3, 2024)
+            tx.SetDescription('Colon key test')
+            s1 = Split(book)
+            s1.SetParent(tx)
+            s1.SetAccount(dining)
+            s1.SetValue(GncNumeric(1000, 100))
+            s2 = Split(book)
+            s2.SetParent(tx)
+            s2.SetAccount(checking)
+            s2.SetValue(GncNumeric(-1000, 100))
+
+            with pytest.raises(ValueError, match="must not contain ':'"):
+                set_custom_metadata(tx, {'a:b': 'value'})
+
+            tx.RollbackEdit()
+            session.end()
+        finally:
+            import os
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+    def test_colon_in_nested_key_raises_value_error(self):
+        """Multi-segment colon key like 'a:b:c' also raises ValueError."""
+        import pytest
+
+        from infrastructure.gnucash.kvp import set_custom_metadata
+
+        session, book, path = _make_book()
+        try:
+            from gnucash import GncNumeric, Split, Transaction
+            cad = book.get_table().lookup('CURRENCY', 'CAD')
+            root = book.get_root_account()
+            checking = root.lookup_by_name('Assets').lookup_by_name('Bank').lookup_by_name('Checking')
+            dining = root.lookup_by_name('Expenses').lookup_by_name('Dining')
+
+            tx = Transaction(book)
+            tx.BeginEdit()
+            tx.SetCurrency(cad)
+            tx.SetDate(2, 3, 2024)
+            tx.SetDescription('Nested colon key test')
+            s1 = Split(book)
+            s1.SetParent(tx)
+            s1.SetAccount(dining)
+            s1.SetValue(GncNumeric(500, 100))
+            s2 = Split(book)
+            s2.SetParent(tx)
+            s2.SetAccount(checking)
+            s2.SetValue(GncNumeric(-500, 100))
+
+            with pytest.raises(ValueError, match="must not contain ':'"):
+                set_custom_metadata(tx, {'a:b:c': 'value'})
+
+            tx.RollbackEdit()
+            session.end()
+        finally:
+            import os
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+    def test_dot_in_key_is_allowed(self):
+        """Keys with dots (e.g. 'tax.category') are valid and round-trip correctly."""
+        from infrastructure.gnucash.kvp import get_custom_metadata, set_custom_metadata
+
+        session, book, path = _make_book()
+        try:
+            from gnucash import GncNumeric, Split, Transaction
+            cad = book.get_table().lookup('CURRENCY', 'CAD')
+            root = book.get_root_account()
+            checking = root.lookup_by_name('Assets').lookup_by_name('Bank').lookup_by_name('Checking')
+            dining = root.lookup_by_name('Expenses').lookup_by_name('Dining')
+
+            tx = Transaction(book)
+            tx.BeginEdit()
+            tx.SetCurrency(cad)
+            tx.SetDate(3, 3, 2024)
+            tx.SetDescription('Dot key test')
+            s1 = Split(book)
+            s1.SetParent(tx)
+            s1.SetAccount(dining)
+            s1.SetValue(GncNumeric(2000, 100))
+            s2 = Split(book)
+            s2.SetParent(tx)
+            s2.SetAccount(checking)
+            s2.SetValue(GncNumeric(-2000, 100))
+
+            set_custom_metadata(tx, {'tax.category': 'meals', 'receipt.id': 'R-42'})
+            tx.CommitEdit()
+
+            result = get_custom_metadata(tx)
+            assert result.get('tax.category') == 'meals'
+            assert result.get('receipt.id') == 'R-42'
+            session.end()
+        finally:
+            import os
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+    def test_import_with_colon_key_raises(self):
+        """create_transaction raises ValueError when a custom key contains ':'."""
+        import pytest
+
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            directive = _build_directive('2024-03-04', 'Colon key import', [
+                {'account': 'Expenses:Dining', 'amount': '10.00'},
+                {'account': 'Assets:Bank:Checking', 'amount': '-10.00'},
+            ], metadata={'bad:key': 'value'})
+
+            with pytest.raises(ValueError, match="must not contain ':'"):
+                GnuCashImporter.create_transaction(directive, book)
+
+            session.end()
+        finally:
+            import os
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+    def test_update_with_colon_key_raises(self):
+        """update_transaction raises ValueError when a custom tx key contains ':'."""
+        import os
+
+        import pytest
+        from gnucash import Query, Transaction
+
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            # Create a transaction first
+            directive = _build_directive('2024-03-05', 'Update colon test', [
+                {'account': 'Expenses:Dining', 'amount': '20.00'},
+                {'account': 'Assets:Bank:Checking', 'amount': '-20.00'},
+            ])
+            GnuCashImporter.create_transaction(directive, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            q = Query()
+            q.search_for('Trans')
+            q.set_book(book2)
+            txs = [Transaction(instance=t) for t in q.run()]
+            existing_tx = txs[0]
+
+            bad_directive = _build_directive('2024-03-05', 'Update colon test', [
+                {'account': 'Expenses:Dining', 'amount': '20.00'},
+                {'account': 'Assets:Bank:Checking', 'amount': '-20.00'},
+            ], metadata={'bad:key': 'value'})
+
+            with pytest.raises(ValueError, match="must not contain ':'"):
+                GnuCashImporter.update_transaction(existing_tx, bad_directive, book2)
+
+            session2.end()
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)

--- a/tests/unit/services/test_kvp_metadata.py
+++ b/tests/unit/services/test_kvp_metadata.py
@@ -1,0 +1,923 @@
+"""
+Unit tests for KVP metadata storage on GnuCash transactions and splits.
+
+Covers:
+- set_custom_metadata / get_custom_metadata roundtrip on a transaction
+- Custom metadata imported via create_transaction and read back
+- Custom metadata exported via format_as_plaintext appears in output
+- Full roundtrip: import plaintext with custom tags → export → custom tags in output
+- update_transaction merges custom metadata (new keys added, existing keys updated)
+- Split-level custom metadata roundtrip
+- Known keys (notes, guid, etc.) are NOT stored as custom KVP
+- Empty/missing custom metadata returns {}
+
+Tests use real GnuCash sessions (no mocks). Run in Docker.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_session(path):
+    """Open a new GnuCash session at *path* (SESSION_NEW_STORE)."""
+    from gnucash import Session
+    try:
+        from gnucash import SessionOpenMode
+        return Session(f'xml://{path}', SessionOpenMode.SESSION_NEW_STORE)
+    except ImportError:
+        return Session(f'xml://{path}', is_new=True)
+
+
+def _open_session(path):
+    """Open an existing GnuCash session at *path*."""
+    from gnucash import Session
+    try:
+        from gnucash import SessionOpenMode
+        return Session(f'xml://{path}', SessionOpenMode.SESSION_NORMAL_OPEN)
+    except ImportError:
+        return Session(f'xml://{path}')
+
+
+def _make_book():
+    """
+    Create a minimal GnuCash book with CAD accounts for testing.
+
+    Returns (session, book, path). Caller must call session.end() and
+    clean up path after use.
+    """
+    import gnucash
+    from gnucash import Account
+
+    fd, path = tempfile.mkstemp(suffix='.gnucash')
+    os.close(fd)
+    os.unlink(path)
+
+    session = _make_session(path)
+    book = session.book
+    root = book.get_root_account()
+    cad = book.get_table().lookup('CURRENCY', 'CAD')
+
+    def _acct(name, acct_type, parent):
+        a = Account(book)
+        a.SetName(name)
+        a.SetType(acct_type)
+        a.SetCommodity(cad)
+        parent.append_child(a)
+        return a
+
+    assets = _acct('Assets', gnucash.ACCT_TYPE_ASSET, root)
+    bank = _acct('Bank', gnucash.ACCT_TYPE_BANK, assets)
+    _acct('Checking', gnucash.ACCT_TYPE_BANK, bank)
+    expenses = _acct('Expenses', gnucash.ACCT_TYPE_EXPENSE, root)
+    _acct('Dining', gnucash.ACCT_TYPE_EXPENSE, expenses)
+
+    return session, book, path
+
+
+def _build_directive(date_str, tx_desc, splits, metadata=None):
+    """
+    Build a minimal PlaintextDirective for a TRANSACTION.
+
+    *splits* is a list of dicts: {'account': str, 'amount': str, ...optional metadata...}
+    """
+    from services.plaintext_parser import DirectiveType, PlaintextDirective
+
+    tx_dir = PlaintextDirective(DirectiveType.TRANSACTION, level=0, line='')
+    tx_dir.props = {'date': date_str, 'tx_num': None, 'tx_desc': tx_desc}
+    tx_dir.metadata = metadata or {}
+
+    for s in splits:
+        split_dir = PlaintextDirective(DirectiveType.SPLIT, level=1, line='')
+        split_dir.props = {'account': s['account'], 'amount': s['amount']}
+        split_dir.metadata = {k: v for k, v in s.items() if k not in ('account', 'amount')}
+        tx_dir.children.append(split_dir)
+
+    return tx_dir
+
+
+# ---------------------------------------------------------------------------
+# Tests: set_custom_metadata / get_custom_metadata low-level roundtrip
+# ---------------------------------------------------------------------------
+
+class TestKvpRoundtrip:
+    def test_set_and_get_custom_metadata_on_transaction(self):
+        """set_custom_metadata followed by get_custom_metadata returns original dict."""
+        from gnucash import GncNumeric, Split, Transaction
+
+        from infrastructure.gnucash.kvp import get_custom_metadata, set_custom_metadata
+
+        session, book, path = _make_book()
+        try:
+            cad = book.get_table().lookup('CURRENCY', 'CAD')
+            root = book.get_root_account()
+
+            checking = root.lookup_by_name('Assets').lookup_by_name('Bank').lookup_by_name('Checking')
+            dining = root.lookup_by_name('Expenses').lookup_by_name('Dining')
+
+            tx = Transaction(book)
+            tx.BeginEdit()
+            tx.SetCurrency(cad)
+            tx.SetDate(1, 1, 2024)
+            tx.SetDescription('Test tx')
+
+            s1 = Split(book)
+            s1.SetParent(tx)
+            s1.SetAccount(dining)
+            s1.SetValue(GncNumeric(2000, 100))
+
+            s2 = Split(book)
+            s2.SetParent(tx)
+            s2.SetAccount(checking)
+            s2.SetValue(GncNumeric(-2000, 100))
+
+            metadata = {'receipt': 'R-001', 'category': 'food', 'amount_usd': '14.50'}
+            set_custom_metadata(tx, metadata)
+
+            tx.CommitEdit()
+            session.save()
+            session.end()
+
+            # Re-open and read back
+            session2 = _open_session(path)
+            book2 = session2.book
+            from gnucash import Query
+            q = Query()
+            q.search_for('Trans')
+            q.set_book(book2)
+            txs = [Transaction(instance=t) for t in q.run()]
+            assert len(txs) == 1
+
+            result = get_custom_metadata(txs[0])
+            assert result == metadata
+            session2.end()
+
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+    def test_get_custom_metadata_returns_empty_when_no_slot(self):
+        """get_custom_metadata returns {} when no KVP slot has been set."""
+        from gnucash import GncNumeric, Split, Transaction
+
+        from infrastructure.gnucash.kvp import get_custom_metadata
+
+        session, book, path = _make_book()
+        try:
+            cad = book.get_table().lookup('CURRENCY', 'CAD')
+            root = book.get_root_account()
+            checking = root.lookup_by_name('Assets').lookup_by_name('Bank').lookup_by_name('Checking')
+            dining = root.lookup_by_name('Expenses').lookup_by_name('Dining')
+
+            tx = Transaction(book)
+            tx.BeginEdit()
+            tx.SetCurrency(cad)
+            tx.SetDate(2, 1, 2024)
+            tx.SetDescription('No metadata tx')
+
+            s1 = Split(book)
+            s1.SetParent(tx)
+            s1.SetAccount(dining)
+            s1.SetValue(GncNumeric(1000, 100))
+
+            s2 = Split(book)
+            s2.SetParent(tx)
+            s2.SetAccount(checking)
+            s2.SetValue(GncNumeric(-1000, 100))
+
+            tx.CommitEdit()
+
+            result = get_custom_metadata(tx)
+            assert result == {}
+
+            session.end()
+
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+    def test_set_custom_metadata_noop_for_empty_dict(self):
+        """set_custom_metadata with empty dict does not raise and leaves slot empty."""
+        from gnucash import GncNumeric, Split, Transaction
+
+        from infrastructure.gnucash.kvp import get_custom_metadata, set_custom_metadata
+
+        session, book, path = _make_book()
+        try:
+            cad = book.get_table().lookup('CURRENCY', 'CAD')
+            root = book.get_root_account()
+            checking = root.lookup_by_name('Assets').lookup_by_name('Bank').lookup_by_name('Checking')
+            dining = root.lookup_by_name('Expenses').lookup_by_name('Dining')
+
+            tx = Transaction(book)
+            tx.BeginEdit()
+            tx.SetCurrency(cad)
+            tx.SetDate(3, 1, 2024)
+            tx.SetDescription('Empty meta tx')
+
+            s1 = Split(book)
+            s1.SetParent(tx)
+            s1.SetAccount(dining)
+            s1.SetValue(GncNumeric(500, 100))
+
+            s2 = Split(book)
+            s2.SetParent(tx)
+            s2.SetAccount(checking)
+            s2.SetValue(GncNumeric(-500, 100))
+
+            set_custom_metadata(tx, {})
+            tx.CommitEdit()
+
+            assert get_custom_metadata(tx) == {}
+            session.end()
+
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+    def test_split_level_custom_metadata_roundtrip(self):
+        """set_custom_metadata / get_custom_metadata roundtrip works on a Split."""
+        from gnucash import GncNumeric, Split, Transaction
+
+        from infrastructure.gnucash.kvp import get_custom_metadata, set_custom_metadata
+
+        session, book, path = _make_book()
+        try:
+            cad = book.get_table().lookup('CURRENCY', 'CAD')
+            root = book.get_root_account()
+            checking = root.lookup_by_name('Assets').lookup_by_name('Bank').lookup_by_name('Checking')
+            dining = root.lookup_by_name('Expenses').lookup_by_name('Dining')
+
+            tx = Transaction(book)
+            tx.BeginEdit()
+            tx.SetCurrency(cad)
+            tx.SetDate(4, 1, 2024)
+            tx.SetDescription('Split meta tx')
+
+            s1 = Split(book)
+            s1.SetParent(tx)
+            s1.SetAccount(dining)
+            s1.SetValue(GncNumeric(3000, 100))
+            set_custom_metadata(s1, {'vendor': 'Acme', 'ref': '42'})
+
+            s2 = Split(book)
+            s2.SetParent(tx)
+            s2.SetAccount(checking)
+            s2.SetValue(GncNumeric(-3000, 100))
+
+            tx.CommitEdit()
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            from gnucash import Query
+            q = Query()
+            q.search_for('Trans')
+            q.set_book(book2)
+            txs = [Transaction(instance=t) for t in q.run()]
+            assert len(txs) == 1
+
+            splits = txs[0].GetSplitList()
+            dining_split = next(
+                s for s in splits if s.GetAccount().GetName() == 'Dining'
+            )
+            result = get_custom_metadata(dining_split)
+            assert result == {'vendor': 'Acme', 'ref': '42'}
+            session2.end()
+
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+
+# ---------------------------------------------------------------------------
+# Tests: create_transaction stores custom metadata via importer
+# ---------------------------------------------------------------------------
+
+class TestCreateTransactionKvpMetadata:
+    def test_custom_tx_metadata_stored_on_import(self):
+        """create_transaction stores non-standard metadata keys as KVP."""
+        from gnucash import Query, Transaction
+
+        from infrastructure.gnucash.kvp import get_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            directive = _build_directive('2024-01-10', 'Lunch', [
+                {'account': 'Expenses:Dining', 'amount': '25.00'},
+                {'account': 'Assets:Bank:Checking', 'amount': '-25.00'},
+            ], metadata={'receipt': 'R-999', 'notes': 'business lunch'})
+
+            GnuCashImporter.create_transaction(directive, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            q = Query()
+            q.search_for('Trans')
+            q.set_book(book2)
+            txs = [Transaction(instance=t) for t in q.run()]
+            assert len(txs) == 1
+
+            custom = get_custom_metadata(txs[0])
+            # 'receipt' is custom (not in KNOWN_TX_METADATA_KEYS) → must be stored
+            assert custom.get('receipt') == 'R-999'
+            # 'notes' is a known key → must NOT be stored as custom KVP
+            assert 'notes' in txs[0].GetNotes() or txs[0].GetNotes() == 'business lunch'
+            assert 'notes' not in custom
+            session2.end()
+
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+    def test_known_tx_keys_not_stored_as_custom_kvp(self):
+        """create_transaction does not store guid/notes/doc_link as custom KVP."""
+        from gnucash import Query, Transaction
+
+        from infrastructure.gnucash.kvp import get_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            directive = _build_directive('2024-01-11', 'Office dinner', [
+                {'account': 'Expenses:Dining', 'amount': '80.00'},
+                {'account': 'Assets:Bank:Checking', 'amount': '-80.00'},
+            ], metadata={
+                'guid': 'abcdef1234567890abcdef1234567890',
+                'notes': 'team event',
+                'doc_link': 'https://example.com/receipt.pdf',
+            })
+
+            GnuCashImporter.create_transaction(directive, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            q = Query()
+            q.search_for('Trans')
+            q.set_book(book2)
+            txs = [Transaction(instance=t) for t in q.run()]
+            assert len(txs) == 1
+
+            custom = get_custom_metadata(txs[0])
+            for known_key in ('guid', 'notes', 'doc_link'):
+                assert known_key not in custom, f"'{known_key}' should not be in custom KVP"
+            session2.end()
+
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+    def test_custom_split_metadata_stored_on_import(self):
+        """create_transaction stores non-standard split metadata keys as KVP."""
+        from gnucash import Query, Transaction
+
+        from infrastructure.gnucash.kvp import get_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            directive = _build_directive('2024-01-12', 'Split meta test', [
+                {'account': 'Expenses:Dining', 'amount': '40.00',
+                 'vendor': 'Pizza Palace', 'memo': 'team lunch'},
+                {'account': 'Assets:Bank:Checking', 'amount': '-40.00'},
+            ])
+
+            GnuCashImporter.create_transaction(directive, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            q = Query()
+            q.search_for('Trans')
+            q.set_book(book2)
+            txs = [Transaction(instance=t) for t in q.run()]
+            assert len(txs) == 1
+
+            splits = txs[0].GetSplitList()
+            dining_split = next(
+                s for s in splits if s.GetAccount().GetName() == 'Dining'
+            )
+            custom = get_custom_metadata(dining_split)
+            assert custom.get('vendor') == 'Pizza Palace'
+            # 'memo' is a known split key → must NOT be stored as custom KVP
+            assert 'memo' not in custom
+            session2.end()
+
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+    def test_no_custom_metadata_when_all_keys_are_known(self):
+        """create_transaction stores no KVP when all keys are standard."""
+        from gnucash import Query, Transaction
+
+        from infrastructure.gnucash.kvp import get_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            directive = _build_directive('2024-01-13', 'Standard tx', [
+                {'account': 'Expenses:Dining', 'amount': '10.00', 'memo': 'lunch'},
+                {'account': 'Assets:Bank:Checking', 'amount': '-10.00'},
+            ], metadata={'notes': 'just a note'})
+
+            GnuCashImporter.create_transaction(directive, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            q = Query()
+            q.search_for('Trans')
+            q.set_book(book2)
+            txs = [Transaction(instance=t) for t in q.run()]
+            assert len(txs) == 1
+
+            assert get_custom_metadata(txs[0]) == {}
+            session2.end()
+
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+
+# ---------------------------------------------------------------------------
+# Tests: export emits custom metadata lines
+# ---------------------------------------------------------------------------
+
+class TestExportEmitsCustomMetadata:
+    def test_custom_tx_metadata_appears_in_plaintext_output(self):
+        """format_as_plaintext emits custom KVP metadata lines after notes."""
+        from gnucash import GncNumeric, Query, Split, Transaction
+
+        from infrastructure.gnucash.kvp import set_custom_metadata
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        session, book, path = _make_book()
+        try:
+            cad = book.get_table().lookup('CURRENCY', 'CAD')
+            root = book.get_root_account()
+            checking = root.lookup_by_name('Assets').lookup_by_name('Bank').lookup_by_name('Checking')
+            dining = root.lookup_by_name('Expenses').lookup_by_name('Dining')
+
+            tx = Transaction(book)
+            tx.BeginEdit()
+            tx.SetCurrency(cad)
+            tx.SetDate(5, 1, 2024)
+            tx.SetDescription('Export test')
+
+            s1 = Split(book)
+            s1.SetParent(tx)
+            s1.SetAccount(dining)
+            s1.SetValue(GncNumeric(1500, 100))
+
+            s2 = Split(book)
+            s2.SetParent(tx)
+            s2.SetAccount(checking)
+            s2.SetValue(GncNumeric(-1500, 100))
+
+            set_custom_metadata(tx, {'invoice_no': 'INV-001', 'project': 'alpha'})
+            tx.CommitEdit()
+            session.save()
+            session.end()
+
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                use_case = ExportTransactionsUseCase(repo)
+                result = use_case.execute()
+                output = use_case.format_as_plaintext(result)
+            finally:
+                repo.close()
+
+            assert 'invoice_no: "INV-001"' in output
+            assert 'project: "alpha"' in output
+
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+    def test_custom_split_metadata_appears_in_plaintext_output(self):
+        """format_as_plaintext emits custom split KVP metadata lines after memo."""
+        from gnucash import GncNumeric, Query, Split, Transaction
+
+        from infrastructure.gnucash.kvp import set_custom_metadata
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        session, book, path = _make_book()
+        try:
+            cad = book.get_table().lookup('CURRENCY', 'CAD')
+            root = book.get_root_account()
+            checking = root.lookup_by_name('Assets').lookup_by_name('Bank').lookup_by_name('Checking')
+            dining = root.lookup_by_name('Expenses').lookup_by_name('Dining')
+
+            tx = Transaction(book)
+            tx.BeginEdit()
+            tx.SetCurrency(cad)
+            tx.SetDate(6, 1, 2024)
+            tx.SetDescription('Split export test')
+
+            s1 = Split(book)
+            s1.SetParent(tx)
+            s1.SetAccount(dining)
+            s1.SetValue(GncNumeric(2000, 100))
+            set_custom_metadata(s1, {'cost_center': 'marketing', 'approved_by': 'Alice'})
+
+            s2 = Split(book)
+            s2.SetParent(tx)
+            s2.SetAccount(checking)
+            s2.SetValue(GncNumeric(-2000, 100))
+
+            tx.CommitEdit()
+            session.save()
+            session.end()
+
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                use_case = ExportTransactionsUseCase(repo)
+                result = use_case.execute()
+                output = use_case.format_as_plaintext(result)
+            finally:
+                repo.close()
+
+            assert 'approved_by: "Alice"' in output
+            assert 'cost_center: "marketing"' in output
+
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+    def test_no_custom_metadata_lines_when_none_stored(self):
+        """format_as_plaintext does not add custom metadata lines when none stored."""
+        from gnucash import GncNumeric, Split, Transaction
+
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        session, book, path = _make_book()
+        try:
+            cad = book.get_table().lookup('CURRENCY', 'CAD')
+            root = book.get_root_account()
+            checking = root.lookup_by_name('Assets').lookup_by_name('Bank').lookup_by_name('Checking')
+            dining = root.lookup_by_name('Expenses').lookup_by_name('Dining')
+
+            tx = Transaction(book)
+            tx.BeginEdit()
+            tx.SetCurrency(cad)
+            tx.SetDate(7, 1, 2024)
+            tx.SetDescription('No custom meta')
+
+            s1 = Split(book)
+            s1.SetParent(tx)
+            s1.SetAccount(dining)
+            s1.SetValue(GncNumeric(500, 100))
+
+            s2 = Split(book)
+            s2.SetParent(tx)
+            s2.SetAccount(checking)
+            s2.SetValue(GncNumeric(-500, 100))
+
+            tx.CommitEdit()
+            session.save()
+            session.end()
+
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                use_case = ExportTransactionsUseCase(repo)
+                result = use_case.execute()
+                output = use_case.format_as_plaintext(result)
+            finally:
+                repo.close()
+
+            # pt/__data slot should not appear in output at all
+            assert 'pt/__data' not in output
+
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+
+# ---------------------------------------------------------------------------
+# Tests: full roundtrip — import plaintext with custom tags → export → tags present
+# ---------------------------------------------------------------------------
+
+class TestFullRoundtrip:
+    def test_import_then_export_preserves_custom_tx_metadata(self):
+        """Custom metadata imported via create_transaction survives export roundtrip."""
+        from gnucash import Query, Transaction
+
+        from infrastructure.gnucash.kvp import get_custom_metadata
+        from repositories.gnucash_repository import GnuCashRepository
+        from services.gnucash_importer import GnuCashImporter
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        session, book, path = _make_book()
+        try:
+            directive = _build_directive('2024-02-01', 'Roundtrip tx', [
+                {'account': 'Expenses:Dining', 'amount': '60.00'},
+                {'account': 'Assets:Bank:Checking', 'amount': '-60.00'},
+            ], metadata={'tax_category': 'meals_entertainment', 'fiscal_year': '2024'})
+
+            GnuCashImporter.create_transaction(directive, book)
+            session.save()
+            session.end()
+
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                use_case = ExportTransactionsUseCase(repo)
+                result = use_case.execute()
+                output = use_case.format_as_plaintext(result)
+            finally:
+                repo.close()
+
+            assert 'tax_category: "meals_entertainment"' in output
+            assert 'fiscal_year: "2024"' in output
+
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+    def test_import_then_export_preserves_custom_split_metadata(self):
+        """Custom split metadata imported via create_transaction survives export roundtrip."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from services.gnucash_importer import GnuCashImporter
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        session, book, path = _make_book()
+        try:
+            directive = _build_directive('2024-02-02', 'Split roundtrip tx', [
+                {'account': 'Expenses:Dining', 'amount': '35.00',
+                 'po_number': 'PO-2024-007'},
+                {'account': 'Assets:Bank:Checking', 'amount': '-35.00'},
+            ])
+
+            GnuCashImporter.create_transaction(directive, book)
+            session.save()
+            session.end()
+
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                use_case = ExportTransactionsUseCase(repo)
+                result = use_case.execute()
+                output = use_case.format_as_plaintext(result)
+            finally:
+                repo.close()
+
+            assert 'po_number: "PO-2024-007"' in output
+
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+
+# ---------------------------------------------------------------------------
+# Tests: update_transaction merges custom metadata
+# ---------------------------------------------------------------------------
+
+class TestUpdateTransactionKvpMetadata:
+    @pytest.fixture
+    def book_with_tx(self):
+        """
+        Temp GnuCash file with one transaction that already has custom KVP metadata.
+
+        Yields (path, guid_string).
+        """
+        from gnucash import GncNumeric, Split, Transaction
+
+        from infrastructure.gnucash.kvp import set_custom_metadata
+
+        session, book, path = _make_book()
+        try:
+            cad = book.get_table().lookup('CURRENCY', 'CAD')
+            root = book.get_root_account()
+            checking = root.lookup_by_name('Assets').lookup_by_name('Bank').lookup_by_name('Checking')
+            dining = root.lookup_by_name('Expenses').lookup_by_name('Dining')
+
+            tx = Transaction(book)
+            tx.BeginEdit()
+            tx.SetCurrency(cad)
+            tx.SetDate(10, 1, 2024)
+            tx.SetDescription('Original')
+
+            s1 = Split(book)
+            s1.SetParent(tx)
+            s1.SetAccount(dining)
+            s1.SetValue(GncNumeric(4500, 100))
+
+            s2 = Split(book)
+            s2.SetParent(tx)
+            s2.SetAccount(checking)
+            s2.SetValue(GncNumeric(-4500, 100))
+
+            set_custom_metadata(tx, {'existing_key': 'original_value', 'keep_key': 'keep_me'})
+            tx.CommitEdit()
+            guid = tx.GetGUID().to_string()
+
+            session.save()
+            session.end()
+
+            yield path, guid
+
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+            lock = path + '.LCK'
+            if os.path.exists(lock):
+                os.unlink(lock)
+
+    def test_update_adds_new_custom_metadata_keys(self, book_with_tx):
+        """update_transaction adds new custom KVP keys not previously present."""
+        from gnucash import Query, Transaction
+
+        from infrastructure.gnucash.kvp import get_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = book_with_tx
+        session = _open_session(path)
+        book = session.book
+
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        directive = _build_directive('2024-01-10', 'Original', [
+            {'account': 'Expenses:Dining', 'amount': '45.00'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-45.00'},
+        ], metadata={'new_key': 'new_value'})
+
+        GnuCashImporter.update_transaction(existing_tx, directive, book)
+        session.save()
+        session.end()
+
+        session2 = _open_session(path)
+        book2 = session2.book
+        q2 = Query()
+        q2.search_for('Trans')
+        q2.set_book(book2)
+        txs2 = [Transaction(instance=t) for t in q2.run()]
+        updated = next(t for t in txs2 if t.GetGUID().to_string() == guid)
+
+        custom = get_custom_metadata(updated)
+        assert custom.get('new_key') == 'new_value'
+        assert custom.get('keep_key') == 'keep_me'
+        session2.end()
+
+    def test_update_overwrites_existing_custom_metadata_keys(self, book_with_tx):
+        """update_transaction overwrites custom KVP keys that already exist."""
+        from gnucash import Query, Transaction
+
+        from infrastructure.gnucash.kvp import get_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = book_with_tx
+        session = _open_session(path)
+        book = session.book
+
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        directive = _build_directive('2024-01-10', 'Original', [
+            {'account': 'Expenses:Dining', 'amount': '45.00'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-45.00'},
+        ], metadata={'existing_key': 'updated_value'})
+
+        GnuCashImporter.update_transaction(existing_tx, directive, book)
+        session.save()
+        session.end()
+
+        session2 = _open_session(path)
+        book2 = session2.book
+        q2 = Query()
+        q2.search_for('Trans')
+        q2.set_book(book2)
+        txs2 = [Transaction(instance=t) for t in q2.run()]
+        updated = next(t for t in txs2 if t.GetGUID().to_string() == guid)
+
+        custom = get_custom_metadata(updated)
+        assert custom.get('existing_key') == 'updated_value'
+        # key not mentioned in directive but was in original → preserved
+        assert custom.get('keep_key') == 'keep_me'
+        session2.end()
+
+    def test_update_split_custom_metadata_merged(self, book_with_tx):
+        """update_transaction merges split-level custom KVP metadata."""
+        from gnucash import GncNumeric, Query, Split, Transaction
+
+        from infrastructure.gnucash.kvp import get_custom_metadata, set_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = book_with_tx
+        # First add custom metadata to the split
+        session = _open_session(path)
+        book = session.book
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        existing_tx.BeginEdit()
+        for split in existing_tx.GetSplitList():
+            if split.GetAccount().GetName() == 'Dining':
+                set_custom_metadata(split, {'split_key': 'original', 'stable': 'yes'})
+        existing_tx.CommitEdit()
+        session.save()
+        session.end()
+
+        import time
+        time.sleep(1)
+
+        # Now update with a directive that adds a new split key
+        session2 = _open_session(path)
+        book2 = session2.book
+        q2 = Query()
+        q2.search_for('Trans')
+        q2.set_book(book2)
+        txs2 = [Transaction(instance=t) for t in q2.run()]
+        existing_tx2 = next(t for t in txs2 if t.GetGUID().to_string() == guid)
+
+        directive = _build_directive('2024-01-10', 'Original', [
+            {'account': 'Expenses:Dining', 'amount': '45.00', 'split_key': 'updated'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-45.00'},
+        ])
+
+        GnuCashImporter.update_transaction(existing_tx2, directive, book2)
+        session2.save()
+        session2.end()
+
+        session3 = _open_session(path)
+        book3 = session3.book
+        q3 = Query()
+        q3.search_for('Trans')
+        q3.set_book(book3)
+        txs3 = [Transaction(instance=t) for t in q3.run()]
+        updated = next(t for t in txs3 if t.GetGUID().to_string() == guid)
+
+        dining_split = next(
+            s for s in updated.GetSplitList() if s.GetAccount().GetName() == 'Dining'
+        )
+        custom = get_custom_metadata(dining_split)
+        assert custom.get('split_key') == 'updated'
+        assert custom.get('stable') == 'yes'
+        session3.end()

--- a/use_cases/export_transactions.py
+++ b/use_cases/export_transactions.py
@@ -17,6 +17,7 @@ from gnucash.gnucash_core_c import (
     xaccTransLookup,
 )
 
+from infrastructure.gnucash.kvp import get_custom_metadata
 from infrastructure.gnucash.utils import (
     encode_value_as_string,
     get_account_full_name,
@@ -325,6 +326,11 @@ class ExportTransactionsUseCase:
         if tx_notes and tx_notes.strip() != "":
             lines.append(f'\tnotes: {encode_value_as_string(tx_notes)}')
 
+        # Emit custom KVP metadata
+        custom_meta = get_custom_metadata(transaction)
+        for key, value in sorted(custom_meta.items()):
+            lines.append(f'\t{key}: {encode_value_as_string(value)}')
+
         # Splits
         for split in tx_splits:
             self._format_split(split, tx_currency_namespace, tx_currency_symbol, lines)
@@ -372,6 +378,11 @@ class ExportTransactionsUseCase:
 
         if memo and memo != "":
             lines.append(f'\t\tmemo:{encode_value_as_string(memo)}')
+
+        # Emit custom split KVP metadata
+        custom_split_meta = get_custom_metadata(split)
+        for key, value in sorted(custom_split_meta.items()):
+            lines.append(f'\t\t{key}: {encode_value_as_string(value)}')
 
     def execute_by_guid(self, guid: str) -> ExportResult:
         """


### PR DESCRIPTION
Implements KVP (key-value pair) slot storage so plaintext directives can carry arbitrary metadata keys beyond GnuCash's built-in fields, matching beancount's open-ended metadata model.

## What changed

### infrastructure/gnucash/kvp.py (new)
- `set_custom_metadata(obj, dict)` / `get_custom_metadata(obj) → dict` store JSON in a single `plaintext_metadata` KVP slot on any Transaction or Split.
- Three-tier compatibility:
  - **GnuCash 4.x+ (SWIG)**: `obj.GetSlots()` → `KvpFrame.set_slot_path`
  - **GnuCash 3.8 (Ubuntu 20)**: `GetSlots()` does not exist; falls back to `qof_instance_set_kvp` / `qof_instance_get_kvp` from `libgncmod-engine.so`, passing a GLib `GValue` (via libgobject-2.0).
  - `kvp_frame_set_string` (GnuCash 2.x API) does NOT exist in 3.8; the qof_instance path was found by inspecting libgncmod-engine.so symbols with `nm -D`.
- `qof_instance_set_dirty` called after every write so the XML backend re-serialises the object on `session.save()`. Without this, KVP changes on existing objects loaded from disk are silently dropped.
- `KNOWN_TX_METADATA_KEYS` / `KNOWN_SPLIT_METADATA_KEYS` frozensets define which keys have dedicated GnuCash setters; all others → KVP.

### services/gnucash_importer.py
- `create_transaction`: stores non-standard split and transaction metadata keys as custom KVP after setting standard fields.
- `update_transaction`: reads existing custom KVP and merges with directive metadata (new values win; unmentioned keys preserved).

### use_cases/export_transactions.py
- `_format_transaction`: emits `\t{key}: {value}` for each custom KVP key (sorted) after the standard transaction metadata lines.
- `_format_split`: emits `\t\t{key}: {value}` for each custom split KVP key (sorted) after the standard split metadata lines.

### tests/unit/services/test_kvp_metadata.py (new, 16 tests)
- Low-level roundtrip: set/get on Transaction and Split, empty dict noop
- `create_transaction` stores custom keys; known keys NOT stored as KVP
- Export emits custom tx/split metadata; no extra lines when none stored
- Full import → export roundtrip preserves custom tx and split metadata
- `update_transaction` adds new keys, overwrites existing, preserves unmentioned keys (merge semantics for both tx and split level)

All 9 supported OS versions pass (Debian 11/12/13, Ubuntu 20/22/24, Fedora 41, Arch Linux, openSUSE Tumbleweed).