### PR TITLE
feat: explicit posted/payment status in invoice export; expand test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,12 +521,52 @@ invoice "INV-2026-001"
     price: 150
     taxable: true
     tax_table: "GST"
+  posted: none
+  payment: none
+
+invoice "INV-2026-002"
+  customer_id: "CUST-001"
+  currency: CAD
+  date_opened: 2026-01-15
+  entry:
+    date: 2026-01-15
+    description: "Consulting services"
+    account: "Income:Consulting"
+    quantity: 10
+    price: 150
+    taxable: true
+    tax_table: "GST"
   posted:
     date: 2026-01-15
     due: 2026-02-14
     ar_account: "Assets:Accounts Receivable"
-    memo: "Invoice INV-2026-001"
+    memo: "Invoice INV-2026-002"
     accumulate: true
+  payment: none
+
+invoice "INV-2026-003"
+  customer_id: "CUST-001"
+  currency: CAD
+  date_opened: 2026-01-15
+  entry:
+    date: 2026-01-15
+    description: "Consulting services"
+    account: "Income:Consulting"
+    quantity: 10
+    price: 150
+    taxable: true
+    tax_table: "GST"
+  posted:
+    date: 2026-01-15
+    due: 2026-02-14
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-2026-003"
+    accumulate: true
+  payment:
+    date: 2026-01-30
+    amount: 1575
+    bank_account: "Assets:Bank"
+    memo: "Payment received"
 
 bill "BILL-2026-001"
   vendor_id: "VEND-001"
@@ -545,6 +585,48 @@ bill "BILL-2026-001"
     ap_account: "Liabilities:Accounts Payable"
     memo: "Bill BILL-2026-001"
     accumulate: true
+  payment: none
+```
+
+**Invoice and bill status fields**
+
+The `posted:` and `payment:` fields are always present in exported output.
+`none` is an explicit sentinel meaning "not applicable":
+
+| `posted:` value | `payment:` value | Meaning |
+|---|---|---|
+| `none` | `none` | Invoice created but not yet posted to AR/AP |
+| data block | `none` | Posted, no payments received yet |
+| data block | data block(s) | Posted with one or more payments applied |
+
+On **import**, `posted: none` and `payment: none` are no-ops — they produce the same result as omitting the field entirely. The following combinations are rejected with a clear error:
+
+- `posted: none` together with a `posted:` block (contradictory)
+- More than one `posted:` block (an invoice can only be posted once)
+- `payment: none` together with a `payment:` block (contradictory)
+- A `payment:` block on an invoice that has `posted: none` (cannot pay an unposted invoice)
+
+An invoice with **multiple partial payments** can have multiple `payment:` blocks — one per payment transaction:
+
+```
+invoice "INV-2026-004"
+  ...
+  posted:
+    date: 2026-02-01
+    due: 2026-03-03
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-2026-004"
+    accumulate: true
+  payment:
+    date: 2026-02-10
+    amount: 500
+    bank_account: "Assets:Bank"
+    memo: "First instalment"
+  payment:
+    date: 2026-02-20
+    amount: 500
+    bank_account: "Assets:Bank"
+    memo: "Second instalment"
 ```
 
 ### Print an invoice to PDF

--- a/docs/DEBUGGING_GNUCASH_BINDINGS.md
+++ b/docs/DEBUGGING_GNUCASH_BINDINGS.md
@@ -179,6 +179,84 @@ SWIG's gncEntryGetDescription has const-type mismatches that:
 - ctypes version works reliably across all distributions
 ```
 
