### PR TITLE
docs: clarify update strategy memo/action field semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,18 @@ fails immediately if either condition is not met — it will never silently crea
 transaction. All GUIDs are validated before any changes are applied, so a file with one
 bad GUID leaves the book untouched.
 
+**`update` strategy — field update semantics:**
+
+When using `--strategy update`, each field is updated only if it is explicitly present in the plaintext file. The rules for `memo` (and `action`) on splits are:
+
+| Plaintext value | Effect on existing GnuCash memo |
+|---|---|
+| Field omitted entirely | Left unchanged |
+| `memo: ""` (empty string) | Cleared (set to empty) |
+| `memo: "some text"` | Replaced with new text |
+
+In other words, **omitting a field means "leave it alone"**, while supplying an empty string means "clear it". This applies to both split `memo` and split `action`.
+
 **How conflicts are detected:**
 
 An account from plaintext exists in GnuCash if:


### PR DESCRIPTION
Add a table under the --strategy update section of the README explaining exactly how memo (and action) fields behave:

- Omitting the field entirely leaves the existing GnuCash value unchanged
- Supplying memo: "" clears the field (calls SetMemo(""))
- Supplying memo: "text" replaces the field with the new value

This distinction was not previously documented and caused user confusion about whether an empty string means "clear" or "leave alone".