### PR TITLE
feat: support exporting multiple transactions by GUID in one pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,21 +338,30 @@ gnucash-plaintext export mybook.gnucash transactions.txt \
   --account "Assets:Bank"
 ```
 
-### Export a single transaction by GUID
+### Export transactions by GUID
 
-Export one specific transaction to plaintext (useful for AI-assisted editing or review):
+Export one or more transactions to plaintext (useful for AI-assisted editing or review):
 
 ```bash
+# Single transaction
 gnucash-plaintext export-transaction mybook.gnucash --guid 317c8ae6e0084c33951d052b9f1b9f23
+
+# Multiple transactions in one pass
+gnucash-plaintext export-transaction mybook.gnucash \
+    --guid 317c8ae6e0084c33951d052b9f1b9f23 \
+    --guid a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
 ```
 
-The output is self-contained — it includes the commodity and account declarations needed to re-import or process the transaction independently. Output goes to stdout by default; use `-o` to write to a file:
+The output is self-contained — it includes the commodity and account declarations needed to re-import or process the transactions independently. When multiple GUIDs are given, shared commodities and accounts are emitted only once. Output goes to stdout by default; use `-o` to write to a file:
 
 ```bash
-gnucash-plaintext export-transaction mybook.gnucash --guid 317c8ae6e0084c33951d052b9f1b9f23 -o tx.txt
+gnucash-plaintext export-transaction mybook.gnucash \
+    --guid 317c8ae6e0084c33951d052b9f1b9f23 \
+    --guid a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4 \
+    -o batch.txt
 ```
 
-`--guid` is required. Omitting it prints an error with usage guidance.
+At least one `--guid` is required. Omitting it prints an error with usage guidance.
 
 ### Delete a transaction by GUID
 

--- a/cli/export_transaction_cmd.py
+++ b/cli/export_transaction_cmd.py
@@ -1,5 +1,5 @@
 """
-CLI command for exporting a single GnuCash transaction by GUID to plaintext.
+CLI command for exporting one or more GnuCash transactions by GUID to plaintext.
 """
 
 import os
@@ -14,20 +14,25 @@ from use_cases.export_transactions import ExportTransactionsUseCase
 @click.command()
 @click.argument('gnucash_file', required=False, type=click.Path())
 @click.option('-i', '--input', 'input_file', type=click.Path(), help='Input GnuCash XML file')
-@click.option('--guid', required=False, default=None, help='GUID of the transaction to export (32-character hex)')
+@click.option('--guid', 'guids', required=False, multiple=True, help='GUID of a transaction to export (32-character hex); repeat for multiple')
 @click.option('-o', '--output', 'output_path', type=click.Path(), help='Output file (defaults to stdout)')
-def export_transaction(gnucash_file, input_file, guid, output_path):
+def export_transaction(gnucash_file, input_file, guids, output_path):
     """
-    Export a single transaction from a GnuCash file to plaintext format.
+    Export one or more transactions from a GnuCash file to plaintext format.
 
-    --guid is required. The output includes the commodity and account
-    declarations needed to make the block self-contained for import or
-    AI processing.
+    --guid is required and may be repeated to export multiple transactions in
+    one pass. The output includes the commodity and account declarations needed
+    to make the block self-contained for import or AI processing. Shared
+    commodities and accounts are emitted only once.
 
     \b
     Examples:
 
         gnucash-plaintext export-transaction mybook.gnucash --guid 317c8ae6e0084c33951d052b9f1b9f23
+
+        gnucash-plaintext export-transaction mybook.gnucash \\
+            --guid 317c8ae6e0084c33951d052b9f1b9f23 \\
+            --guid a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
 
         gnucash-plaintext export-transaction -i mybook.gnucash --guid 317c8ae6e0084c33951d052b9f1b9f23 -o tx.txt
     """
@@ -36,9 +41,9 @@ def export_transaction(gnucash_file, input_file, guid, output_path):
     if not gnucash_file:
         raise click.UsageError("Missing input file. Use positional argument or -i/--input flag.")
 
-    if not guid:
+    if not guids:
         raise click.UsageError(
-            "Missing --guid. export-transaction requires a transaction GUID.\n"
+            "Missing --guid. export-transaction requires at least one transaction GUID.\n"
             "Example: gnucash-plaintext export-transaction mybook.gnucash --guid <32-char-hex>"
         )
 
@@ -51,13 +56,13 @@ def export_transaction(gnucash_file, input_file, guid, output_path):
 
         try:
             use_case = ExportTransactionsUseCase(repo)
-            result = use_case.execute_by_guid(guid)
+            result = use_case.execute_by_guids(guids)
             plaintext = use_case.format_as_plaintext(result)
 
             if output_path:
-                with open(output_path, 'w') as f:
+                with open(output_path, 'w', encoding='utf-8') as f:
                     f.write(plaintext)
-                click.echo(f"✓ Transaction {guid} exported to {output_path}")
+                click.echo(f"✓ {len(guids)} transaction(s) exported to {output_path}")
             else:
                 sys.stdout.write(plaintext)
 

--- a/tests/unit/use_cases/test_export_transactions.py
+++ b/tests/unit/use_cases/test_export_transactions.py
@@ -260,3 +260,98 @@ class TestExportByGuid:
 
             with pytest.raises(ValueError, match="No transaction found"):
                 use_case.execute_by_guid("deadbeefdeadbeefdeadbeefdeadbeef")
+
+
+class TestExportByGuids:
+    """Test execute_by_guids — multi-transaction export"""
+
+    def test_export_two_guids_returns_both_transactions(self, temp_gnucash_with_transactions):
+        """execute_by_guids returns all requested transactions"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+
+            all_result = use_case.execute()
+            assert len(all_result.transactions) >= 2, "fixture needs at least 2 transactions"
+            guid0 = all_result.transactions[0].GetGUID().to_string()
+            guid1 = all_result.transactions[1].GetGUID().to_string()
+
+            result = use_case.execute_by_guids([guid0, guid1])
+
+            assert len(result.transactions) == 2
+            result_guids = {tx.GetGUID().to_string() for tx in result.transactions}
+            assert guid0 in result_guids
+            assert guid1 in result_guids
+
+    def test_export_by_guids_shared_commodities_emitted_once(self, temp_gnucash_with_transactions):
+        """Commodities shared across multiple transactions appear only once in the result"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+
+            all_result = use_case.execute()
+            guids = [tx.GetGUID().to_string() for tx in all_result.transactions[:2]]
+
+            result = use_case.execute_by_guids(guids)
+
+            # Commodity tickers must be unique in the result
+            tickers = [c.get_mnemonic() for c, _ in result.commodities]
+            assert len(tickers) == len(set(tickers)), "duplicate commodity in result"
+
+    def test_export_by_guids_duplicate_guid_ignored(self, temp_gnucash_with_transactions):
+        """Passing the same GUID twice produces exactly one transaction in the result"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+
+            all_result = use_case.execute()
+            guid = all_result.transactions[0].GetGUID().to_string()
+
+            result = use_case.execute_by_guids([guid, guid])
+
+            assert len(result.transactions) == 1
+
+    def test_export_by_guids_invalid_guid_raises(self, temp_gnucash_with_transactions):
+        """execute_by_guids raises ValueError for a malformed GUID"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+
+            with pytest.raises(ValueError, match="Invalid GUID format"):
+                use_case.execute_by_guids(["not-a-guid"])
+
+    def test_export_by_guids_nonexistent_guid_raises(self, temp_gnucash_with_transactions):
+        """execute_by_guids raises ValueError when a GUID is not found"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+
+            with pytest.raises(ValueError, match="No transaction found"):
+                use_case.execute_by_guids(["deadbeefdeadbeefdeadbeefdeadbeef"])
+
+    def test_execute_by_guid_delegates_to_execute_by_guids(self, temp_gnucash_with_transactions):
+        """execute_by_guid (singular) returns same result as execute_by_guids with one element"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+
+            all_result = use_case.execute()
+            guid = all_result.transactions[0].GetGUID().to_string()
+
+            single = use_case.execute_by_guid(guid)
+            multi  = use_case.execute_by_guids([guid])
+
+            assert len(single.transactions) == len(multi.transactions) == 1
+            assert single.transactions[0].GetGUID().to_string() == guid

--- a/use_cases/export_transactions.py
+++ b/use_cases/export_transactions.py
@@ -7,7 +7,7 @@ with all metadata required for round-trip import.
 
 import datetime
 import os
-from typing import Optional
+from typing import Optional, Sequence
 
 from gnucash import Transaction
 from gnucash.gnucash_core_c import (
@@ -397,13 +397,48 @@ class ExportTransactionsUseCase:
         for key, value in sorted(custom_split_meta.items()):
             lines.append(f'\t\t{key}: {encode_value_as_string(value)}')
 
+    def execute_by_guids(self, guids: Sequence[str]) -> ExportResult:
+        """
+        Export one or more transactions identified by their GUIDs in one pass.
+
+        Looks up each GUID with xaccTransLookup (O(1) per lookup), then feeds
+        every transaction into a single ExportResult via _collect_transaction_data.
+        Commodities and accounts are deduplicated naturally by the seen-sets in
+        ExportResult — no post-hoc merging needed.
+
+        Duplicate GUIDs in the input are silently ignored (each transaction
+        appears exactly once in the result).
+
+        Args:
+            guids: sequence of 32-character hex GUID strings
+
+        Returns:
+            ExportResult containing all matched transactions plus the union of
+            their commodity and account declarations
+
+        Raises:
+            ValueError: if any GUID is malformed or not found in the book
+        """
+        result = ExportResult()
+        seen_guids = set()
+        for guid in guids:
+            if guid in seen_guids:
+                continue
+            seen_guids.add(guid)
+            gnc_guid = GncGUID()
+            if not string_to_guid(guid, gnc_guid):
+                raise ValueError(f"Invalid GUID format: {guid}")
+            raw = xaccTransLookup(gnc_guid, self.repository.book.instance)
+            if raw is None:
+                raise ValueError(f"No transaction found with GUID: {guid}")
+            self._collect_transaction_data(Transaction(instance=raw), result)
+        return result
+
     def execute_by_guid(self, guid: str) -> ExportResult:
         """
         Export a single transaction identified by its GUID.
 
-        Uses xaccTransLookup for O(1) direct lookup — no scan of all
-        transactions. The result includes the commodity and account
-        declarations for that transaction so the output is self-contained.
+        Convenience wrapper around execute_by_guids for the single-item case.
 
         Args:
             guid: 32-character hex GUID string of the transaction to export
@@ -416,18 +451,7 @@ class ExportTransactionsUseCase:
             ValueError: if the GUID string is malformed or no transaction
                         with that GUID exists
         """
-        gnc_guid = GncGUID()
-        if not string_to_guid(guid, gnc_guid):
-            raise ValueError(f"Invalid GUID format: {guid}")
-
-        raw = xaccTransLookup(gnc_guid, self.repository.book.instance)
-        if raw is None:
-            raise ValueError(f"No transaction found with GUID: {guid}")
-
-        target = Transaction(instance=raw)
-        result = ExportResult()
-        self._collect_transaction_data(target, result)
-        return result
+        return self.execute_by_guids([guid])
 
     def export_to_file(
         self,


### PR DESCRIPTION
Previously export-transaction accepted a single --guid. This change makes --guid repeatable so any number of transactions can be exported in one command, with shared commodities and accounts emitted only once.

Changes:
- ExportTransactionsUseCase.execute_by_guids: new core method that accepts a Sequence[str] of GUIDs, looks up each with xaccTransLookup (O(1) per lookup), and feeds every transaction into a single ExportResult via _collect_transaction_data; seen-sets in ExportResult deduplicate commodities/accounts naturally — no post-hoc merging; duplicate GUIDs in the input are silently ignored (each transaction appears exactly once)
- ExportTransactionsUseCase.execute_by_guid: now delegates to execute_by_guids([guid]) — eliminates logic duplication
- export_transaction_cmd: --guid is now repeatable (multiple=True, renamed param to guids); single --guid usage is fully backward- compatible; all cases go through execute_by_guids; file writes use encoding='utf-8'; success message reports count
- README: update export-transaction section with multi-guid examples
- Tests: six new tests covering two-guid export, shared-commodity deduplication, duplicate-guid suppression, error paths, and execute_by_guid delegation