+## Invoice / Bill Payment — Hard-Won Findings
+
+Discovered 2026-03-27 while implementing multi-payment test coverage.
+
+### 1. `ApplyPayment` — always pass `None` for the transaction argument
+
+`gncInvoiceApplyPayment(invoice, txn, ...)` creates the payment transaction
+internally when `txn` is `NULL`/`None`. **Never** allocate the transaction
+yourself with `xaccMallocTransaction` and pass it in.
+
+```python
+# ❌ WRONG — segfaults on GnuCash 3.8 (ubuntu20)
+new_txn = Transaction(instance=gc.xaccMallocTransaction(book.instance))
+invoice.ApplyPayment(new_txn, bank, amount, exch, date, memo, num)
+
+# ✅ CORRECT — GnuCash allocates and initialises the transaction internally
+invoice.ApplyPayment(None, bank, amount, exch, date, memo, num)
+```
+
+**Why it segfaults**: `ApplyPayment` calls `xaccTransBeginEdit(txn)` internally.
+A transaction created via `Transaction(instance=xaccMallocTransaction(...))` in
+Python has not been through the same GnuCash object-initialisation path that
+`ApplyPayment` expects. On GnuCash 3.8, this causes a GLib assertion failure
+(`g_type_instance_get_private: instance != NULL`) and SIGSEGV.
+
+On GnuCash 4.x/5.x the manually-allocated transaction happened to work
+(probably because the object model changed), but the `None` path is correct
+and portable on all versions.
+
+### 2. Payment memo lives on the split, not the transaction description
+
+```python
+# ❌ WRONG — txn.GetDescription() returns the owner/customer name, not the memo
+pay_memo = txn.GetDescription()   # e.g. "Acme Corp" on OpenSUSE GnuCash 5.x
+
+# ✅ CORRECT — read memo from the bank (non-AR) split
+for i in range(txn.CountSplits()):
+    split = txn.GetSplit(i)
+    acct = split.GetAccount()
+    atype = gc.xaccAccountGetType(acct.instance)
+    if atype not in (gc.ACCT_TYPE_RECEIVABLE, gc.ACCT_TYPE_PAYABLE):
+        pay_memo = split.GetMemo() or ''
+        break
+```
+
+**Why**: `gncInvoiceApplyPayment` calls `xaccTransSetDescription(txn, owner_name)`
+unconditionally — the `memo` parameter is stored on the splits, not the
+transaction description. On newer GnuCash (Debian 13, Ubuntu 22/24) the
+description was incidentally set to the memo by some code path, but on
+OpenSUSE/GnuCash 5.x it contains the customer name. Reading from the split is
+the only portable approach.
+
+### 3. Pass `''` not `None` for `const char*` parameters on GnuCash 3.8
+
+```python
+# ❌ WRONG — None may be passed as NULL, which some GnuCash 3.8 functions
+#           do not guard against
+num = entry_directive.metadata.get('num', None)
+invoice.ApplyPayment(None, bank, amount, exch, date, memo, num)
+
+# ✅ CORRECT — empty string is always safe for optional const char* args
+num = entry_directive.metadata.get('num', '')
+invoice.ApplyPayment(None, bank, amount, exch, date, memo, num)
+```
+
+**Scope**: This pattern applies to any optional `const char*` SWIG binding
+parameter where the field may not be present in the input. GnuCash 4.x+ is
+generally null-safe, but GnuCash 3.8 on ubuntu20 is not.
+
+### 4. Platform-specific summary for payment operations
+
+| Platform | `ApplyPayment(None, ...)` | `split.GetMemo()` | `''` for optional num |
+|---|---|---|---|
+| Debian 11–13 (GnuCash 4.4–5.10) | ✅ | ✅ | ✅ |
+| Ubuntu 20.04 (GnuCash 3.8) | ✅ | ✅ | ✅ required |
+| Ubuntu 22/24 (GnuCash 4.8–4.9) | ✅ | ✅ | ✅ |
+| OpenSUSE / Fedora | ✅ | ✅ (txn.GetDescription ❌) | ✅ |
+
 ## Summary
 
 1. **No prediction possible** - test to discover failures
@@ -186,5 +264,7 @@ SWIG's gncEntryGetDescription has const-type mismatches that:
 3. **Test all platforms** - Ubuntu/Debian differences are common
 4. **Document the failures** - helps future maintainers
 5. **Use engine.py utilities** - safe ctypes patterns
+6. **`ApplyPayment(None, ...)`** - never pass a manually-allocated transaction
+7. **Payment memo on split** - never read from `txn.GetDescription()`
 
 This approach has proven necessary for maximum compatibility across Ubuntu 20/22/24 and Debian 11/12/13.

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -523,7 +523,26 @@ class GnuCashImporter:
         if directive.type != DirectiveType.INVOICE:
             raise ValueError(f"Expected INVOICE but got {directive.type}")
 
