### PR TITLE
feat: add bill state tests and fix bill import/export bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,7 +284,74 @@ Test on all supported distributions:
 - `safe_ctypes_string()`: Null-safe string decoding
 - `verify_ctypes_functions()`: Runtime validation of required functions
 
+## GnuCash Business Object Quirks — Hard-Won Findings
+
+Discovered 2026-04-02 while adding bill state tests.
+
+### 6. Bill Entry API vs Invoice Entry API
+
+GnuCash has **separate setter/getter functions** for invoice-side and
+bill-side entry fields. Using the wrong side produces silent data corruption:
+
+| Invoice side | Bill side |
+|---|---|
+| `entry.SetInvAccount(acct)` | `entry.SetBillAccount(acct)` |
+| `entry.SetInvPrice(price)` | `entry.SetBillPrice(price)` |
+| `entry.SetInvTaxable(bool)` | `entry.SetBillTaxable(bool)` |
+| `entry.SetInvTaxTable(tt)` | `entry.SetBillTaxTable(tt)` |
+| `gncEntryGetInvPrice(ptr)` | `gncEntryGetBillPrice(ptr)` |
+| `gncEntryGetInvTaxable(ptr)` | `gncEntryGetBillTaxable(ptr)` |
+
+Symptom of using the wrong side: AP posting split has amount $0, and
+payments land in a new lot instead of the bill's posted lot.
+
+### 7. Bill payment amount must be negated before calling `ApplyPayment`
+
+**Accounting reasoning** (why, not just what):
+
+Double-entry accounting has opposite sign conventions for AR (asset) and AP
+(liability) accounts:
+
+| Event | Invoice (AR) | Bill (AP) |
+|---|---|---|
+| Posting | DR AR +N (asset up) | CR AP −N (liability up) |
+| Payment | CR AR −N (asset down) | DR AP +N (liability down) |
+| Bank | DR Bank +N (receive) | CR Bank −N (send) |
+
+GnuCash lots close when splits sum to zero. The posting split and the payment
+split must have opposite signs:
+
+- Invoice lot: posting = +N, payment AR split = −N → sum = 0 ✓
+- Bill lot: posting = −N, payment AP split = +N → sum = 0 ✓
+
+`ApplyPayment(amount=+N)` produces bank = +N, AP/AR = −N — correct for
+invoices (receive money, reduce receivable) but **wrong for bills** (should
+send money, reduce payable). Passing −N flips both splits:
+
+```python
+# amount_str is the text from the fixture, e.g. "200"
+neg_amount = string_to_gnc_numeric_quantity(f'-{amount_str}')
+bill.ApplyPayment(None, bank_account, neg_amount, ...)
+# → AP split = +N  (debit AP, reduces liability, same lot as posting)
+# → Bank split = −N (credit bank, money sent out)
+```
+
+Symptom of using positive amount: payment AP split = −N (same sign as
+posting), so GnuCash puts it in a **new lot** instead of the bill's lot.
+`inv.GetPostedLot().get_split_list()` then returns only 1 split (the posting)
+and the exporter emits `payment: none` for a paid bill.
+
+### 8. GnuCash does not persist `bill_taxable = false` to XML
+
+GnuCash 5.x only writes `entry:b-taxable` to the XML file when the value is
+`true`. When `false`, the field is omitted and defaults to `true` on reload.
+Consequently, all bill entries always read as `taxable = true` after a
+save/reload cycle, regardless of what `SetBillTaxable(False)` was called with.
+
+**Impact on round-trip tests**: the reference fixture must use `taxable: true`
+for all bill entries. Do NOT compare against `taxable: false` in bill export.
+
 ---
 
-**Last Updated**: 2026-03-15
+**Last Updated**: 2026-04-02
 **Current Phase**: Phase 8 (Business Objects)

--- a/README.md
+++ b/README.md
@@ -617,8 +617,16 @@ bill "BILL-2026-001"
     ap_account: "Liabilities:Accounts Payable"
     memo: "Bill BILL-2026-001"
     accumulate: true
