### PR TITLE
Fix update_transaction dropping duplicate-account splits (meal+tip bug)

### DIFF
--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -322,8 +322,10 @@ class GnuCashImporter:
         full-name. Splits for accounts absent from the directive are removed; splits
         for new accounts are created.
 
-        Note: When two splits in the directive share the same account (rare but valid),
-        the last directive entry for that account wins — consistent with create_transaction.
+        Note: When two splits in the directive share the same account (e.g. meal + tip
+        both on Expenses:Dining), all of them are applied positionally — each directive
+        entry is matched to the corresponding existing split at the same index for that
+        account. Extra existing splits are removed; extra desired splits are created.
 
         Args:
             existing_tx: GnuCash Transaction object to update
@@ -382,15 +384,18 @@ class GnuCashImporter:
 
             tx_currency = existing_tx.GetCurrency()
 
-            # Build account-name → split maps for existing and desired splits
-            existing_splits_by_account = {}
+            # Build account-name → [splits] map for existing splits.
+            # Using lists preserves multiple splits that share the same account
+            # (e.g. meal + tip both posted to Expenses:Dining).
+            existing_splits_by_account: dict[str, list] = {}
             for split in existing_tx.GetSplitList():
                 acct_name = get_account_full_name(split.GetAccount())
-                existing_splits_by_account[acct_name] = split
+                existing_splits_by_account.setdefault(acct_name, []).append(split)
 
-            desired_by_account = {}
+            # Build account-name → [directives] map for desired splits.
+            desired_by_account: dict[str, list] = {}
             for child in directive.children:
-                desired_by_account[child.props['account']] = child
+                desired_by_account.setdefault(child.props['account'], []).append(child)
 
             # Validate all desired accounts exist before making any changes
             for acct_name in desired_by_account:
@@ -398,54 +403,63 @@ class GnuCashImporter:
                     raise ValueError(f"Account not found: {acct_name}")
 
             # Remove splits for accounts no longer in the directive
-            for acct_name, split in list(existing_splits_by_account.items()):
+            for acct_name, splits in list(existing_splits_by_account.items()):
                 if acct_name not in desired_by_account:
-                    split.Destroy()
+                    for split in splits:
+                        split.Destroy()
 
-            # Update existing splits or create new ones
-            for acct_name, split_directive in desired_by_account.items():
+            # Update existing splits or create new ones, matched positionally
+            # within each account group.
+            for acct_name, split_directives in desired_by_account.items():
                 split_account = find_account(root_account, acct_name)
                 split_account_currency = split_account.GetCommodity()
-                amount = string_to_gnc_numeric(split_directive.props['amount'], split_account_currency)
+                existing_splits = existing_splits_by_account.get(acct_name, [])
 
-                if 'value' in split_directive.metadata:
-                    value = string_to_gnc_numeric(split_directive.metadata['value'], tx_currency)
-                else:
-                    value = amount
+                # Destroy excess existing splits when directive has fewer
+                for surplus in existing_splits[len(split_directives):]:
+                    surplus.Destroy()
 
-                if acct_name in existing_splits_by_account:
-                    split = existing_splits_by_account[acct_name]
-                else:
-                    split = Split(book)
-                    split.SetParent(existing_tx)
-                    split.SetAccount(split_account)
+                for i, split_directive in enumerate(split_directives):
+                    amount = string_to_gnc_numeric(split_directive.props['amount'], split_account_currency)
 
-                split.SetAmount(amount)
-                split.SetValue(value)
+                    if 'value' in split_directive.metadata:
+                        value = string_to_gnc_numeric(split_directive.metadata['value'], tx_currency)
+                    else:
+                        value = amount
 
-                if 'share_price' in split_directive.metadata:
-                    share_price = string_to_gnc_numeric(split_directive.metadata['share_price'], tx_currency)
-                    split.SetSharePrice(share_price)
+                    if i < len(existing_splits):
+                        split = existing_splits[i]
+                    else:
+                        split = Split(book)
+                        split.SetParent(existing_tx)
+                        split.SetAccount(split_account)
 
-                if 'action' in split_directive.metadata:
-                    action = split_directive.metadata['action']
-                    if action is not None:
-                        split.SetAction(action)
+                    split.SetAmount(amount)
+                    split.SetValue(value)
 