-        invoice = Invoice(book, directive.props['id'], book.get_table().lookup("CURRENCY", directive.metadata['currency']), book.CustomerLookupByID(directive.metadata['customer_id']))
+        inv_id = directive.props['id']
+
+        # Validate: posted: none and a real posted: block are contradictory
+        has_posted_none = directive.metadata.get('posted') == 'none'
+        posted_children = [c for c in directive.children if c.type == DirectiveType.POSTED]
+        if has_posted_none and posted_children:
+            raise ValueError(f'Invoice {inv_id}: contradictory "posted: none" and posted: block')
+        if len(posted_children) > 1:
+            raise ValueError(f'Invoice {inv_id}: multiple posted: blocks are not allowed')
+
+        # Validate: payment: none and a real payment: block are contradictory;
+        # also, an unposted invoice cannot have payments
+        has_payment_none = directive.metadata.get('payment') == 'none'
+        payment_children = [c for c in directive.children if c.type == DirectiveType.PAYMENT]
+        if has_payment_none and payment_children:
+            raise ValueError(f'Invoice {inv_id}: contradictory "payment: none" and payment: block')
+        if has_posted_none and payment_children:
+            raise ValueError(f'Invoice {inv_id}: cannot have payment: blocks on an unposted invoice (posted: none)')
+
+        invoice = Invoice(book, inv_id, book.get_table().lookup("CURRENCY", directive.metadata['currency']), book.CustomerLookupByID(directive.metadata['customer_id']))
         invoice.BeginEdit()
         invoice.SetDateOpened(datetime.strptime(directive.metadata['date_opened'], "%Y-%m-%d"))
 
@@ -580,9 +599,12 @@ class GnuCashImporter:
                 pay_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
                 amount = string_to_gnc_numeric_quantity(entry_directive.metadata['amount'])
                 memo = entry_directive.metadata['memo']
-                num = entry_directive.metadata.get('num', None)
-                new_txn = Transaction(instance=gc.xaccMallocTransaction(book.instance))
-                invoice.ApplyPayment(new_txn, bank_account, amount, GncNumeric(1, 1), pay_date, memo, num)
+                num = entry_directive.metadata.get('num', '')
+                # Pass None for txn: GnuCash creates the payment transaction
+                # internally. Passing a manually-allocated Transaction causes
+                # a segfault on GnuCash 3.8 (ubuntu20) because the transaction
+                # is not properly initialised before ApplyPayment uses it.
+                invoice.ApplyPayment(None, bank_account, amount, GncNumeric(1, 1), pay_date, memo, num)
 
         invoice.CommitEdit()
         logging.debug(f"Created invoice {directive.props['id']}")
@@ -592,8 +614,27 @@ class GnuCashImporter:
         if directive.type != DirectiveType.BILL:
             raise ValueError(f"Expected BILL but got {directive.type}")
 
+        bill_id = directive.props['id']
+
+        # Validate: posted: none and a real posted: block are contradictory
+        has_posted_none = directive.metadata.get('posted') == 'none'
+        posted_children = [c for c in directive.children if c.type == DirectiveType.POSTED]
+        if has_posted_none and posted_children:
+            raise ValueError(f'Bill {bill_id}: contradictory "posted: none" and posted: block')
+        if len(posted_children) > 1:
+            raise ValueError(f'Bill {bill_id}: multiple posted: blocks are not allowed')
+
+        # Validate: payment: none and a real payment: block are contradictory;
+        # also, an unposted bill cannot have payments
+        has_payment_none = directive.metadata.get('payment') == 'none'
+        payment_children = [c for c in directive.children if c.type == DirectiveType.PAYMENT]
+        if has_payment_none and payment_children:
+            raise ValueError(f'Bill {bill_id}: contradictory "payment: none" and payment: block')
+        if has_posted_none and payment_children:
+            raise ValueError(f'Bill {bill_id}: cannot have payment: blocks on an unposted bill (posted: none)')
+
         # Bills are Invoice objects whose owner is a Vendor (no separate Bill class)
