### PR TITLE
feat: add --output-new option to import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,29 @@ Preview without making changes (dry run):
 gnucash-plaintext import mybook.gnucash transactions.txt --dry-run
 ```
 
+#### Capturing GUIDs of newly imported transactions
+
+When importing new transactions, GnuCash assigns a GUID to each one. Use
+`--output-new` to capture those transaction blocks (with their `guid:` fields)
+immediately after import — without a separate export step:
+
+```bash
+# Write new transactions to a file
+gnucash-plaintext import mybook.gnucash transactions.txt --output-new new.txt
+
+# Print to stdout
+gnucash-plaintext import mybook.gnucash transactions.txt --output-new -
+```
+
+The output contains only the transaction blocks (no commodity or account
+preamble). Each block includes the `guid:` field assigned by GnuCash, which
+you can use later with `--strategy update` to edit those transactions
+in-place, or with `get-transaction` / `delete-transaction-by-guid` to
+look them up directly.
+
+If all transactions in the file are duplicates and none are imported, no
+output is written (the option is silently ignored).
+
 ### Import and export business objects
 
 Customers, vendors, tax tables, invoices, and bills can be round-tripped

--- a/cli/import_cmd.py
+++ b/cli/import_cmd.py
@@ -10,6 +10,7 @@ from repositories.gnucash_repository import GnuCashRepository, SessionMode
 from services.conflict_resolver import ResolutionStrategy
 from services.gnucash_importer import GnuCashImporter
 from services.plaintext_parser import DirectiveType, PlaintextParser
+from use_cases.export_transactions import ExportTransactionsUseCase
 from use_cases.import_transactions import ImportTransactionsUseCase
 
 
@@ -37,7 +38,14 @@ from use_cases.import_transactions import ImportTransactionsUseCase
     help='Create a new GnuCash file (file must not already exist)'
 )
 @click.option('--include-business-objects', is_flag=True, help='Include business objects (customers, invoices, etc.)')
-def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, strategy, dry_run, create_new, include_business_objects):
+@click.option(
+    '--output-new',
+    'output_new',
+    type=click.Path(),
+    default=None,
+    help='Write newly imported transactions (with GUIDs) to this file. Use "-" for stdout.'
+)
+def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, strategy, dry_run, create_new, include_business_objects, output_new):
     """
     Import plaintext transactions to GnuCash file.
 
@@ -62,6 +70,10 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
         gnucash-plaintext import -i mybook.gnucash -f transactions.txt --strategy keep-incoming
 
         gnucash-plaintext import --new mybook.gnucash chart-of-accounts.txt
+
+        gnucash-plaintext import mybook.gnucash transactions.txt --output-new new.txt
+
+        gnucash-plaintext import mybook.gnucash transactions.txt --output-new -
     """
     # Support both positional and flag-based arguments
     gnucash_file = gnucash_path or gnucash_file
@@ -74,6 +86,8 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
 
     if create_new and dry_run:
         raise click.UsageError("--new and --dry-run are mutually exclusive: --new always creates a file.")
+    if output_new and dry_run:
+        click.echo("Warning: --output-new is ignored in dry-run mode (no changes are saved)", err=True)
 
     # Validate all paths before touching the filesystem
     if create_new:
@@ -90,6 +104,10 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
             )
     if not os.path.exists(input_file):
         raise click.UsageError(f"Plaintext file does not exist: {input_file}")
+    if output_new and output_new != '-':
+        out_dir = os.path.dirname(os.path.abspath(output_new))
+        if not os.path.isdir(out_dir):
+            raise click.UsageError(f"--output-new directory does not exist: {out_dir}")
 
     # Map CLI strategy to ResolutionStrategy enum
     strategy_map = {
@@ -166,6 +184,23 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
                 click.echo("Saving changes...")
                 repo.save()
                 click.echo("✓ Changes saved")
+
+                # Write newly created transactions (transaction blocks only, with GUIDs)
+                if output_new and result.new_transactions:
+                    exporter = ExportTransactionsUseCase(repo)
+                    plaintext = exporter.format_transaction_list(result.new_transactions)
+                    if output_new == '-':
+                        # Write raw plaintext to stdout — no header so output
+                        # remains parseable when piped or redirected
+                        click.echo(plaintext, nl=False)
+                    else:
+                        try:
+                            with open(output_new, 'w', encoding='utf-8') as f:
+                                f.write(plaintext)
+                            click.echo(f"✓ New transactions written to {output_new}")
+                        except OSError as exc:
+                            click.echo(f"✗ Could not write --output-new file: {exc}", err=True)
+                            raise SystemExit(1) from exc
             elif dry_run:
                 click.echo("")
                 click.echo("✓ Dry run complete (no changes made)")

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -177,13 +177,17 @@ class GnuCashImporter:
         logging.debug(f"Created account {account_fullname}")
 
     @staticmethod
-    def create_transaction(directive: PlaintextDirective, book: Book):
+    def create_transaction(directive: PlaintextDirective, book: Book) -> 'Transaction':
         """
         Create transaction from directive.
 
         Args:
             directive: PlaintextDirective of type TRANSACTION
             book: GnuCash book
+
+        Returns:
+            The newly created GnuCash Transaction object (after CommitEdit).
+            Raises on any error (e.g. missing account) — never returns None.
         """
         if directive.type != DirectiveType.TRANSACTION:
             raise ValueError(f"Expected TRANSACTION but got {directive.type}")
@@ -300,7 +304,7 @@ class GnuCashImporter:
 
         transaction.CommitEdit()
         logging.debug(f"Created transaction on {date_str}")
-        return True
+        return transaction
 
     @staticmethod
     def update_transaction(existing_tx, directive: PlaintextDirective, book: Book) -> None:

--- a/tests/integration/test_cli_import.py
+++ b/tests/integration/test_cli_import.py
@@ -6,6 +6,7 @@ These tests verify the CLI command works end-to-end.
 
 import os
 import tempfile
+import time
 
 from click.testing import CliRunner
 
@@ -281,6 +282,65 @@ class TestImportCLI:
             assert result.exit_code != 0
             assert "mutually exclusive" in result.output
             assert not os.path.exists(new_gnucash)
+
+    def test_output_new_to_file(self, import_new_plaintext_with_transaction):
+        """--output-new <file> writes the imported transaction block (with guid) to the file."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            new_gnucash = os.path.join(tmpdir, "book.gnucash")
+            out_file = os.path.join(tmpdir, "new.txt")
+
+            result = runner.invoke(import_transactions, [
+                '--new', new_gnucash, import_new_plaintext_with_transaction,
+                '--output-new', out_file,
+            ])
+
+            assert result.exit_code == 0, result.output
+            assert "New transactions written to" in result.output
+            assert os.path.exists(out_file)
+            with open(out_file, encoding='utf-8') as f:
+                content = f.read()
+            assert 'guid:' in content
+            assert '"Test transaction"' in content
+
+    def test_output_new_to_stdout(self, import_new_plaintext_with_transaction):
+        """--output-new - writes the transaction block directly to stdout (no extra header)."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            new_gnucash = os.path.join(tmpdir, "book.gnucash")
+
+            result = runner.invoke(import_transactions, [
+                '--new', new_gnucash, import_new_plaintext_with_transaction,
+                '--output-new', '-',
+            ])
+
+            assert result.exit_code == 0, result.output
+            assert 'guid:' in result.output
+            assert '"Test transaction"' in result.output
+
+    def test_output_new_silent_when_no_new_transactions(self, import_new_plaintext_with_transaction):
+        """--output-new produces no output file when all transactions are duplicates."""
+        runner = CliRunner()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            new_gnucash = os.path.join(tmpdir, "book.gnucash")
+            out_file = os.path.join(tmpdir, "new.txt")
+
+            # First import creates the transaction
+            runner.invoke(import_transactions, [
+                '--new', new_gnucash, import_new_plaintext_with_transaction,
+            ])
+            time.sleep(1)  # avoid backup timestamp collision on OpenSUSE
+            # Second import: duplicate — nothing new should be written
+            result = runner.invoke(import_transactions, [
+                new_gnucash, import_new_plaintext_with_transaction,
+                '--output-new', out_file,
+            ])
+
+            assert result.exit_code == 0, result.output
+            assert not os.path.exists(out_file), "output-new file should not be created when nothing is imported"
 
     def test_import_new_reports_account_creation_error(self, import_new_plaintext_invalid_account_type):
         """--new with an unrecognised account type reports the error in the summary.

--- a/tests/unit/services/test_gnucash_importer_errors.py
+++ b/tests/unit/services/test_gnucash_importer_errors.py
@@ -240,8 +240,11 @@ class TestCreateTransactionErrors:
             ]
             directive = _tx_directive_with_currency(splits)
 
+            from gnucash import Transaction
             result = GnuCashImporter.create_transaction(directive, book)
-            assert result is True
+            assert isinstance(result, Transaction)
+            assert result.GetDescription() == 'Test'
+            assert result.GetDate().strftime('%Y-%m-%d') == '2024-06-15'
         finally:
             session.end()
             if os.path.exists(path):

--- a/use_cases/export_transactions.py
+++ b/use_cases/export_transactions.py
@@ -209,6 +209,19 @@ class ExportTransactionsUseCase:
             self._format_transaction(transaction, lines)
         return '\n'.join(lines) + '\n' if lines else ''
 
+    def format_transaction_list(self, transactions: list) -> str:
+        """
+        Format a list of Transaction objects as plaintext (transaction blocks only).
+
+        Collects all required data from the transactions and returns their
+        plaintext representation without commodity or account preamble.
+        Useful for outputting newly imported transactions with their GUIDs.
+        """
+        result = ExportResult()
+        for tx in transactions:
+            self._collect_transaction_data(tx, result)
+        return self.format_transactions_section(result)
+
     def _file_date_str(self) -> str:
         """Return GnuCash file modification date as YYYY-MM-DD string."""
         mtime = os.path.getmtime(self.repository.file_path)

--- a/use_cases/import_transactions.py
+++ b/use_cases/import_transactions.py
@@ -32,6 +32,7 @@ class ImportResult:
         self.duplicates = []
         self.conflicts = []
         self.errors = []
+        self.new_transactions = []  # Transaction objects created during this import
 
     def get_summary(self) -> str:
         """Get summary string"""
@@ -361,8 +362,9 @@ class ImportTransactionsUseCase:
                         continue
 
                     # Create transaction
-                    importer.create_transaction(child, book)
+                    tx = importer.create_transaction(child, book)
                     result.imported_count += 1
+                    result.new_transactions.append(tx)
 
                 except Exception as e:
                     logging.error(f"Failed to import transaction: {e}")


### PR DESCRIPTION
After a successful import, write the newly created transactions (transaction blocks only, with guid: metadata) to a file or stdout, so users can know assigned GUIDs without a separate export step.

Changes:
- gnucash_importer.create_transaction: return the Transaction object instead of True; add -> Transaction return type annotation and note in docstring that it raises on error and never returns None
- ImportResult.new_transactions: list that collects every Transaction created during import (non-UPDATE path; UPDATE modifies existing transactions and produces no new ones)
- import_from_file: capture return value of create_transaction and append to result.new_transactions
- ExportTransactionsUseCase.format_transaction_list: new public method that takes a list of Transaction objects and returns their plaintext representation (transaction blocks only, no commodity/account preamble)
- import_cmd: new --output-new <FILE> option; use "-" for stdout
  - Pre-validates output directory exists before any import runs (consistent with "Validate all paths before touching the filesystem" pattern already in the command)
  - Warns (stderr) when combined with --dry-run (no file is saved)
  - After repo.save(), calls exporter.format_transaction_list() and writes to the specified destination
  - Stdout mode (-) writes raw plaintext only — no header so output remains parseable when piped or redirected
  - OSError on file write emits a clean error message and exits non-zero
  - Silent (no file created) when no new transactions were imported
  - File writes use encoding='utf-8' for multi-currency descriptions
- README: document --output-new usage and GUID workflow
- Tests: three new integration tests (file output, stdout output, silent on all-duplicate run with time.sleep(1) to avoid OpenSUSE backup timestamp collision); unit test for create_transaction return value upgraded to isinstance(Transaction) + description/date assertions