-                if 'memo' in split_directive.metadata:
-                    memo = split_directive.metadata['memo']
-                    if memo is not None:
-                        split.SetMemo(memo)
+                    if 'share_price' in split_directive.metadata:
+                        share_price = string_to_gnc_numeric(split_directive.metadata['share_price'], tx_currency)
+                        split.SetSharePrice(share_price)
 
-                # Update split-level custom metadata (merge: new values win)
-                custom_split_meta = {
-                    k: v for k, v in split_directive.metadata.items()
-                    if k not in KNOWN_SPLIT_METADATA_KEYS and v is not None
-                }
-                if custom_split_meta:
-                    existing_split_custom = get_custom_metadata(split)
-                    existing_split_custom.update(custom_split_meta)
-                    set_custom_metadata(split, existing_split_custom)
+                    if 'action' in split_directive.metadata:
+                        action = split_directive.metadata['action']
+                        if action is not None:
+                            split.SetAction(action)
+
+                    if 'memo' in split_directive.metadata:
+                        memo = split_directive.metadata['memo']
+                        if memo is not None:
+                            split.SetMemo(memo)
+
+                    # Update split-level custom metadata (merge: new values win)
+                    custom_split_meta = {
+                        k: v for k, v in split_directive.metadata.items()
+                        if k not in KNOWN_SPLIT_METADATA_KEYS and v is not None
+                    }
+                    if custom_split_meta:
+                        existing_split_custom = get_custom_metadata(split)
+                        existing_split_custom.update(custom_split_meta)
+                        set_custom_metadata(split, existing_split_custom)
 
             existing_tx.CommitEdit()
             logging.debug(f"Updated transaction on {date_str}")

--- a/tests/unit/services/test_update_transaction.py
+++ b/tests/unit/services/test_update_transaction.py
@@ -524,6 +524,296 @@ class TestUpdateTransactionMetadata:
         session2.end()
 
 
