### PR TITLE
docs: bank import workflow guide and runnable matching demo

### DIFF
--- a/demos/bank_import_matching/demo.py
+++ b/demos/bank_import_matching/demo.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""
+Bank Import Matching Demo
+=========================
+
+Demonstrates the conflict between a GnuCash invoice payment transaction
+and a bank OFX import transaction, and shows how interactive matching
+resolves it by linking them via FITID.
+
+Run inside Docker:
+    bash demos/bank_import_matching/run.sh
+
+What this demo shows:
+    1. An invoice payment is applied in GnuCash  → State 2 transaction
+       (Bank + AR, no FITID)
+    2. The same payment arrives via bank OFX import → State 1 transaction
+       (Bank + Imbalance, FITID stored as metadata)
+    3. Both appear in the bank account — a double-count
+    4. Interactive matching by date + amount finds the pair
+    5. User confirms → FITID transferred, Imbalance transaction deleted → State 3
+
+WARNING: The date + amount matching in this demo is for illustration only.
+         It will produce wrong results when two transactions share the same
+         date and amount. You are responsible for implementing a matching
+         strategy appropriate for your data.
+"""
+
+import glob as glob_module
+import os
+import tempfile
+import time
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_DATE = (15, 3, 2026)          # day, month, year
+SAMPLE_AMOUNT_NUM = 100000           # GncNumeric numerator   (1000.00 CAD)
+SAMPLE_AMOUNT_DEN = 100              # GncNumeric denominator
+SAMPLE_FITID = "BNK-20260315-00042"  # bank's unique transaction ID
+SAMPLE_BANK_MEMO = "e-TRANSFER FROM ACME CORP REF 00042"
+SAMPLE_INVOICE_DESC = "Payment for INV-2026-031 (Acme Corp)"
+
+
+# ---------------------------------------------------------------------------
+# Book setup
+# ---------------------------------------------------------------------------
+
+def create_book(path):
+    """
+    Create a new GnuCash file with a minimal account structure:
+
+        Assets
+          Bank
+            Checking      ← the bank account we are importing into
+          Receivable
+            AcmeCorp      ← AR account for invoice payment
+        Income
+          Services
+        Imbalance
+          CAD             ← placeholder used by bank import (State 1)
+    """
+    import gnucash
+    from gnucash import Account, Session
+
+    try:
+        from gnucash import SessionOpenMode
+        session = Session(f'xml://{path}', SessionOpenMode.SESSION_NEW_STORE)
+    except ImportError:
+        session = Session(f'xml://{path}', is_new=True)
+
+    book = session.book
+    root = book.get_root_account()
+    cad = book.get_table().lookup('CURRENCY', 'CAD')
+
+    def make(parent, name, acct_type):
+        acct = Account(book)
+        acct.SetName(name)
+        acct.SetType(acct_type)
+        acct.SetCommodity(cad)
+        parent.append_child(acct)
+        return acct
+
+    assets     = make(root,    'Assets',     gnucash.ACCT_TYPE_ASSET)
+    bank       = make(assets,  'Bank',       gnucash.ACCT_TYPE_BANK)
+    make(bank,    'Checking',   gnucash.ACCT_TYPE_BANK)
+    recv       = make(assets,  'Receivable', gnucash.ACCT_TYPE_RECEIVABLE)
+    make(recv,    'AcmeCorp',   gnucash.ACCT_TYPE_RECEIVABLE)
+    income     = make(root,    'Income',     gnucash.ACCT_TYPE_INCOME)
+    _services  = make(income,  'Services',   gnucash.ACCT_TYPE_INCOME)
+    imbalance  = make(root,    'Imbalance',  gnucash.ACCT_TYPE_ASSET)
+    make(imbalance, 'CAD',      gnucash.ACCT_TYPE_ASSET)
+
+    session.save()
+    session.end()
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Transaction helpers
+# ---------------------------------------------------------------------------
+
+def _find_account(root, path):
+    """Walk account path like 'Assets:Bank:Checking'."""
+    acc = root
+    for name in path.split(':'):
+        acc = next(
+            (c for c in acc.get_children_sorted() if c.GetName() == name),
+            None,
+        )
+        if acc is None:
+            return None
+    return acc
+
+
+def create_invoice_payment(path):
+    """
+    State 2: invoice payment transaction.
+
+    Simulates what GnuCash creates when you apply payment to an invoice:
+        Assets:Bank:Checking          +1000.00 CAD  reconcile=n
+        Assets:Receivable:AcmeCorp    -1000.00 CAD
+
+    No FITID — GnuCash's Apply Payment knows nothing about bank references.
+    """
+    from gnucash import GncNumeric, Session, Split, Transaction
+
+    try:
+        from gnucash import SessionOpenMode
+        session = Session(f'xml://{path}', SessionOpenMode.SESSION_NORMAL_OPEN)
+    except ImportError:
+        session = Session(f'xml://{path}', is_new=False)
+
+    book = session.book
+    cad = book.get_table().lookup('CURRENCY', 'CAD')
+    root = book.get_root_account()
+    checking = _find_account(root, 'Assets:Bank:Checking')
+    ar_acme  = _find_account(root, 'Assets:Receivable:AcmeCorp')
+
+    tx = Transaction(book)
+    tx.BeginEdit()
+    tx.SetCurrency(cad)
+    tx.SetDate(*SAMPLE_DATE)
+    tx.SetDescription(SAMPLE_INVOICE_DESC)
+
+    s_bank = Split(book)
+    s_bank.SetParent(tx)
+    s_bank.SetAccount(checking)
+    s_bank.SetValue(GncNumeric(SAMPLE_AMOUNT_NUM, SAMPLE_AMOUNT_DEN))
+    s_bank.SetReconcile('n')   # not yet matched to any bank statement
+
+    s_ar = Split(book)
+    s_ar.SetParent(tx)
+    s_ar.SetAccount(ar_acme)
+    s_ar.SetValue(GncNumeric(-SAMPLE_AMOUNT_NUM, SAMPLE_AMOUNT_DEN))
+
+    tx.CommitEdit()
+    session.save()
+    session.end()
+
+    print("[State 2] Invoice payment transaction created:")
+    print(f"          {SAMPLE_INVOICE_DESC}")
+    print("          Assets:Bank:Checking +1000.00 CAD  reconcile=n  (no FITID)")
+    print("          Assets:Receivable:AcmeCorp -1000.00 CAD")
+    print()
+
+
+def create_bank_import(path):
+    """
+    State 1: bank OFX import transaction.
+
+    Simulates what gnucash-plaintext's import-bank command creates when it
+    sees an OFX entry with no matching FITID already in the book:
+        Assets:Bank:Checking          +1000.00 CAD  reconcile=c
+        Imbalance:CAD                 -1000.00 CAD
+
+    FITID is stored as custom metadata on the bank split so it can never
+    be imported twice.
+    """
+    from gnucash import GncNumeric, Session, Split, Transaction
+
+    from infrastructure.gnucash.kvp import set_custom_metadata
+
+    try:
+        from gnucash import SessionOpenMode
+        session = Session(f'xml://{path}', SessionOpenMode.SESSION_NORMAL_OPEN)
+    except ImportError:
+        session = Session(f'xml://{path}', is_new=False)
+
+    book = session.book
+    cad = book.get_table().lookup('CURRENCY', 'CAD')
+    root = book.get_root_account()
+    checking   = _find_account(root, 'Assets:Bank:Checking')
+    imbal_cad  = _find_account(root, 'Imbalance:CAD')
+
+    tx = Transaction(book)
+    tx.BeginEdit()
+    tx.SetCurrency(cad)
+    tx.SetDate(*SAMPLE_DATE)
+    tx.SetDescription(SAMPLE_BANK_MEMO)
+
+    s_bank = Split(book)
+    s_bank.SetParent(tx)
+    s_bank.SetAccount(checking)
+    s_bank.SetValue(GncNumeric(SAMPLE_AMOUNT_NUM, SAMPLE_AMOUNT_DEN))
+    s_bank.SetReconcile('c')   # cleared: seen on bank statement
+
+    # Store FITID on the bank split — this is the deduplication key.
+    # Any future import-bank run that sees the same FITID will skip this entry.
+    set_custom_metadata(s_bank, {'fitid': SAMPLE_FITID})
+
+    s_imbal = Split(book)
+    s_imbal.SetParent(tx)
+    s_imbal.SetAccount(imbal_cad)
+    s_imbal.SetValue(GncNumeric(-SAMPLE_AMOUNT_NUM, SAMPLE_AMOUNT_DEN))
+
+    tx.CommitEdit()
+    session.save()
+    session.end()
+
+    print("[State 1] Bank OFX import transaction created:")
+    print(f"          {SAMPLE_BANK_MEMO}")
+    print(f"          Assets:Bank:Checking +1000.00 CAD  reconcile=c  FITID={SAMPLE_FITID}")
+    print("          Imbalance:CAD -1000.00 CAD")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Conflict detection
+# ---------------------------------------------------------------------------
+
+def show_conflict(path):
+    """
+    Show that the bank account now has two splits for the same real deposit.
+    """
+    from gnucash import Session
+
+    try:
+        from gnucash import SessionOpenMode
+        session = Session(f'xml://{path}', SessionOpenMode.SESSION_NORMAL_OPEN)
+    except ImportError:
+        session = Session(f'xml://{path}', is_new=False)
+
+    try:
+        book = session.book
+        root = book.get_root_account()
+        checking = _find_account(root, 'Assets:Bank:Checking')
+
+        print("=" * 60)
+        print("CONFLICT: Assets:Bank:Checking now has TWO splits")
+        print("          for the same real-world deposit of $1000.00:")
+        print("=" * 60)
+        for split in checking.GetSplitList():
+            tx = split.parent
+            val = split.GetValue()
+            rec = split.GetReconcile()
+            print(f"  [{rec}]  {tx.GetDescription():<45}  {val.num() / val.denom():+.2f} CAD")
+        print()
+    finally:
+        session.end()
+
+
+# ---------------------------------------------------------------------------
+# Interactive matching (date + amount — DEMO ONLY, see disclaimer)
+# ---------------------------------------------------------------------------
+
+def interactive_match(path):
+    """
+    WARNING: Matches by date + amount. For demo purposes only.
+             Same-day same-amount collisions will produce wrong suggestions.
+             You are responsible for your own matching strategy.
+    """
+    from gnucash import Session
+
+    from infrastructure.gnucash.kvp import get_custom_metadata, set_custom_metadata
+
+    print("WARNING: The following match is based on date + amount only.")
+    print("         This is a DEMO. Same-day same-amount collisions will")
+    print("         produce wrong results. You own your matching logic.")
+    print()
+
+    try:
+        from gnucash import SessionOpenMode
+        session = Session(f'xml://{path}', SessionOpenMode.SESSION_NORMAL_OPEN)
+    except ImportError:
+        session = Session(f'xml://{path}', is_new=False)
+
+    try:
+        book = session.book
+        root = book.get_root_account()
+        checking = _find_account(root, 'Assets:Bank:Checking')
+
+        # Separate splits into State 1 (have FITID) and State 2 (no FITID, reconcile=n)
+        state1 = []   # (split, tx, fitid)
+        state2 = []   # (split, tx)
+
+        for split in checking.GetSplitList():
+            tx = split.parent
+            meta = get_custom_metadata(split)
+            fitid = meta.get('fitid')
+            if fitid:
+                state1.append((split, tx, fitid))
+            elif split.GetReconcile() == 'n':
+                state2.append((split, tx))
+
+        if not state1:
+            print("No unlinked bank import transactions found.")
+            return
+
+        for s1_split, s1_tx, fitid in state1:
+            s1_val = s1_split.GetValue()
+            s1_amount = s1_val.num() / s1_val.denom()
+            s1_date = s1_tx.GetDate()
+
+            print(f"Bank entry:  {s1_tx.GetDescription()}")
+            print(f"             date={s1_date}  amount={s1_amount:+.2f} CAD  FITID={fitid}")
+            print()
+
+            # Find State 2 candidates with matching date + amount (DEMO ONLY)
+            candidates = []
+            for s2_split, s2_tx in state2:
+                s2_val = s2_split.GetValue()
+                s2_amount = s2_val.num() / s2_val.denom()
+                if s2_tx.GetDate() == s1_date and abs(s2_amount - s1_amount) < 0.001:
+                    candidates.append((s2_split, s2_tx))
+
+            if not candidates:
+                print("  No matching invoice payment found by date + amount.")
+                print("  Leaving as State 1 (Imbalance). Categorize manually.")
+                print()
+                continue
+
+            if len(candidates) > 1:
+                print(f"  AMBIGUOUS: {len(candidates)} transactions match this date + amount.")
+                print("  Cannot auto-resolve. Inspect manually:")
+                for i, (_, tx) in enumerate(candidates):
+                    print(f"    [{i}] {tx.GetDescription()}")
+                print()
+                continue
+
+            s2_split, s2_tx = candidates[0]
+            print(f"  Candidate:  {s2_tx.GetDescription()}")
+            print("              (no FITID, reconcile=n)")
+            print()
+
+            answer = input(
+                f"  Is '{s1_tx.GetDescription()}'\n"
+                f"  the same payment as '{s2_tx.GetDescription()}'? [y/N] "
+            ).strip().lower()
+
+            if answer != 'y':
+                print("  Skipped.")
+                print()
+                continue
+
+            # --- Link: transfer FITID to invoice payment, delete Imbalance txn ---
+            s2_tx.BeginEdit()
+            set_custom_metadata(s2_split, {'fitid': fitid})
+            s2_split.SetReconcile('c')
+            s2_tx.CommitEdit()
+
+            # CommitEdit after Destroy is required to flush the deletion from
+            # GnuCash's in-memory transaction list (mirrors GnuCashRepository
+            # .delete_transaction which uses the same pattern).
+            s1_tx.BeginEdit()
+            s1_tx.Destroy()
+            s1_tx.CommitEdit()
+            session.save()
+            print()
+            print("[State 3] Linked. Result:")
+            print(f"          {s2_tx.GetDescription()}")
+            print(f"          Assets:Bank:Checking +1000.00 CAD  reconcile=c  FITID={fitid}")
+            print("          Assets:Receivable:AcmeCorp -1000.00 CAD")
+            print()
+
+    finally:
+        session.end()
+
+
+# ---------------------------------------------------------------------------
+# Final state
+# ---------------------------------------------------------------------------
+
+def show_result(path):
+    from gnucash import Session
+
+    from infrastructure.gnucash.kvp import get_custom_metadata
+
+    try:
+        from gnucash import SessionOpenMode
+        session = Session(f'xml://{path}', SessionOpenMode.SESSION_NORMAL_OPEN)
+    except ImportError:
+        session = Session(f'xml://{path}', is_new=False)
+
+    try:
+        book = session.book
+        root = book.get_root_account()
+        checking = _find_account(root, 'Assets:Bank:Checking')
+
+        print("=" * 60)
+        print("FINAL: Assets:Bank:Checking splits")
+        print("=" * 60)
+        for split in checking.GetSplitList():
+            tx = split.parent
+            val = split.GetValue()
+            rec = split.GetReconcile()
+            meta = get_custom_metadata(split)
+            fitid = meta.get('fitid', '(none)')
+            print(f"  [{rec}]  {tx.GetDescription():<45}  {val.num() / val.denom():+.2f}  FITID={fitid}")
+        print()
+    finally:
+        session.end()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    fd, path = tempfile.mkstemp(suffix='.gnucash')
+    os.close(fd)
+    os.unlink(path)
+
+    try:
+        print()
+        print("=== Bank Import Matching Demo ===")
+        print()
+
+        print("Step 1: Create sample GnuCash book")
+        create_book(path)
+        print("        Done.")
+        print()
+
+        print("Step 2: Apply Payment on invoice (GnuCash GUI equivalent)")
+        create_invoice_payment(path)
+        time.sleep(1)  # avoid backup timestamp collision on rapid session reopen
+
+        print("Step 3: Import bank OFX entry (import-bank equivalent)")
+        create_bank_import(path)
+        time.sleep(1)
+
+        print("Step 4: Show the conflict")
+        show_conflict(path)
+
+        print("Step 5: Interactive matching (date + amount — DEMO ONLY)")
+        print()
+        interactive_match(path)
+
+        print("Step 6: Final state")
+        show_result(path)
+
+    finally:
+        for suffix in ('', '.LCK'):
+            if os.path.exists(path + suffix):
+                os.unlink(path + suffix)
+        for backup in glob_module.glob(path + '.*.gnucash'):
+            os.unlink(backup)
+        log_path = path + '.log'
+        if os.path.exists(log_path):
+            os.unlink(log_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/demos/bank_import_matching/run.sh
+++ b/demos/bank_import_matching/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Run the bank import matching demo inside Docker.
+#
+# Usage (from repo root):
+#   ./scripts/run.sh latest bash /workspace/demos/bank_import_matching/run.sh
+#
+# Or with a specific GnuCash version:
+#   ./scripts/run.sh debian12 bash /workspace/demos/bank_import_matching/run.sh
+
+set -e
+
+cd /workspace
+pip install -e . --quiet --break-system-packages 2>/dev/null \
+    || pip install -e . --quiet
+
+python3 demos/bank_import_matching/demo.py

--- a/docs/bank-import-workflow.md
+++ b/docs/bank-import-workflow.md
@@ -1,0 +1,322 @@
+# Bank Import Workflow with gnucash-plaintext
+
+## The Problem
+
+GnuCash users who manage invoices face a recurring conflict when importing bank
+statements: the payment for an invoice may appear in two places simultaneously.
+
+1. **GnuCash Apply Payment** — when you mark an invoice as paid, GnuCash creates
+   a double-entry transaction internally:
+   ```
+   2026-03-15  Payment for INV-2026-001
+     Assets:Bank:Chequing          +1,000.00 CAD
+     Assets:Receivable:Client      -1,000.00 CAD
+   ```
+
+2. **Bank statement (OFX/QFX/CSV)** — your bank also records that same deposit:
+   ```
+   2026-03-15  TRANSFER REF 12345   +1,000.00 CAD
+   ```
+
+If both end up in GnuCash as separate transactions, you have double-counted the
+deposit. Your bank account balance will be overstated by $1,000.
+
+---
+
+## Why GnuCash's Built-in OFX Importer Doesn't Fully Solve This
+
+GnuCash's `File → Import → Import OFX/QIF` uses BAYES probabilistic matching to
+detect if an imported bank entry already exists as a transaction. When it finds a
+match, it marks the existing transaction as cleared (`c`) and discards the OFX
+entry — no duplicate is created.
+
+However, BAYES matching **frequently fails for invoice payments** because:
+
+- Invoice payment transactions are created internally by GnuCash with generic
+  descriptions like `"Payment"` or an invoice number
+- These descriptions have no resemblance to the bank's memo text
+  (`"TRANSFER REF 12345"`)
+- BAYES has no training history to correlate them
+
+When BAYES fails to match, GnuCash creates a second transaction from the OFX
+entry, leaving you with a duplicate bank split and an `Imbalance` account entry
+that needs manual cleanup.
+
+---
+
+## Why gnucash-plaintext Cannot Rely on Amount + Date Matching
+
+A natural fallback is to match bank entries to existing transactions by
+`(account, date, amount)`. This fails in practice because:
+
+- Two customers can pay the same invoice amount on the same day
+- Duplicate charges (e.g., two $50 grocery purchases in one day) are common
+- There is no way to enforce import ordering — bank import may happen before or
+  after Apply Payment
+
+Any system that auto-matches on amount + date alone will produce silent wrong
+matches in these cases.
+
+---
+
+## The Only Reliable Deduplication Key: FITID
+
+Every OFX transaction contains a `<FITID>` field — the Financial Institution
+Transaction ID. This is the bank's own unique identifier for the transaction. It
+is stable, collision-free, and permanent.
+
+The design principle: **FITID is the primary deduplication key. Nothing else is.**
+
+- If a FITID has already been recorded in GnuCash (as a split KVP), the OFX entry
+  is a duplicate and must be skipped entirely.
+- If a FITID has not been seen, the OFX entry is new and should be imported.
+
+Invoice payment transactions created by GnuCash's Apply Payment have no FITID.
+This is the root of the conflict — the bank knows its FITID, but GnuCash's
+payment record does not.
+
+---
+
+## Transaction States
+
+Understanding three states helps reason about the workflow:
+
+### State 1: Bank-anchored (OFX imported, not yet categorized)
+
+The bank entry has been imported. The FITID is stored. The other side of the
+transaction is `Imbalance` — a placeholder until the user categorizes it.
+
+```
+transaction 2026-03-15
+  fitid: abc123
+  memo: "TRANSFER REF 12345"
+  split Assets:Bank:Chequing          +1000.00 CAD   reconcile=c
+  split Imbalance:CAD                 -1000.00 CAD
+```
+
+### State 2: Categorized (Apply Payment done, not yet linked to bank entry)
+
+The invoice payment transaction exists in GnuCash with proper accounts. The bank
+split has not been matched to a bank statement entry — no FITID yet.
+
+```
+transaction 2026-03-15
+  memo: "Payment for INV-2026-001"
+  split Assets:Bank:Chequing          +1000.00 CAD   reconcile=n
+  split Assets:Receivable:Client      -1000.00 CAD
+```
+
+### State 3: Fully linked (complete)
+
+The transaction is categorized correctly and the FITID has been recorded. The
+bank split is marked cleared. This is the final desired state.
+
+```
+transaction 2026-03-15
+  fitid: abc123
+  memo: "Payment for INV-2026-001"
+  split Assets:Bank:Chequing          +1000.00 CAD   reconcile=c
+  split Assets:Receivable:Client      -1000.00 CAD
+```
+
+---
+
+## The Two Orderings
+
+Since ordering cannot be enforced, both sequences must be handled.
+
+### Ordering A: Apply Payment first, then import bank statement
+
+1. You apply payment on invoice → State 2 transaction created in GnuCash
+2. You later import the bank OFX file
+3. FITID `abc123` is not found in GnuCash (the invoice payment has no FITID)
+4. `import-bank` creates a State 1 transaction → now two bank splits for the same
+   real-world deposit exist
+
+Resolution: run `link-bank` (see below) to merge them into State 3.
+
+### Ordering B: Import bank statement first, then apply payment
+
+1. You import the bank OFX file → State 1 transaction created (Imbalance)
+2. You later apply payment on the invoice
+3. `apply-payment` (via gnucash-plaintext) detects an existing State 1 transaction
+   for the same bank account, date, and amount
+4. If exactly one candidate: re-categorizes it to State 3 (replaces Imbalance
+   with AR, FITID already present)
+5. If multiple candidates (same-day same-amount collision): flags for manual
+   review — does not auto-resolve
+
+> **Note**: Ordering B automatic resolution only works if `apply-payment` goes
+> through gnucash-plaintext. If you use GnuCash's GUI Apply Payment, you will
+> always end up needing the `link-bank` step.
+
+---
+
+## The Three Commands
+
+> **Note:** `import-bank`, `apply-payment`, and `link-bank` are proposed
+> commands — they do not exist yet in gnucash-plaintext. This section describes
+> the intended design so that contributors and integrators can build toward it.
+
+### `import-bank`
+
+Imports OFX/QFX/CSV bank entries into GnuCash.
+
+**Rules:**
+- For each entry, check if the FITID is already stored in any split KVP in the
+  target account. If yes: skip entirely (idempotent).
+- If no FITID match: create a State 1 transaction with `Imbalance` as the other
+  split. Store the FITID on the bank split's KVP.
+- Never attempts to auto-match by amount or date.
+
+**Result:** safe to run multiple times. Each OFX entry is imported at most once.
+Uncategorized transactions accumulate as State 1 until resolved.
+
+---
+
+### `apply-payment` (gnucash-plaintext)
+
+Applies a payment to an invoice and records it in GnuCash.
+
+**Rules:**
+- Look for existing State 1 transactions in the bank account with the same date
+  and amount.
+  - **Zero matches:** create a State 2 transaction normally.
+  - **Exactly one match:** re-categorize it to State 3 — replace the Imbalance
+    split with the AR split, and the FITID is already attached.
+  - **Multiple matches:** create a State 2 transaction and write the ambiguous
+    candidates to the `--needs-review` output. Do not auto-resolve.
+
+---
+
+### `link-bank`
+
+A reconciliation pass that links State 1 and State 2 transactions to each other,
+producing State 3.
+
+This command handles all unresolved cases left by either ordering.
+
+**What it does:**
+1. Finds all State 1 transactions (have FITID, have Imbalance split).
+2. Finds all State 2 transactions (no FITID, bank split reconcile=`n`).
+3. For each State 1 transaction, finds State 2 candidates by `(bank account,
+   date, amount)`.
+
+**Resolution rules:**
+- **Zero State 2 candidates:** the bank entry has no matching invoice payment.
+  Leave as State 1. User must categorize it manually.
+- **Exactly one candidate:** high-confidence match. Automatically resolve to
+  State 3: copy FITID to the invoice payment's bank split, mark it `c`, delete
+  the Imbalance transaction.
+- **Multiple candidates (same date, same amount, same account):** output to
+  review file. Do not auto-resolve.
+
+**Review file format for ambiguous cases:**
+```
+AMBIGUOUS MATCH — manual resolution required
+  Bank entry:    2026-03-15  FITID=abc123  memo="TRANSFER REF 12345"  +1000.00 CAD
+  Candidate A:   GUID=aaa-111  "Payment INV-2026-001"  AR:Client:AcmeCorp
+  Candidate B:   GUID=bbb-222  "Payment INV-2026-003"  AR:Client:OtherCorp
+
+  Resolve with:
+    gnucash-plaintext link-bank --fitid abc123 --guid aaa-111
+```
+
+---
+
+## Summary: Which Cases Are Automatic vs Manual
+
+| Scenario | Ordering | Auto-resolved? |
+|---|---|---|
+| Unique amount on the day, OFX first, `apply-payment` via gnucash-plaintext | B | Yes — on `apply-payment` |
+| Unique amount on the day, Apply Payment first via GnuCash GUI | A | Yes — on `link-bank` |
+| Same-day same-amount, any ordering | A or B | No — review file required |
+| Bank entry with no invoice payment (e.g. bank fee) | — | No — user categorizes manually |
+| OFX imported twice (same FITID) | — | Yes — skipped on second import |
+
+---
+
+## Reconciliation and the `y` Status
+
+GnuCash tracks each split's reconciliation status:
+
+- `n` — not reconciled (default for all new transactions)
+- `c` — cleared (the split has been matched to a bank statement entry)
+- `y` — reconciled (the split has been formally balanced against a closing
+  statement balance and locked)
+
+`import-bank` sets imported bank splits to `c`. `link-bank` promotes matched
+splits from `n` to `c`. The `y` status is set later during GnuCash's formal
+monthly reconciliation (`Actions → Reconcile`), where you verify the closing
+balance of your statement. Nothing in this workflow skips that step — it remains
+the authoritative final check.
+
+---
+
+## Building Interactive Tools on Top of gnucash-plaintext
+
+gnucash-plaintext is intentionally non-interactive — it reads files and writes
+files, with no prompts. This makes it scriptable and automation-friendly.
+
+However, the `link-bank` review file is designed as a data contract that
+higher-level tools can consume. A tool built on top of gnucash-plaintext can
+implement an interactive matching experience:
+
+1. Run `import-bank` and `link-bank --dry-run --output-review review.json`
+2. Read the review file to find ambiguous or unmatched State 1 transactions
+3. For each unmatched bank entry, ask the user:
+   > "This deposit of $1,000.00 on 2026-03-15 (TRANSFER REF 12345) — is this
+   > a payment for an invoice?"
+4. If the user says yes, present a list of open invoices of that amount/currency
+   and let them pick
+5. Call `gnucash-plaintext link-bank --fitid abc123 --guid aaa-111` to resolve
+
+This pattern lets any UI layer — a web app, a desktop app, a terminal TUI, or
+even a chat-based assistant — drive the matching interactively, while
+gnucash-plaintext handles the GnuCash book mutations safely.
+
+The same pattern works for non-invoice categorization: "Is this $45.00 at SHELL
+a fuel expense?" → user picks account → tool emits the correct plaintext
+transaction and calls `import`.
+
+### Demo: Interactive Matching by Date and Amount
+
+A runnable demo is included at `demos/bank_import_matching/demo.py`. Run it
+inside Docker from the repo root:
+
+```bash
+./scripts/run.sh latest bash /workspace/demos/bank_import_matching/run.sh
+```
+
+The demo:
+1. Creates a temporary GnuCash book with sample accounts
+2. Creates an invoice payment transaction (State 2 — no FITID)
+3. Creates a bank OFX import transaction for the same amount (State 1 — FITID
+   stored as metadata on the bank split)
+4. Shows the conflict: two splits in the bank account for the same deposit
+5. Runs interactive date + amount matching and asks you to confirm the link
+6. On confirmation: transfers the FITID to the invoice payment split, marks it
+   cleared, and removes the Imbalance transaction
+7. Shows the resolved final state (State 3)
+
+> **The date + amount matching in the demo is for illustration only.**
+> Same-day same-amount collisions will produce wrong suggestions.
+> You are responsible for implementing a matching strategy appropriate
+> for your data. The demo shows the shape of the interaction — not a
+> production-ready algorithm.
+
+---
+
+## Practical Recommendation
+
+For users managing invoices and bank imports together:
+
+1. Use `import-bank` for all bank OFX/QFX/CSV imports. Do not use GnuCash's
+   built-in importer for accounts where you also use Apply Payment.
+2. Use `apply-payment` via gnucash-plaintext rather than GnuCash's GUI, so the
+   system can detect existing State 1 transactions automatically.
+3. Run `link-bank` after any batch of imports or payments to resolve remaining
+   State 1 / State 2 pairs.
+4. Check the review file for any ambiguous cases and resolve them with the
+   provided command.
+5. Perform monthly reconciliation in GnuCash as usual to promote `c` → `y`.


### PR DESCRIPTION
Adds docs/bank-import-workflow.md explaining the conflict between GnuCash Apply Payment and bank OFX import, and why naive solutions fail:

- GnuCash built-in BAYES matching fails for invoice payments because payment descriptions don't match bank memo text
- (account, date, amount) matching is unreliable: same-day same-amount collisions are real
- Import order cannot be enforced

Documents a three-state design (bank-anchored, categorized, fully linked) and three proposed commands (import-bank, apply-payment, link-bank) that handle both orderings safely, with human review only for genuinely ambiguous cases. Clearly marked as proposed/not yet implemented to avoid misleading readers.

Includes a section on building interactive tools on top of gnucash-plaintext: the review file is a data contract that any UI layer (web, TUI, chat assistant) can consume to drive matching.

Also adds demos/bank_import_matching/ — a verified runnable demo:
- Creates a temp GnuCash book with sample accounts
- Creates an invoice payment (State 2, no FITID)
- Creates a bank OFX import transaction (State 1, FITID on split KVP)
- Shows the double-count conflict in the bank account
- Runs interactive date+amount matching with explicit disclaimer that this is demo-only — same-day same-amount collisions require a real matching strategy from the integrator
- On user confirmation: transfers FITID, marks split cleared, removes the Imbalance transaction via BeginEdit/Destroy/CommitEdit
- Prints verified State 3 result: one split, correct FITID
- All sessions protected with try/finally; backup and log files cleaned up

Run inside Docker from repo root:
  ./scripts/run.sh latest bash /workspace/demos/bank_import_matching/run.sh