-        bill = Invoice(book, directive.props['id'], book.get_table().lookup("CURRENCY", directive.metadata['currency']), book.VendorLookupByID(directive.metadata['vendor_id']))
+        bill = Invoice(book, bill_id, book.get_table().lookup("CURRENCY", directive.metadata['currency']), book.VendorLookupByID(directive.metadata['vendor_id']))
         bill.BeginEdit()
         bill.SetDateOpened(datetime.strptime(directive.metadata['date_opened'], "%Y-%m-%d"))
 
@@ -643,9 +684,8 @@ class GnuCashImporter:
                 pay_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
                 amount = string_to_gnc_numeric_quantity(entry_directive.metadata['amount'])
                 memo = entry_directive.metadata['memo']
-                num = entry_directive.metadata.get('num', None)
-                new_txn = Transaction(instance=gc.xaccMallocTransaction(book.instance))
-                bill.ApplyPayment(new_txn, bank_account, amount, GncNumeric(1, 1), pay_date, memo, num)
+                num = entry_directive.metadata.get('num', '')
+                bill.ApplyPayment(None, bank_account, amount, GncNumeric(1, 1), pay_date, memo, num)
 
         bill.CommitEdit()
         logging.debug(f"Created bill {directive.props['id']}")

--- a/tests/fixtures/business_objects.txt
+++ b/tests/fixtures/business_objects.txt
@@ -22,6 +22,10 @@
   type: Asset
   commodity.namespace: "CURRENCY"
   commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Bank
+  type: Asset
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
 
 customer "1"
   name: "Test Customer"
@@ -53,3 +57,106 @@ invoice "INV-2026-001"
     ar_account: "Assets:Accounts Receivable"
     memo: "Invoice INV-2026-001"
     accumulate: true
+
+invoice "INV-2026-002"
+  customer_id: "1"
+  currency: CAD
+  date_opened: 2026-01-15
+  entry:
+    date: 2026-01-15
+    description: "Consulting Hours"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 2
+    price: 75
+    taxable: true
+    tax_included: false
+    tax_table: "GST"
+
+invoice "INV-2026-003"
+  customer_id: "1"
+  currency: CAD
+  date_opened: 2026-01-20
+  entry:
+    date: 2026-01-20
+    description: "Project Deliverable"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 1
+    price: 200
+    taxable: true
+    tax_included: false
+    tax_table: "GST"
+  posted:
+    date: 2026-01-20
+    due: 2026-02-19
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-2026-003"
+    accumulate: true
+  payment:
+    date: 2026-01-25
+    amount: 210
+    bank_account: "Assets:Bank"
+    memo: "Payment for INV-2026-003"
+
+invoice "INV-2026-004"
+  customer_id: "1"
+  currency: CAD
+  date_opened: 2026-02-01
+  entry:
+    date: 2026-02-01
+    description: "Retainer Services"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 3
+    price: 100
+    taxable: true
+    tax_included: false
+    tax_table: "GST"
+  posted:
+    date: 2026-02-01
+    due: 2026-03-03
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-2026-004"
+    accumulate: true
+  payment:
+    date: 2026-02-10
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Partial payment 1 for INV-2026-004"
+  payment:
+    date: 2026-02-20
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Partial payment 2 for INV-2026-004"
+
+invoice "INV-2026-005"
+  customer_id: "1"
+  currency: CAD
+  date_opened: 2026-02-05
+  entry:
+    date: 2026-02-05
+    description: "Annual Support"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 1
+    price: 400
+    taxable: true
+    tax_included: false
+    tax_table: "GST"
+  posted:
+    date: 2026-02-05
+    due: 2026-03-07
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-2026-005"
+    accumulate: true
+  payment:
+    date: 2026-02-15
+    amount: 200
+    bank_account: "Assets:Bank"
+    memo: "First payment for INV-2026-005"
+  payment:
+    date: 2026-02-28
+    amount: 220
+    bank_account: "Assets:Bank"
+    memo: "Final payment for INV-2026-005"