+@pytest.fixture
+def gnucash_with_meal_and_tip_transaction():
+    """
+    Temp GnuCash file with one CAD transaction that has two splits for the same
+    Dining account (meal + tip):
+
+      2024-03-07  Restaurant meal with tip
+        Expenses:Dining  30.45 CAD  (meal)
+        Expenses:Dining   5.00 CAD  (tip)
+        Assets:Bank:Checking  -35.45 CAD
+
+    Yields (path, guid_string).
+    """
+    fd, path = tempfile.mkstemp(suffix='.gnucash')
+    os.close(fd)
+    os.unlink(path)
+
+    try:
+        import gnucash
+        from gnucash import Account, GncNumeric, Split, Transaction
+
+        session = _make_session(path)
+        book = session.book
+        root = book.get_root_account()
+        commod_table = book.get_table()
+        cad = commod_table.lookup('CURRENCY', 'CAD')
+
+        assets = Account(book)
+        assets.SetName('Assets')
+        assets.SetType(gnucash.ACCT_TYPE_ASSET)
+        assets.SetCommodity(cad)
+        root.append_child(assets)
+
+        bank = Account(book)
+        bank.SetName('Bank')
+        bank.SetType(gnucash.ACCT_TYPE_BANK)
+        bank.SetCommodity(cad)
+        assets.append_child(bank)
+
+        checking = Account(book)
+        checking.SetName('Checking')
+        checking.SetType(gnucash.ACCT_TYPE_BANK)
+        checking.SetCommodity(cad)
+        bank.append_child(checking)
+
+        expenses = Account(book)
+        expenses.SetName('Expenses')
+        expenses.SetType(gnucash.ACCT_TYPE_EXPENSE)
+        expenses.SetCommodity(cad)
+        root.append_child(expenses)
+
+        dining = Account(book)
+        dining.SetName('Dining')
+        dining.SetType(gnucash.ACCT_TYPE_EXPENSE)
+        dining.SetCommodity(cad)
+        expenses.append_child(dining)
+
+        tx = Transaction(book)
+        tx.BeginEdit()
+        tx.SetCurrency(cad)
+        tx.SetDate(7, 3, 2024)
+        tx.SetDescription("Restaurant meal with tip")
+
+        # Two splits on the same Dining account
+        s_meal = Split(book)
+        s_meal.SetParent(tx)
+        s_meal.SetAccount(dining)
+        s_meal.SetValue(GncNumeric(3045, 100))
+
+        s_tip = Split(book)
+        s_tip.SetParent(tx)
+        s_tip.SetAccount(dining)
+        s_tip.SetValue(GncNumeric(500, 100))
+
+        s_checking = Split(book)
+        s_checking.SetParent(tx)
+        s_checking.SetAccount(checking)
+        s_checking.SetValue(GncNumeric(-3545, 100))
+
+        tx.CommitEdit()
+        guid = tx.GetGUID().to_string()
+
+        session.save()
+        session.end()
+
+        yield path, guid
+
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+        lock = path + '.LCK'
+        if os.path.exists(lock):
+            os.unlink(lock)
+
+
+class TestUpdateTransactionDuplicateAccountSplits:
+    """Tests for update_transaction when multiple splits share the same account."""
+
+    def test_two_splits_same_account_both_amounts_updated(self, gnucash_with_meal_and_tip_transaction):
+        """
+        Regression: updating a transaction with two splits for the same account
+        must update both splits — not silently drop one and create an imbalance.
+        """
+        from gnucash import Query, Transaction
+
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = gnucash_with_meal_and_tip_transaction
+        session = _open_session(path)
+        book = session.book
+
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        directive = _build_directive('2024-03-07', 'Restaurant meal with tip', [
+            {'account': 'Expenses:Dining', 'amount': '40.00'},
+            {'account': 'Expenses:Dining', 'amount': '8.00'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-48.00'},
+        ])
+
+        GnuCashImporter.update_transaction(existing_tx, directive, book)
+        session.save()
+        session.end()
+
+        session2 = _open_session(path)
+        book2 = session2.book
+        q2 = Query()
+        q2.search_for('Trans')
+        q2.set_book(book2)
+        txs2 = [Transaction(instance=t) for t in q2.run()]
+        updated = next(t for t in txs2 if t.GetGUID().to_string() == guid)
+
+        dining_splits = [
+            s for s in updated.GetSplitList()
+            if s.GetAccount().GetName() == 'Dining'
+        ]
+        assert len(dining_splits) == 2, (
+            f"Expected 2 Dining splits, got {len(dining_splits)}"
+        )
+
+        dining_amounts = sorted(s.GetValue().num() for s in dining_splits)
+        assert dining_amounts == [800, 4000], (
+            f"Expected Dining splits of 8.00 and 40.00, got {dining_amounts}"
+        )
+
+        account_names = [s.GetAccount().GetName() for s in updated.GetSplitList()]
+        imbalance_splits = [n for n in account_names if 'Imbalance' in n or 'imbalance' in n]
+        assert imbalance_splits == [], f"Unexpected imbalance splits: {imbalance_splits}"
+
+        session2.end()
+
+    def test_update_from_one_to_two_splits_same_account(self, gnucash_with_one_transaction):
+        """
+        Regression: updating from a single dining split to two dining splits
+        (adding a tip) must create both splits without imbalance.
+        """
+        from gnucash import Query, Transaction
+
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = gnucash_with_one_transaction
+        session = _open_session(path)
+        book = session.book
+
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        directive = _build_directive('2024-03-01', 'Grocery shopping', [
+            {'account': 'Expenses:Dining', 'amount': '45.00'},
+            {'account': 'Expenses:Dining', 'amount': '5.00'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-50.00'},
+        ])
+
+        GnuCashImporter.update_transaction(existing_tx, directive, book)
+        session.save()
+        session.end()
+
+        session2 = _open_session(path)
+        book2 = session2.book
+        q2 = Query()
+        q2.search_for('Trans')
+        q2.set_book(book2)
+        txs2 = [Transaction(instance=t) for t in q2.run()]
+        updated = next(t for t in txs2 if t.GetGUID().to_string() == guid)
+
+        dining_splits = [
+            s for s in updated.GetSplitList()
+            if s.GetAccount().GetName() == 'Dining'
+        ]
+        assert len(dining_splits) == 2, (
+            f"Expected 2 Dining splits after update, got {len(dining_splits)}"
+        )
+
+        dining_amounts = sorted(s.GetValue().num() for s in dining_splits)
+        assert dining_amounts == [500, 4500], (
+            f"Expected Dining 45.00 and 5.00, got {dining_amounts}"
+        )
+
+        account_names = [s.GetAccount().GetName() for s in updated.GetSplitList()]
+        imbalance_splits = [n for n in account_names if 'Imbalance' in n or 'imbalance' in n]
+        assert imbalance_splits == [], f"Unexpected imbalance splits: {imbalance_splits}"
+
+        session2.end()
+
+    def test_three_splits_same_account_reduced_to_two(self, gnucash_with_meal_and_tip_transaction):
+        """
+        Regression: when directive has fewer splits for an account than currently
+        exist, the excess existing splits must be destroyed (not left as orphans).
+        Here we add a third Dining split to the fixture then update with only two.
+        """
+        import gnucash as gnc
+        from gnucash import GncNumeric, Query, Split, Transaction
+
+        from services.gnucash_importer import GnuCashImporter
+
+        path, guid = gnucash_with_meal_and_tip_transaction
+
+        # Add a third Dining split so the transaction has 3
+        session = _open_session(path)
+        book = session.book
+        q = Query()
+        q.search_for('Trans')
+        q.set_book(book)
+        txs = [Transaction(instance=t) for t in q.run()]
+        existing_tx = next(t for t in txs if t.GetGUID().to_string() == guid)
+
+        from infrastructure.gnucash.utils import find_account
+        dining = find_account(book.get_root_account(), 'Expenses:Dining')
+        existing_tx.BeginEdit()
+        extra = Split(book)
+        extra.SetParent(existing_tx)
+        extra.SetAccount(dining)
+        extra.SetValue(GncNumeric(200, 100))
+        existing_tx.CommitEdit()
+        session.save()
+        session.end()
+
+        import time
+        time.sleep(1)
+
+        # Now update with only 2 Dining splits — the third must be destroyed
+        session2 = _open_session(path)
+        book2 = session2.book
+        q2 = Query()
+        q2.search_for('Trans')
+        q2.set_book(book2)
+        txs2 = [Transaction(instance=t) for t in q2.run()]
+        existing_tx2 = next(t for t in txs2 if t.GetGUID().to_string() == guid)
+
+        directive = _build_directive('2024-03-07', 'Restaurant meal with tip', [
+            {'account': 'Expenses:Dining', 'amount': '30.45'},
+            {'account': 'Expenses:Dining', 'amount': '5.00'},
+            {'account': 'Assets:Bank:Checking', 'amount': '-35.45'},
+        ])
+
+        GnuCashImporter.update_transaction(existing_tx2, directive, book2)
+        session2.save()
+        session2.end()
+
+        time.sleep(1)
+
+        session3 = _open_session(path)
+        book3 = session3.book
+        q3 = Query()
+        q3.search_for('Trans')
+        q3.set_book(book3)
+        txs3 = [Transaction(instance=t) for t in q3.run()]
+        updated = next(t for t in txs3 if t.GetGUID().to_string() == guid)
+
+        dining_splits = [
+            s for s in updated.GetSplitList()
+            if s.GetAccount().GetName() == 'Dining'
+        ]
+        assert len(dining_splits) == 2, (
+            f"Expected 2 Dining splits after removing excess, got {len(dining_splits)}"
+        )
+
+        account_names = [s.GetAccount().GetName() for s in updated.GetSplitList()]
+        imbalance_splits = [n for n in account_names if 'Imbalance' in n or 'imbalance' in n]
+        assert imbalance_splits == [], f"Unexpected imbalance splits: {imbalance_splits}"
+
+        session3.end()
+
+
 class TestUpdateTransactionErrorHandling:
     def test_invalid_account_raises_and_does_not_corrupt(self, gnucash_with_one_transaction):
         """update_transaction raises ValueError for unknown account and leaves transaction intact."""


### PR DESCRIPTION
When a transaction has two splits for the same account (e.g. meal 30.45 + tip 5.00 both on Expenses:Meals and entertainment), update_transaction was using a plain dict keyed by account name. The second split directive overwrote the first, so only the last amount was applied and the first split was silently dropped, leaving the transaction imbalanced.

Fix: use lists grouped by account name for both existing_splits_by_account and desired_by_account, then match existing splits to desired ones positionally within each account group. Excess existing splits (when directive has fewer than currently exist) are destroyed.

Tests added in TestUpdateTransactionDuplicateAccountSplits:
- test_two_splits_same_account_both_amounts_updated
- test_update_from_one_to_two_splits_same_account
- test_three_splits_same_account_reduced_to_two