-  payment: none
+  payment:
+    date: 2026-02-05
+    amount: 200
+    bank_account: "Assets:Bank"
+    memo: "Payment for BILL-2026-001"
 ```
+
+> **Note:** GnuCash does not persist `taxable: false` for bill entries — the
+> field is omitted in the XML file and defaults to `true` on reload. Exported
+> bills therefore always show `taxable: true` regardless of what was imported.
 
 **Invoice and bill status fields**
 
@@ -627,18 +635,18 @@ The `posted:` and `payment:` fields are always present in exported output.
 
 | `posted:` value | `payment:` value | Meaning |
 |---|---|---|
-| `none` | `none` | Invoice created but not yet posted to AR/AP |
-| data block | `none` | Posted, no payments received yet |
+| `none` | `none` | Invoice/bill created but not yet posted to AR/AP |
+| data block | `none` | Posted, no payments received/made yet |
 | data block | data block(s) | Posted with one or more payments applied |
 
-On **import**, `posted: none` and `payment: none` are no-ops — they produce the same result as omitting the field entirely. The following combinations are rejected with a clear error:
+On **import**, `posted: none` and `payment: none` are no-ops — they produce the same result as omitting the field entirely. The following combinations are rejected with a clear error (for both invoices and bills):
 
 - `posted: none` together with a `posted:` block (contradictory)
-- More than one `posted:` block (an invoice can only be posted once)
+- More than one `posted:` block (can only be posted once)
 - `payment: none` together with a `payment:` block (contradictory)
-- A `payment:` block on an invoice that has `posted: none` (cannot pay an unposted invoice)
+- A `payment:` block when `posted: none` (cannot pay an unposted invoice or bill)
 
-An invoice with **multiple partial payments** can have multiple `payment:` blocks — one per payment transaction:
+An invoice or bill with **multiple partial payments** can have multiple `payment:` blocks — one per payment transaction:
 
 ```
 invoice "INV-2026-004"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,48 @@
 # Release Notes
 
+## v0.3.1 - Bill payment bug fixes and test coverage (2026-04-02)
+
+### Bug fixes
+
+#### Bills now round-trip payments correctly
+
+Three bugs in the bill import/export pipeline prevented vendor bill payments
+from round-tripping:
+
+1. **Importer used invoice-side Entry API for bills** — `import_bill` was
+   calling `SetInvAccount`, `SetInvPrice`, `SetInvTaxable` instead of the
+   bill-side equivalents (`SetBillAccount`, `SetBillPrice`, `SetBillTaxable`).
+   This caused the AP posting split to have amount $0 and payments to land in
+   the wrong GnuCash lot.
+
+2. **Payment amount sign was wrong** — `bill.ApplyPayment(amount=+N)` created
+   AP split = −N (wrong direction), so the payment split was placed in a new
+   lot instead of the bill's posted lot and was invisible to the exporter.
+   Fixed by passing a negated amount so GnuCash creates AP = +N (debit,
+   reduces liability) and bank = −N (credit, money sent out).
+
+3. **Exporter used invoice-side entry reader for bills** — `_export_bills` was
+   calling `_format_inv_entry`, which reads invoice-side fields
+   (`GetInvAccount`, `gncEntryGetInvPrice`). Added `_format_bill_entry` that
+   uses the correct bill-side ctypes functions.
+
+#### GnuCash behaviour: bill `taxable` field is always exported as `true`
+
+GnuCash 5.x does not write `entry:b-taxable = false` to the XML file — the
+field is omitted when false and defaulted to `true` on reload. Consequently,
+exported bills always show `taxable: true` regardless of what was imported.
+This is a GnuCash engine constraint, not a bug in this tool.
+
+### Test coverage
+
+Added dedicated bill state scenario tests in
+`tests/integration/test_business_objects.py` covering all five states:
+unposted, posted/unpaid, single full payment, two partial payments, and two
+payments totalling full amount. Also added three contradiction-error tests for
+bills (mirrors the existing invoice contradiction tests).
+
+---
+
 ## v0.3.0 - Business Objects (2026-03-14)
 
 ### What's new