--- a/tests/fixtures/business_objects_only.txt
+++ b/tests/fixtures/business_objects_only.txt
@@ -28,3 +28,109 @@ invoice "INV-2026-001"
     ar_account: "Assets:Accounts Receivable"
     memo: "Invoice INV-2026-001"
     accumulate: true
+  payment: none
+
+invoice "INV-2026-002"
+  customer_id: "1"
+  currency: CAD
+  date_opened: 2026-01-15
+  entry:
+    date: 2026-01-15
+    description: "Consulting Hours"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 2
+    price: 75
+    taxable: true
+    tax_included: false
+    tax_table: "GST"
+  posted: none
+  payment: none
+
+invoice "INV-2026-003"
+  customer_id: "1"
+  currency: CAD
+  date_opened: 2026-01-20
+  entry:
+    date: 2026-01-20
+    description: "Project Deliverable"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 1
+    price: 200
+    taxable: true
+    tax_included: false
+    tax_table: "GST"
+  posted:
+    date: 2026-01-20
+    due: 2026-02-19
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-2026-003"
+    accumulate: true
+  payment:
+    date: 2026-01-25
+    amount: 210
+    bank_account: "Assets:Bank"
+    memo: "Payment for INV-2026-003"
+
+invoice "INV-2026-004"
+  customer_id: "1"
+  currency: CAD
+  date_opened: 2026-02-01
+  entry:
+    date: 2026-02-01
+    description: "Retainer Services"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 3
+    price: 100
+    taxable: true
+    tax_included: false
+    tax_table: "GST"
+  posted:
+    date: 2026-02-01
+    due: 2026-03-03
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-2026-004"
+    accumulate: true
+  payment:
+    date: 2026-02-10
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Partial payment 1 for INV-2026-004"
+  payment:
+    date: 2026-02-20
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Partial payment 2 for INV-2026-004"
+
+invoice "INV-2026-005"
+  customer_id: "1"
+  currency: CAD
+  date_opened: 2026-02-05
+  entry:
+    date: 2026-02-05
+    description: "Annual Support"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 1
+    price: 400
+    taxable: true
+    tax_included: false
+    tax_table: "GST"
+  posted:
+    date: 2026-02-05
+    due: 2026-03-07
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-2026-005"
+    accumulate: true
+  payment:
+    date: 2026-02-15
+    amount: 200
+    bank_account: "Assets:Bank"
+    memo: "First payment for INV-2026-005"
+  payment:
+    date: 2026-02-28
+    amount: 220
+    bank_account: "Assets:Bank"
+    memo: "Final payment for INV-2026-005"

--- a/tests/integration/test_business_objects.py
+++ b/tests/integration/test_business_objects.py
@@ -1,6 +1,7 @@
 import os
 import re
 
+import pytest
 from click.testing import CliRunner
 
 from cli.main import cli
@@ -31,6 +32,14 @@ def extract_business_objects(text: str) -> str:
     if current:
         blocks.append('\n'.join(current))
     return '\n\n'.join(b.rstrip() for b in blocks)
+
+
+def get_invoice_block(exported_biz: str, invoice_id: str) -> str:
+    """Return the exported block for the given invoice ID, or empty string."""
+    for block in exported_biz.split('\n\n'):
+        if block.startswith(f'invoice "{invoice_id}"'):
+            return block
+    return ''
 
 
 def test_business_objects_roundtrip(tmp_path):
@@ -71,7 +80,178 @@ def test_business_objects_roundtrip(tmp_path):
         f"--- exported ---\n{exported_biz}"
     )
 
+    # ── Per-invoice state assertions ──────────────────────────────────────────
+
+    # INV-2026-001: posted, not paid
+    # Must have a posted: block and an explicit "payment: none" sentinel
+    inv1 = get_invoice_block(exported_biz, 'INV-2026-001')
+    assert inv1, "INV-2026-001 must appear in export"
+    assert '  posted:' in inv1, "INV-2026-001 must have a posted: block"
+    assert '  payment: none' in inv1, "INV-2026-001 must have payment: none (not paid)"
+
+    # INV-2026-002: unposted
+    # Must appear (export now includes unposted) with both sentinels
+    inv2 = get_invoice_block(exported_biz, 'INV-2026-002')
+    assert inv2, "INV-2026-002 (unposted) must appear in export"
+    assert '  posted: none' in inv2, "INV-2026-002 must have posted: none (unposted)"
+    assert '  payment: none' in inv2, "INV-2026-002 must have payment: none (unposted, no payments)"
+
+    # INV-2026-003: posted, single full payment
+    inv3 = get_invoice_block(exported_biz, 'INV-2026-003')
+    assert inv3, "INV-2026-003 must appear in export"
+    assert '  posted:' in inv3, "INV-2026-003 must have a posted: block"
+    assert '  payment:' in inv3, "INV-2026-003 must have a payment: block"
+    assert 'payment: none' not in inv3, "INV-2026-003 must not have payment: none"
+    assert inv3.count('  payment:') == 1, "INV-2026-003 must have exactly one payment block"
+
+    # INV-2026-004: posted, two partial payments, amount still remaining
+    inv4 = get_invoice_block(exported_biz, 'INV-2026-004')
+    assert inv4, "INV-2026-004 must appear in export"
+    assert '  posted:' in inv4, "INV-2026-004 must have a posted: block"
+    assert inv4.count('  payment:') == 2, "INV-2026-004 must have exactly two payment blocks"
+    assert 'payment: none' not in inv4
+    assert 'Partial payment 1 for INV-2026-004' in inv4
+    assert 'Partial payment 2 for INV-2026-004' in inv4
+
+    # INV-2026-005: posted, two payments, fully paid (zero balance)
+    inv5 = get_invoice_block(exported_biz, 'INV-2026-005')
+    assert inv5, "INV-2026-005 must appear in export"
+    assert '  posted:' in inv5, "INV-2026-005 must have a posted: block"
+    assert inv5.count('  payment:') == 2, "INV-2026-005 must have exactly two payment blocks"
+    assert 'payment: none' not in inv5
+    assert 'First payment for INV-2026-005' in inv5
+    assert 'Final payment for INV-2026-005' in inv5
+
     # Test the print-invoice command
     result = runner.invoke(cli, ["print-invoice", str(gnucash_file), "--invoice-id", "INV-2026-001", "-o", str(pdf_file)])
     assert result.exit_code == 0, f"print-invoice failed:\n{result.output}"
     assert os.path.exists(pdf_file)
+
+
+_CONTRADICTION_CASES = [
+    (
+        "posted_none_and_posted_block",
+        """
+invoice "INV-X"
+  customer_id: "1"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Test"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 1
+    price: 100
+    taxable: false
+    tax_included: false
+  posted: none
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Test"
+    accumulate: true
+""",
+        'contradictory "posted: none" and posted: block',
+    ),
+    (
+        "payment_none_and_payment_block",
+        """
+invoice "INV-X"
+  customer_id: "1"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Test"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 1
+    price: 100
+    taxable: false
+    tax_included: false
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Test"
+    accumulate: true
+  payment: none
+  payment:
+    date: 2026-01-15
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Pay"
+""",
+        'contradictory "payment: none" and payment: block',
+    ),
+    (
+        "payment_on_unposted_invoice",
+        """
+invoice "INV-X"
+  customer_id: "1"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Test"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 1
+    price: 100
+    taxable: false
+    tax_included: false
+  posted: none
+  payment:
+    date: 2026-01-15
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Pay"
+""",
+        'cannot have payment: blocks on an unposted invoice',
+    ),
+]
+
+
+@pytest.mark.parametrize("case_name,invoice_txt,expected_error", _CONTRADICTION_CASES)
+def test_invoice_contradiction_errors(tmp_path, case_name, invoice_txt, expected_error):
+    """Contradictory posted:/payment: combinations must produce clear errors, not silently corrupt the book."""
+    runner = CliRunner()
+    gnucash_file = tmp_path / "test.gnucash"
+
+    preamble = """\
+2026-01-01 open Assets
+  type: Asset
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Accounts Receivable
+  type: Asset
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Bank
+  type: Asset
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Income
+  type: Income
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Income:Sales
+  type: Income
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+
+customer "1"
+  name: "Test Customer"
+  currency: CAD
+
+"""
+    input_file = tmp_path / f"{case_name}.txt"
+    input_file.write_text(preamble + invoice_txt)
+
+    result = runner.invoke(cli, ["import", "--new", str(gnucash_file), str(input_file), "--include-business-objects"])
+    assert result.exit_code != 0, f"Import should have failed for case {case_name!r} but succeeded"
+    assert expected_error in result.output, (
+        f"Expected error message {expected_error!r} not found in output:\n{result.output}"
+    )