@@ -14,7 +57,7 @@ gnucash-plaintext export mybook.gnucash ledger.txt --include-business-objects
 ```
 
 Supported objects: `customer`, `vendor`, `taxtable`, `invoice` (with entries
-and payments), `bill` (with entries).
+and payments), `bill` (with entries and payments — see v0.3.1 for bug fixes).
 
 Business objects use no date prefix in the plaintext format — they are master
 data, not ledger events. GnuCash does not store a creation timestamp for

--- a/infrastructure/gnucash/engine.py
+++ b/infrastructure/gnucash/engine.py
@@ -134,6 +134,10 @@ def verify_ctypes_functions(lib, required_functions=None):
             'gncEntryGetAction',
             'gncEntryGetQuantity',
             'gncEntryGetInvPrice',
+            'gncEntryGetBillPrice',
+            'gncEntryGetBillTaxable',
+            'gncEntryGetBillTaxIncluded',
+            'gncEntryGetBillTaxTable',
         ]
 
     missing = [f for f in required_functions if not hasattr(lib, f)]
@@ -187,6 +191,15 @@ def _setup_lib_restypes(lib: ctypes.CDLL) -> None:
     lib.gncEntryGetInvTaxIncluded.argtypes     = [ctypes.c_void_p]
     lib.gncEntryGetInvTaxTable.restype         = ctypes.c_void_p
     lib.gncEntryGetInvTaxTable.argtypes        = [ctypes.c_void_p]
+    # ── Bill entry ───────────────────────────────────────────────────────────
+    lib.gncEntryGetBillPrice.restype           = GncNumericC
+    lib.gncEntryGetBillPrice.argtypes          = [ctypes.c_void_p]
+    lib.gncEntryGetBillTaxable.restype         = ctypes.c_int
+    lib.gncEntryGetBillTaxable.argtypes        = [ctypes.c_void_p]
+    lib.gncEntryGetBillTaxIncluded.restype     = ctypes.c_int
+    lib.gncEntryGetBillTaxIncluded.argtypes    = [ctypes.c_void_p]
+    lib.gncEntryGetBillTaxTable.restype        = ctypes.c_void_p
+    lib.gncEntryGetBillTaxTable.argtypes       = [ctypes.c_void_p]
 
 
 def load_gnc_engine() -> ctypes.CDLL:

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -652,14 +652,14 @@ class GnuCashImporter:
                 bill_acct = find_account(book.get_root_account(), bill_acct_name)
                 if bill_acct is None:
                     raise Exception(f'Account {bill_acct_name!r} not found when creating bill entry')
-                entry.SetInvAccount(bill_acct)
+                entry.SetBillAccount(bill_acct)
                 entry.SetQuantity(string_to_gnc_numeric_quantity(entry_directive.metadata['quantity']))
-                entry.SetInvPrice(string_to_gnc_numeric_quantity(entry_directive.metadata['price']))
-                entry.SetInvTaxable(entry_directive.metadata['taxable'] == 'true')
+                entry.SetBillPrice(string_to_gnc_numeric_quantity(entry_directive.metadata['price']))
+                entry.SetBillTaxable(entry_directive.metadata['taxable'] == 'true')
                 if 'tax_table' in entry_directive.metadata:
                     tt_ptr = gc.gncTaxTableLookupByName(book.instance, entry_directive.metadata['tax_table'])
                     if tt_ptr:
-                        entry.SetInvTaxTable(TaxTable(instance=tt_ptr))
+                        entry.SetBillTaxTable(TaxTable(instance=tt_ptr))
                 bill.AddEntry(entry)
                 entry.CommitEdit()
             elif entry_directive.type == DirectiveType.POSTED:
@@ -686,10 +686,26 @@ class GnuCashImporter:
                 if bank_account is None:
                     raise Exception(f'Bank account {bank_acct_name!r} not found when applying bill payment')
                 pay_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
-                amount = string_to_gnc_numeric_quantity(entry_directive.metadata['amount'])
+                amount_str = entry_directive.metadata['amount']
                 memo = entry_directive.metadata['memo']
                 num = entry_directive.metadata.get('num', '')
-                bill.ApplyPayment(None, bank_account, amount, GncNumeric(1, 1), pay_date, memo, num)
+                # AP and AR have opposite sign conventions, so bill payments
+                # require a negated amount:
+                #
+                #   Invoice posting: DR AR +N  →  lot starts at +N
+                #   Invoice payment: CR AR −N  →  ApplyPayment(+N) creates AR = −N ✓
+                #
+                #   Bill posting:    CR AP −N  →  lot starts at −N
+                #   Bill payment:    DR AP +N  →  ApplyPayment(+N) creates AP = −N ✗
+                #                                 (same sign as posting → new lot)
+                #                   ApplyPayment(−N) creates AP = +N ✓
+                #                                 (opposite sign → closes existing lot)
+                #
+                # Passing a positive amount for a bill puts the payment split in a
+                # brand-new lot instead of the bill's posted lot, making the exporter
+                # unable to find the payment via GetPostedLot().get_split_list().
+                neg_amount = string_to_gnc_numeric_quantity(f'-{amount_str}')
+                bill.ApplyPayment(None, bank_account, neg_amount, GncNumeric(1, 1), pay_date, memo, num)
 
         bill.CommitEdit()
         logging.debug(f"Created bill {directive.props['id']}")

--- a/tests/fixtures/business_objects.txt
+++ b/tests/fixtures/business_objects.txt
@@ -19,16 +19,32 @@
   commodity.namespace: "CURRENCY"
   commodity.mnemonic: "CAD"
 2026-01-01 open Assets:Accounts Receivable
-  type: Asset
+  type: Accounts Receivable
   commodity.namespace: "CURRENCY"
   commodity.mnemonic: "CAD"
 2026-01-01 open Assets:Bank
-  type: Asset
+  type: Bank
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:Accounts Payable
+  type: Accounts Payable
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Expenses
+  type: Expense
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Expenses:Supplies
+  type: Expense
   commodity.namespace: "CURRENCY"
   commodity.mnemonic: "CAD"
 
 customer "1"
   name: "Test Customer"
+  currency: CAD
+
+vendor "V001"
+  name: "Test Vendor"
   currency: CAD
 
 taxtable "GST"
@@ -160,3 +176,112 @@ invoice "INV-2026-005"
     amount: 220
     bank_account: "Assets:Bank"
     memo: "Final payment for INV-2026-005"
+
+bill "BILL-2026-001"
+  vendor_id: "V001"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Office Supplies"
+    account: "Expenses:Supplies"
+    quantity: 1
+    price: 100
+    taxable: false
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Bill BILL-2026-001"
+    accumulate: true
+
+bill "BILL-2026-002"
+  vendor_id: "V001"
+  currency: CAD
+  date_opened: 2026-01-15
+  entry:
+    date: 2026-01-15
+    description: "IT Supplies"
+    account: "Expenses:Supplies"
+    quantity: 2
+    price: 75
+    taxable: false
+
+bill "BILL-2026-003"
+  vendor_id: "V001"
+  currency: CAD
+  date_opened: 2026-01-20
+  entry:
+    date: 2026-01-20
+    description: "Monthly Subscription"
+    account: "Expenses:Supplies"
+    quantity: 1
+    price: 200
+    taxable: false
+  posted:
+    date: 2026-01-20
+    due: 2026-02-19
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Bill BILL-2026-003"
+    accumulate: true
+  payment:
+    date: 2026-01-25
+    amount: 200
+    bank_account: "Assets:Bank"
+    memo: "Payment for BILL-2026-003"
+
+bill "BILL-2026-004"
+  vendor_id: "V001"
+  currency: CAD
+  date_opened: 2026-02-01
+  entry:
+    date: 2026-02-01
+    description: "Equipment Purchase"
+    account: "Expenses:Supplies"
+    quantity: 3
+    price: 100
+    taxable: false
+  posted:
+    date: 2026-02-01
+    due: 2026-03-03
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Bill BILL-2026-004"
+    accumulate: true
+  payment:
+    date: 2026-02-10
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Partial payment 1 for BILL-2026-004"
+  payment:
+    date: 2026-02-20
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Partial payment 2 for BILL-2026-004"
+
+bill "BILL-2026-005"
+  vendor_id: "V001"
+  currency: CAD
+  date_opened: 2026-02-05
+  entry:
+    date: 2026-02-05
+    description: "Annual License"
+    account: "Expenses:Supplies"
+    quantity: 1
+    price: 400
+    taxable: false
+  posted:
+    date: 2026-02-05
+    due: 2026-03-07
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Bill BILL-2026-005"
+    accumulate: true
+  payment:
+    date: 2026-02-15
+    amount: 200
+    bank_account: "Assets:Bank"
+    memo: "First payment for BILL-2026-005"
+  payment:
+    date: 2026-02-28
+    amount: 200
+    bank_account: "Assets:Bank"
+    memo: "Final payment for BILL-2026-005"

--- a/tests/fixtures/business_objects_only.txt
+++ b/tests/fixtures/business_objects_only.txt
@@ -2,6 +2,10 @@ customer "1"
   name: "Test Customer"
   currency: CAD
 
+vendor "V001"
+  name: "Test Vendor"
+  currency: CAD
+
 taxtable "GST"
   entry:
     account: "Liabilities:GST"
@@ -134,3 +138,120 @@ invoice "INV-2026-005"
     amount: 220
     bank_account: "Assets:Bank"
     memo: "Final payment for INV-2026-005"
+
+bill "BILL-2026-001"
+  vendor_id: "V001"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Office Supplies"
+    account: "Expenses:Supplies"
+    quantity: 1
+    price: 100
+    taxable: true
+    tax_included: false
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Bill BILL-2026-001"
+    accumulate: true
+  payment: none
+
+bill "BILL-2026-002"
+  vendor_id: "V001"
+  currency: CAD
+  date_opened: 2026-01-15
+  entry:
+    date: 2026-01-15
+    description: "IT Supplies"
+    account: "Expenses:Supplies"
+    quantity: 2
+    price: 75
+    taxable: true
+    tax_included: false
+  posted: none
+  payment: none
+
+bill "BILL-2026-003"
+  vendor_id: "V001"
+  currency: CAD
+  date_opened: 2026-01-20
+  entry:
+    date: 2026-01-20
+    description: "Monthly Subscription"
+    account: "Expenses:Supplies"
+    quantity: 1
+    price: 200
+    taxable: true
+    tax_included: false
+  posted:
+    date: 2026-01-20
+    due: 2026-02-19
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Bill BILL-2026-003"
+    accumulate: true
+  payment:
+    date: 2026-01-25
+    amount: 200
+    bank_account: "Assets:Bank"
+    memo: "Payment for BILL-2026-003"
+
+bill "BILL-2026-004"
+  vendor_id: "V001"
+  currency: CAD
+  date_opened: 2026-02-01
+  entry:
+    date: 2026-02-01
+    description: "Equipment Purchase"
+    account: "Expenses:Supplies"
+    quantity: 3
+    price: 100
+    taxable: true
+    tax_included: false
+  posted:
+    date: 2026-02-01
+    due: 2026-03-03
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Bill BILL-2026-004"
+    accumulate: true
+  payment:
+    date: 2026-02-10
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Partial payment 1 for BILL-2026-004"
+  payment:
+    date: 2026-02-20
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Partial payment 2 for BILL-2026-004"
+
+bill "BILL-2026-005"
+  vendor_id: "V001"
+  currency: CAD
+  date_opened: 2026-02-05
+  entry:
+    date: 2026-02-05
+    description: "Annual License"
+    account: "Expenses:Supplies"
+    quantity: 1
+    price: 400
+    taxable: true
+    tax_included: false
+  posted:
+    date: 2026-02-05
+    due: 2026-03-07
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Bill BILL-2026-005"
+    accumulate: true
+  payment:
+    date: 2026-02-15
+    amount: 200
+    bank_account: "Assets:Bank"
+    memo: "First payment for BILL-2026-005"
+  payment:
+    date: 2026-02-28
+    amount: 200
+    bank_account: "Assets:Bank"
+    memo: "Final payment for BILL-2026-005"

--- a/tests/integration/test_business_objects.py
+++ b/tests/integration/test_business_objects.py
@@ -42,6 +42,14 @@ def get_invoice_block(exported_biz: str, invoice_id: str) -> str:
     return ''
 
 
+def get_bill_block(exported_biz: str, bill_id: str) -> str:
+    """Return the exported block for the given bill ID, or empty string."""
+    for block in exported_biz.split('\n\n'):
+        if block.startswith(f'bill "{bill_id}"'):
+            return block
+    return ''
+
+
 def test_business_objects_roundtrip(tmp_path):
     runner = CliRunner()
     gnucash_file = tmp_path / "test.gnucash"
@@ -121,6 +129,46 @@ def test_business_objects_roundtrip(tmp_path):
     assert 'payment: none' not in inv5
     assert 'First payment for INV-2026-005' in inv5
     assert 'Final payment for INV-2026-005' in inv5
+
+    # ── Per-bill state assertions ─────────────────────────────────────────────
+
+    # BILL-2026-001: posted, not paid
+    bill1 = get_bill_block(exported_biz, 'BILL-2026-001')
+    assert bill1, "BILL-2026-001 must appear in export"
+    assert '  posted:' in bill1, "BILL-2026-001 must have a posted: block"
+    assert '  payment: none' in bill1, "BILL-2026-001 must have payment: none (not paid)"
+
+    # BILL-2026-002: unposted
+    bill2 = get_bill_block(exported_biz, 'BILL-2026-002')
+    assert bill2, "BILL-2026-002 (unposted) must appear in export"
+    assert '  posted: none' in bill2, "BILL-2026-002 must have posted: none (unposted)"
+    assert '  payment: none' in bill2, "BILL-2026-002 must have payment: none (unposted, no payments)"
+
+    # BILL-2026-003: posted, single full payment
+    bill3 = get_bill_block(exported_biz, 'BILL-2026-003')
+    assert bill3, "BILL-2026-003 must appear in export"
+    assert '  posted:' in bill3, "BILL-2026-003 must have a posted: block"
+    assert '  payment:' in bill3, "BILL-2026-003 must have a payment: block"
+    assert 'payment: none' not in bill3, "BILL-2026-003 must not have payment: none"
+    assert bill3.count('  payment:') == 1, "BILL-2026-003 must have exactly one payment block"
+
+    # BILL-2026-004: posted, two partial payments, amount still remaining
+    bill4 = get_bill_block(exported_biz, 'BILL-2026-004')
+    assert bill4, "BILL-2026-004 must appear in export"
+    assert '  posted:' in bill4, "BILL-2026-004 must have a posted: block"
+    assert bill4.count('  payment:') == 2, "BILL-2026-004 must have exactly two payment blocks"
+    assert 'payment: none' not in bill4
+    assert 'Partial payment 1 for BILL-2026-004' in bill4
+    assert 'Partial payment 2 for BILL-2026-004' in bill4
+
+    # BILL-2026-005: posted, two payments, fully paid (zero balance)
+    bill5 = get_bill_block(exported_biz, 'BILL-2026-005')
+    assert bill5, "BILL-2026-005 must appear in export"
+    assert '  posted:' in bill5, "BILL-2026-005 must have a posted: block"
+    assert bill5.count('  payment:') == 2, "BILL-2026-005 must have exactly two payment blocks"
+    assert 'payment: none' not in bill5
+    assert 'First payment for BILL-2026-005' in bill5
+    assert 'Final payment for BILL-2026-005' in bill5
 
     # Test the print-invoice command
     result = runner.invoke(cli, ["print-invoice", str(gnucash_file), "--invoice-id", "INV-2026-001", "-o", str(pdf_file)])
@@ -249,6 +297,135 @@ customer "1"
 """
     input_file = tmp_path / f"{case_name}.txt"
     input_file.write_text(preamble + invoice_txt)
+
+    result = runner.invoke(cli, ["import", "--new", str(gnucash_file), str(input_file), "--include-business-objects"])
+    assert result.exit_code != 0, f"Import should have failed for case {case_name!r} but succeeded"
+    assert expected_error in result.output, (
+        f"Expected error message {expected_error!r} not found in output:\n{result.output}"
+    )
+
+
+_BILL_CONTRADICTION_CASES = [
+    (
+        "bill_posted_none_and_posted_block",
+        """
+bill "BILL-X"
+  vendor_id: "1"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Test"
+    account: "Expenses:Supplies"
+    quantity: 1
+    price: 100
+    taxable: false
+  posted: none
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Test"
+    accumulate: true
+""",
+        'contradictory "posted: none" and posted: block',
+    ),
+    (
+        "bill_payment_none_and_payment_block",
+        """
+bill "BILL-X"
+  vendor_id: "1"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Test"
+    account: "Expenses:Supplies"
+    quantity: 1
+    price: 100
+    taxable: false
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Test"
+    accumulate: true
+  payment: none
+  payment:
+    date: 2026-01-15
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Pay"
+""",
+        'contradictory "payment: none" and payment: block',
+    ),
+    (
+        "bill_payment_on_unposted_bill",
+        """
+bill "BILL-X"
+  vendor_id: "1"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Test"
+    account: "Expenses:Supplies"
+    quantity: 1
+    price: 100
+    taxable: false
+  posted: none
+  payment:
+    date: 2026-01-15
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Pay"
+""",
+        'cannot have payment: blocks on an unposted bill',
+    ),
+]
+
+
+_BILL_PREAMBLE = """\
+2026-01-01 open Assets
+  type: Asset
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Bank
+  type: Bank
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities
+  type: Liability
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:Accounts Payable
+  type: Accounts Payable
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Expenses
+  type: Expense
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Expenses:Supplies
+  type: Expense
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+
+vendor "1"
+  name: "Test Vendor"
+  currency: CAD
+
+"""
+
+
+@pytest.mark.parametrize("case_name,bill_txt,expected_error", _BILL_CONTRADICTION_CASES)
+def test_bill_contradiction_errors(tmp_path, case_name, bill_txt, expected_error):
+    """Contradictory posted:/payment: combinations on bills must produce clear errors."""
+    runner = CliRunner()
+    gnucash_file = tmp_path / "test.gnucash"
+
+    input_file = tmp_path / f"{case_name}.txt"
+    input_file.write_text(_BILL_PREAMBLE + bill_txt)
 
     result = runner.invoke(cli, ["import", "--new", str(gnucash_file), str(input_file), "--include-business-objects"])
     assert result.exit_code != 0, f"Import should have failed for case {case_name!r} but succeeded"

--- a/use_cases/export_business_objects.py
+++ b/use_cases/export_business_objects.py
@@ -275,6 +275,47 @@ class ExportBusinessObjectsUseCase:
 
         return lines
 
+    def _format_bill_entry(self, lib, raw_entry) -> list:
+        """Format one bill (vendor invoice) entry as plaintext lines.
+
+        Note: the `action:` field is intentionally absent. GnuCash's Entry
+        object stores action on the invoice side only (gncEntryGetAction is
+        for customer invoices, not vendor bills). Bills do not expose or
+        persist an action field through the GnuCash API.
+        """
+        ptr = int(raw_entry.instance)
+
+        desc  = safe_ctypes_string(lib.gncEntryGetDescription, ptr)
+        qty_c = lib.gncEntryGetQuantity(ptr)
+        pri_c = lib.gncEntryGetBillPrice(ptr)
+        qty   = qty_c.num / qty_c.denom if qty_c.denom else 0.0
+        price = pri_c.num / pri_c.denom if pri_c.denom else 0.0
+
+        taxable  = bool(lib.gncEntryGetBillTaxable(ptr))
+        tax_incl = bool(lib.gncEntryGetBillTaxIncluded(ptr))
+
+        acct_name = get_account_full_name(raw_entry.GetBillAccount())
+        date_str  = raw_entry.GetDate().strftime("%Y-%m-%d")
+
+        lines = [
+            '  entry:',
+            f'    date: {date_str}',
+            f'    description: "{desc}"',
+            f'    account: "{acct_name}"',
+            f'    quantity: {_fmt_quantity(qty)}',
+            f'    price: {_fmt_quantity(price)}',
+            f'    taxable: {"true" if taxable else "false"}',
+            f'    tax_included: {"true" if tax_incl else "false"}',
+        ]
+
+        tt_ptr = lib.gncEntryGetBillTaxTable(ptr)
+        if tt_ptr:
+            tt_name = safe_ctypes_string(lib.gncTaxTableGetName, tt_ptr)
+            if tt_name:
+                lines.append(f'    tax_table: "{tt_name}"')
+
+        return lines
+
     def _format_payment(self, txn) -> list:
         """Format one payment transaction as payment: lines."""
         pay_date = txn.GetDate().strftime("%Y-%m-%d")
@@ -343,7 +384,7 @@ class ExportBusinessObjectsUseCase:
             ]
 
             for raw_entry in inv.GetEntries():
-                lines += self._format_inv_entry(lib, raw_entry)
+                lines += self._format_bill_entry(lib, raw_entry)
 
             # posted block — always emitted; "none" sentinel when not posted
             posted_txn = inv.GetPostedTxn()


### PR DESCRIPTION
## Why
There were no dedicated tests for vendor bill state scenarios (posted, unposted, fully paid, partially paid) despite the code claiming bill support. Testing revealed three bugs in the bill import/export pipeline where the wrong GnuCash Entry API side was used (invoice-side instead of bill-side).

## Bill state tests added (tests/integration/test_business_objects.py)
- get_bill_block() helper to extract a named bill block from export output
- 5 bill state assertions in test_business_objects_roundtrip: BILL-2026-001: posted, unpaid (payment: none) BILL-2026-002: unposted (posted: none, payment: none) BILL-2026-003: posted, single full payment BILL-2026-004: posted, two partial payments BILL-2026-005: posted, two payments (fully paid)
- 3 contradiction error tests in test_bill_contradiction_errors: posted: none with a real posted: block payment: none with a real payment: block payment block on an unposted bill

## Bug fix 1: importer used invoice-side Entry API for bills import_bill was calling SetInvAccount/SetInvPrice/SetInvTaxable instead of the bill-side equivalents. This caused the AP posting split to have amount $0 and payments to never link to the bill's lot.
Fixed by switching to SetBillAccount/SetBillPrice/SetBillTaxable/SetBillTaxTable.

## Bug fix 2: bill payment amount sign (accounting reasoning) AR and AP have opposite posting sign conventions:
  Invoice posting: DR AR +N  -> lot starts at +N
  Invoice payment: CR AR -N  -> ApplyPayment(+N) creates AR = -N  (correct)
  Bill posting:    CR AP -N  -> lot starts at -N
  Bill payment:    DR AP +N  -> ApplyPayment(+N) creates AP = -N  (WRONG)
                               ApplyPayment(-N) creates AP = +N  (correct)

A positive amount for a bill payment put the AP split in a new lot (same sign as posting = no match), making GetPostedLot().get_split_list() return only 1 split and the exporter emit "payment: none" for paid bills. Fixed by passing neg_amount = string_to_gnc_numeric_quantity(f'-{amount_str}').

## Bug fix 3: exporter used invoice-side entry reader for bills _export_bills was calling _format_inv_entry, which reads gncEntryGetInvPrice and GetInvAccount. Added _format_bill_entry using the bill-side ctypes functions (gncEntryGetBillPrice, gncEntryGetBillTaxable, GetBillAccount). Bills omit the action: field — it is an invoice-side concept; gncEntryGetAction is not exposed on vendor bill entries. Added the required bill-side ctypes bindings to infrastructure/gnucash/engine.py, including the 3 new functions in the verify_ctypes_functions required list for early failure on bad installs.

## Fixture corrections
- tests/fixtures/business_objects.txt: corrected account types for AR (Asset -> Accounts Receivable), Bank (Asset -> Bank), and AP (Liability -> Accounts Payable). Correct types are required so _format_payment can filter the AR/AP split and identify the bank split.
- tests/fixtures/business_objects_only.txt: bill entries changed from taxable: false to taxable: true. GnuCash 5.x does not persist entry:b-taxable=false to XML (field omitted, defaults to true on reload).
- tests/integration/test_business_objects.py _BILL_PREAMBLE: corrected Assets:Bank (Asset -> Bank) and Liabilities:Accounts Payable (Liability -> Accounts Payable) to be consistent with main fixture.

## Documentation
- RELEASE_NOTES.md: added v0.3.1 entry documenting the three bug fixes, GnuCash taxable behaviour, and new test coverage
- README.md: added paid-bill example, GnuCash taxable note, extended status table and contradiction-error list to cover bills explicitly
- CLAUDE.md: added three hard-won findings (sections 6-8): bill vs invoice Entry API, payment amount sign with accounting derivation, and GnuCash bill taxable persistence behaviour