--- a/use_cases/export_business_objects.py
+++ b/use_cases/export_business_objects.py
@@ -177,11 +177,9 @@ class ExportBusinessObjectsUseCase:
         all_invoices = [gb.Invoice(instance=r) for r in q.run()]
         q.destroy()
 
-        # Only export customer invoices (owner is Customer, not Vendor)
+        # Export all customer invoices (owner is Customer, not Vendor), including unposted
         invoices = []
         for inv in all_invoices:
-            if not inv.IsPosted():
-                continue
             try:
                 cust = inv.GetOwner().GetCustomer()
                 if cust is not None:
@@ -205,7 +203,7 @@ class ExportBusinessObjectsUseCase:
             for raw_entry in inv.GetEntries():
                 lines += self._format_inv_entry(lib, raw_entry)
 
-            # posted block
+            # posted block — always emitted; "none" sentinel when not posted
             posted_txn = inv.GetPostedTxn()
             if posted_txn:
                 ar_name = get_account_full_name(inv.GetPostedAcc())
@@ -215,9 +213,12 @@ class ExportBusinessObjectsUseCase:
                 lines.append(f'    ar_account: "{ar_name}"')
                 lines.append(f'    memo: "{posted_txn.GetDescription()}"')
                 lines.append('    accumulate: true')
+            else:
+                lines.append('  posted: none')
 
-            # payment blocks — from lot splits, excluding the posting transaction
+            # payment blocks — always emitted; "none" sentinel when no payments exist
             lot = inv.GetPostedLot()
+            has_payments = False
             if lot:
                 for raw_split in lot.get_split_list():
                     s   = Split(instance=raw_split)
@@ -228,6 +229,9 @@ class ExportBusinessObjectsUseCase:
                     if gc.gncInvoiceGetInvoiceFromTxn(txn.instance) is not None:
                         continue
                     lines += self._format_payment(txn)
+                    has_payments = True
+            if not has_payments:
+                lines.append('  payment: none')
 
             invoice_strings.append('\n'.join(lines))
         return '\n\n'.join(invoice_strings)
@@ -274,12 +278,15 @@ class ExportBusinessObjectsUseCase:
     def _format_payment(self, txn) -> list:
         """Format one payment transaction as payment: lines."""
         pay_date = txn.GetDate().strftime("%Y-%m-%d")
-        pay_memo = txn.GetDescription() or ''
         pay_num  = txn.GetNum() or ''
 
-        # Find the bank/asset side (non-AR) split for amount + account
+        # Find the bank/asset side (non-AR) split for amount, account, and memo.
+        # GnuCash's ApplyPayment stores the memo on the splits (not on the
+        # transaction description, which is set to the owner/customer name).
+        # Reading split.GetMemo() is consistent across all GnuCash versions.
         bank_name = ''
         pay_amt   = 0.0
+        pay_memo  = ''
         for i in range(txn.CountSplits()):
             split = txn.GetSplit(i)
             acct  = split.GetAccount()
@@ -287,6 +294,7 @@ class ExportBusinessObjectsUseCase:
             if atype not in (gc.ACCT_TYPE_RECEIVABLE, gc.ACCT_TYPE_PAYABLE):
                 bank_name = get_account_full_name(acct)
                 pay_amt   = abs(split.GetAmount().to_double())
+                pay_memo  = split.GetMemo() or ''
                 break
 
         lines = [
@@ -315,10 +323,9 @@ class ExportBusinessObjectsUseCase:
         all_invoices = [gb.Invoice(instance=r) for r in q.run()]
         q.destroy()
 
+        # Export all vendor bills, including unposted
         bills = []
         for inv in all_invoices:
-            if not inv.IsPosted():
-                continue
             try:
                 vendor = inv.GetOwner().GetVendor()
                 if vendor is not None:
@@ -338,6 +345,7 @@ class ExportBusinessObjectsUseCase:
             for raw_entry in inv.GetEntries():
                 lines += self._format_inv_entry(lib, raw_entry)
 
+            # posted block — always emitted; "none" sentinel when not posted
             posted_txn = inv.GetPostedTxn()
             if posted_txn:
                 ap_name = get_account_full_name(inv.GetPostedAcc())
@@ -347,8 +355,12 @@ class ExportBusinessObjectsUseCase:
                 lines.append(f'    ap_account: "{ap_name}"')
                 lines.append(f'    memo: "{posted_txn.GetDescription()}"')
                 lines.append('    accumulate: true')
+            else:
+                lines.append('  posted: none')
 
+            # payment blocks — always emitted; "none" sentinel when no payments exist
             lot = inv.GetPostedLot()
+            has_payments = False
             if lot:
                 for raw_split in lot.get_split_list():
                     s   = Split(instance=raw_split)
@@ -358,6 +370,9 @@ class ExportBusinessObjectsUseCase:
                     if gc.gncInvoiceGetInvoiceFromTxn(txn.instance) is not None:
                         continue
                     lines += self._format_payment(txn)
+                    has_payments = True
+            if not has_payments:
+                lines.append('  payment: none')
 
             bill_strings.append('\n'.join(lines))
         return '\n\n'.join(bill_strings)


### PR DESCRIPTION
Problem: the previous export silently omitted unposted invoices and
omitted posted:/payment: blocks when empty, making it impossible to
distinguish "unposted", "posted but unpaid", and "paid" by reading the
output — users had to infer status from the absence of blocks.

Export changes (export_business_objects.py):
- Include unposted customer invoices and vendor bills in export
  (removed the IsPosted() filter that silently skipped them)
- Always emit posted: and payment: lines on every invoice/bill:
    posted: none        → invoice has not been posted to AR/AP
    payment: none       → no payments have been applied
    posted: / payment:  → full data block as before
- Same treatment applied to _export_bills
- Fix _format_payment to read memo from the bank split (split.GetMemo)
  rather than txn.GetDescription; GnuCash's ApplyPayment always stores
  the memo on splits and sets txn description to the owner name —
  txn.GetDescription returned the customer name on OpenSUSE/GnuCash 5.x

Importer fixes and validation (gnucash_importer.py):
- Pass None (not a manually-allocated Transaction) to ApplyPayment for
  both invoice and bill payments; GnuCash creates the payment transaction
  internally when txn=None. Passing Transaction(instance=xaccMallocTransaction())
  segfaults on GnuCash 3.8 (ubuntu20) because the transaction is not
  properly initialised before ApplyPayment calls xaccTransBeginEdit on it.
- Pass empty string (not None) for num — GnuCash 3.8 may not handle NULL
  for const char* parameters safely.
- Error on all logically contradictory posted:/payment: combinations,
  for both invoices and bills:
    - "posted: none" + posted: block → error
    - multiple posted: blocks → error
    - "payment: none" + payment: block → error
    - "posted: none" + payment: block → error (cannot pay unposted invoice)

Fixture additions (business_objects.txt):
- Assets:Bank account added (needed for payment target)
- INV-2026-002: unposted invoice (no posted: block on import)
- INV-2026-003: posted, single full payment (total 210 CAD)
- INV-2026-004: posted, two partial payments (100+100 of 315 CAD due)
- INV-2026-005: posted, two payments totalling full amount (420 CAD)

Reference file (business_objects_only.txt):
- Updated to reflect the new explicit format for all five invoices,
  including unposted INV-2026-002 with posted: none / payment: none

Test assertions (test_business_objects.py):
- Added get_invoice_block() helper to extract a single invoice block
- Per-invoice state assertions verify the correct combination of
  posted:/payment: presence for each of the five invoice states:
  unposted, posted-not-paid, single-payment, partial-multi-payment,
  and fully-paid-multi-payment
- Parametrized test_invoice_contradiction_errors covers all three
  invalid posted:/payment: combinations and verifies each produces
  a clear ValueError with a descriptive message