### PR TITLE
test: expand unit test coverage across services

### DIFF
--- a/tests/unit/services/test_beancount_parser.py
+++ b/tests/unit/services/test_beancount_parser.py
@@ -1,0 +1,241 @@
+"""
+Unit tests for BeancountParser.
+
+These tests are pure Python — no GnuCash session required.
+The parser expects beancount files with gnucash-* metadata annotations.
+"""
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal valid beancount snippets
+# ---------------------------------------------------------------------------
+
+COMMODITY_BLOCK = """\
+2024-01-01 commodity CAD
+  gnucash-mnemonic: "CAD"
+  gnucash-namespace: "CURRENCY"
+  gnucash-fullname: "Canadian Dollar"
+  gnucash-fraction: "100"
+"""
+
+ACCOUNT_CHECKING = """\
+2024-01-01 open Assets:Bank:Checking CAD
+  gnucash-name: "Assets:Bank:Checking"
+  gnucash-guid: "aaa111"
+  gnucash-type: "BANK"
+  gnucash-placeholder: "false"
+"""
+
+ACCOUNT_GROCERIES = """\
+2024-01-01 open Expenses:Groceries CAD
+  gnucash-name: "Expenses:Groceries"
+  gnucash-guid: "bbb222"
+  gnucash-type: "EXPENSE"
+  gnucash-placeholder: "false"
+"""
+
+TX_BLOCK = """\
+2024-03-01 * "Grocery shopping"
+  gnucash-guid: "tx-guid-001"
+  Assets:Bank:Checking -50.00 CAD
+  Expenses:Groceries 50.00 CAD
+"""
+
+FULL_VALID = COMMODITY_BLOCK + "\n" + ACCOUNT_CHECKING + "\n" + ACCOUNT_GROCERIES + "\n" + TX_BLOCK
+
+
+# ---------------------------------------------------------------------------
+# Commodity parsing
+# ---------------------------------------------------------------------------
+
+class TestBeancountParserCommodity:
+    def test_commodity_parsed(self):
+        from services.beancount_parser import BeancountParser
+        p = BeancountParser()
+        p.parse(COMMODITY_BLOCK + "\n" + ACCOUNT_CHECKING + "\n")
+        assert len(p.commodities) == 1
+        c = p.commodities[0]
+        assert c.symbol == 'CAD'
+        assert c.gnucash_mnemonic == 'CAD'
+        assert c.gnucash_namespace == 'CURRENCY'
+        assert c.gnucash_fullname == 'Canadian Dollar'
+        assert c.gnucash_fraction == 100
+
+    def test_commodity_missing_mnemonic_raises(self):
+        from services.beancount_parser import BeancountParser, BeancountValidationError
+        content = """\
+2024-01-01 commodity CAD
+  gnucash-namespace: "CURRENCY"
+"""
+        p = BeancountParser()
+        with pytest.raises(BeancountValidationError, match="gnucash-mnemonic"):
+            p.parse(content)
+
+    def test_commodity_missing_namespace_raises(self):
+        from services.beancount_parser import BeancountParser, BeancountValidationError
+        content = """\
+2024-01-01 commodity CAD
+  gnucash-mnemonic: "CAD"
+"""
+        p = BeancountParser()
+        with pytest.raises(BeancountValidationError, match="gnucash-namespace"):
+            p.parse(content)
+
+
+# ---------------------------------------------------------------------------
+# Account parsing
+# ---------------------------------------------------------------------------
+
+class TestBeancountParserAccount:
+    def test_account_parsed(self):
+        from services.beancount_parser import BeancountParser
+        p = BeancountParser()
+        p.parse(ACCOUNT_CHECKING)
+        assert len(p.accounts) == 1
+        a = p.accounts[0]
+        assert a.account == 'Assets:Bank:Checking'
+        assert a.gnucash_name == 'Assets:Bank:Checking'
+        assert a.gnucash_guid == 'aaa111'
+        assert a.gnucash_type == 'BANK'
+        assert a.gnucash_placeholder == 'false'
+
+    def test_account_missing_required_metadata_raises(self):
+        from services.beancount_parser import BeancountParser, BeancountValidationError
+        # Missing gnucash-guid
+        content = """\
+2024-01-01 open Assets:Bank:Checking CAD
+  gnucash-name: "Assets:Bank:Checking"
+  gnucash-type: "BANK"
+  gnucash-placeholder: "false"
+"""
+        p = BeancountParser()
+        with pytest.raises(BeancountValidationError, match="gnucash-guid"):
+            p.parse(content)
+
+    def test_account_registered_in_opened_accounts(self):
+        from services.beancount_parser import BeancountParser
+        p = BeancountParser()
+        p.parse(ACCOUNT_CHECKING)
+        assert 'Assets:Bank:Checking' in p.opened_accounts
+
+    def test_get_account_mapping(self):
+        from services.beancount_parser import BeancountParser
+        p = BeancountParser()
+        p.parse(ACCOUNT_CHECKING + "\n" + ACCOUNT_GROCERIES)
+        mapping = p.get_account_mapping()
+        assert mapping['Assets:Bank:Checking'] == 'Assets:Bank:Checking'
+        assert mapping['Expenses:Groceries'] == 'Expenses:Groceries'
+
+
+# ---------------------------------------------------------------------------
+# Transaction parsing
+# ---------------------------------------------------------------------------
+
+class TestBeancountParserTransaction:
+    def test_transaction_parsed(self):
+        from services.beancount_parser import BeancountParser
+        p = BeancountParser()
+        p.parse(FULL_VALID)
+        assert len(p.transactions) == 1
+        tx = p.transactions[0]
+        assert tx.gnucash_guid == 'tx-guid-001'
+        assert tx.narration == 'Grocery shopping'
+        assert tx.flag == '*'
+        assert len(tx.postings) == 2
+
+    def test_transaction_posting_amounts(self):
+        from services.beancount_parser import BeancountParser
+        p = BeancountParser()
+        p.parse(FULL_VALID)
+        tx = p.transactions[0]
+        amounts = {post.account: post.amount for post in tx.postings}
+        assert amounts['Assets:Bank:Checking'] == '-50.00'
+        assert amounts['Expenses:Groceries'] == '50.00'
+
+    def test_transaction_missing_guid_raises(self):
+        from services.beancount_parser import BeancountParser, BeancountValidationError
+        content = (
+            ACCOUNT_CHECKING + "\n" + ACCOUNT_GROCERIES + "\n"
+            + "2024-03-01 * \"Grocery shopping\"\n"
+            + "  Assets:Bank:Checking -50.00 CAD\n"
+            + "  Expenses:Groceries 50.00 CAD\n"
+        )
+        p = BeancountParser()
+        with pytest.raises(BeancountValidationError, match="gnucash-guid"):
+            p.parse(content)
+
+    def test_transaction_with_notes_and_doclink(self):
+        from services.beancount_parser import BeancountParser
+        content = (
+            ACCOUNT_CHECKING + "\n" + ACCOUNT_GROCERIES + "\n"
+            + "2024-03-01 * \"Grocery shopping\"\n"
+            + "  gnucash-guid: \"tx-guid-002\"\n"
+            + "  gnucash-notes: \"some note\"\n"
+            + "  gnucash-doclink: \"https://example.com\"\n"
+            + "  Assets:Bank:Checking -50.00 CAD\n"
+            + "  Expenses:Groceries 50.00 CAD\n"
+        )
+        p = BeancountParser()
+        p.parse(content)
+        tx = p.transactions[0]
+        assert tx.gnucash_notes == 'some note'
+        assert tx.gnucash_doclink == 'https://example.com'
+
+    def test_posting_with_memo_and_action(self):
+        from services.beancount_parser import BeancountParser
+        content = (
+            ACCOUNT_CHECKING + "\n" + ACCOUNT_GROCERIES + "\n"
+            + "2024-03-01 * \"Grocery shopping\"\n"
+            + "  gnucash-guid: \"tx-guid-003\"\n"
+            + "  Assets:Bank:Checking -50.00 CAD\n"
+            + "    gnucash-memo: \"payment\"\n"
+            + "    gnucash-action: \"payment\"\n"
+            + "  Expenses:Groceries 50.00 CAD\n"
+        )
+        p = BeancountParser()
+        p.parse(content)
+        tx = p.transactions[0]
+        checking = next(post for post in tx.postings if post.account == 'Assets:Bank:Checking')
+        assert checking.gnucash_memo == 'payment'
+        assert checking.gnucash_action == 'payment'
+
+    def test_used_accounts_tracked(self):
+        from services.beancount_parser import BeancountParser
+        p = BeancountParser()
+        p.parse(FULL_VALID)
+        assert 'Assets:Bank:Checking' in p.used_accounts
+        assert 'Expenses:Groceries' in p.used_accounts
+
+
+# ---------------------------------------------------------------------------
+# Validation: implicit accounts
+# ---------------------------------------------------------------------------
+
+class TestBeancountParserValidation:
+    def test_implicit_account_raises(self):
+        """Transaction references an account with no open directive."""
+        from services.beancount_parser import BeancountParser, BeancountValidationError
+        content = (
+            ACCOUNT_CHECKING + "\n"
+            + "2024-03-01 * \"Grocery shopping\"\n"
+            + "  gnucash-guid: \"tx-guid-001\"\n"
+            + "  Assets:Bank:Checking -50.00 CAD\n"
+            + "  Expenses:Groceries 50.00 CAD\n"   # no open for this
+        )
+        p = BeancountParser()
+        with pytest.raises(BeancountValidationError, match="Implicit accounts"):
+            p.parse(content)
+
+    def test_all_accounts_open_passes(self):
+        from services.beancount_parser import BeancountParser
+        p = BeancountParser()
+        p.parse(FULL_VALID)  # should not raise
+        assert len(p.transactions) == 1
+
+    def test_comments_and_blank_lines_skipped(self):
+        from services.beancount_parser import BeancountParser
+        content = "; this is a comment\n\n" + FULL_VALID
+        p = BeancountParser()
+        p.parse(content)
+        assert len(p.transactions) == 1

--- a/tests/unit/services/test_conflict_resolver.py
+++ b/tests/unit/services/test_conflict_resolver.py
@@ -647,3 +647,110 @@ class TestConflictResolver:
 
         finally:
             session.end()
+
+
+# ---------------------------------------------------------------------------
+# Additional branch coverage
+# ---------------------------------------------------------------------------
+
+class TestResolveEdgeCases:
+
+    def test_resolve_empty_conflicts_returns_empty_lists(self):
+        """resolve() with no conflicts must return ([], []) without crash."""
+        from services.conflict_resolver import ConflictResolver, ResolutionStrategy
+
+        resolver = ConflictResolver()
+        to_import, unresolved = resolver.resolve([], strategy=ResolutionStrategy.SKIP)
+        assert to_import == []
+        assert unresolved == []
+
+    def test_resolve_empty_keep_existing_returns_empty(self):
+        from services.conflict_resolver import ConflictResolver, ResolutionStrategy
+
+        resolver = ConflictResolver()
+        to_import, unresolved = resolver.resolve([], strategy=ResolutionStrategy.KEEP_EXISTING)
+        assert to_import == []
+        assert unresolved == []
+
+    def test_resolve_empty_keep_incoming_returns_empty(self):
+        from services.conflict_resolver import ConflictResolver, ResolutionStrategy
+
+        resolver = ConflictResolver()
+        to_import, unresolved = resolver.resolve([], strategy=ResolutionStrategy.KEEP_INCOMING)
+        assert to_import == []
+        assert unresolved == []
+
+
+class TestAmountsDifferEdgeCases:
+
+    def _make_split_dict(self, account, num, denom=100):
+        return {'account': account, 'value_num': num, 'value_denom': denom}
+
+    def test_amounts_differ_different_split_counts(self, temp_gnucash_with_transactions):
+        """amounts_differ() returns True when split counts differ."""
+        from gnucash import Query, Session, Transaction
+
+        from services.conflict_resolver import ConflictInfo
+
+        try:
+            from gnucash import SessionOpenMode
+            session = Session(f'xml://{temp_gnucash_with_transactions}',
+                              SessionOpenMode.SESSION_NORMAL_OPEN)
+        except ImportError:
+            session = Session(f'xml://{temp_gnucash_with_transactions}')
+
+        try:
+            book = session.book
+            q = Query()
+            q.search_for('Trans')
+            q.set_book(book)
+            txs = [Transaction(instance=t) for t in q.run()]
+            tx = txs[0]
+
+            info = ConflictInfo(tx, tx)
+            # Manually inject differing split lists to test the count path
+            info.existing_splits = [
+                self._make_split_dict('Expenses:Groceries', 5000),
+                self._make_split_dict('Assets:Bank:Checking', -5000),
+            ]
+            info.incoming_splits = [
+                self._make_split_dict('Expenses:Groceries', 5000),
+            ]
+            assert info.amounts_differ() is True
+        finally:
+            session.end()
+
+    def test_amounts_differ_same_splits_returns_false(self, temp_gnucash_with_transactions):
+        """amounts_differ() returns False when splits are identical."""
+        from gnucash import Query, Session, Transaction
+
+        from services.conflict_resolver import ConflictInfo
+
+        try:
+            from gnucash import SessionOpenMode
+            session = Session(f'xml://{temp_gnucash_with_transactions}',
+                              SessionOpenMode.SESSION_NORMAL_OPEN)
+        except ImportError:
+            session = Session(f'xml://{temp_gnucash_with_transactions}')
+
+        try:
+            book = session.book
+            q = Query()
+            q.search_for('Trans')
+            q.set_book(book)
+            txs = [Transaction(instance=t) for t in q.run()]
+            tx = txs[0]
+
+            info = ConflictInfo(tx, tx)
+            # Two separate lists with the same values — tests structural equality
+            info.existing_splits = [
+                self._make_split_dict('Expenses:Groceries', 5000),
+                self._make_split_dict('Assets:Bank:Checking', -5000),
+            ]
+            info.incoming_splits = [
+                self._make_split_dict('Expenses:Groceries', 5000),
+                self._make_split_dict('Assets:Bank:Checking', -5000),
+            ]
+            assert info.amounts_differ() is False
+        finally:
+            session.end()

--- a/tests/unit/services/test_gnucash_importer_errors.py
+++ b/tests/unit/services/test_gnucash_importer_errors.py
@@ -871,3 +871,150 @@ class TestImportFromFileUnknownAccount:
             assert result.error_count == 0
         finally:
             os.unlink(plaintext)
+
+
+# ---------------------------------------------------------------------------
+# create_commodity — idempotency and already-exists path
+# ---------------------------------------------------------------------------
+
+class TestCreateCommodity:
+    def _commodity_directive(self, mnemonic='XTEST', namespace='CURRENCY',
+                              fullname='Test Commodity', fraction=100):
+        from services.plaintext_parser import DirectiveType, PlaintextDirective
+        d = PlaintextDirective(DirectiveType.CREATE_COMMODITY, 0, '')
+        d.props = {'symbol': mnemonic, 'date': '2024-01-01'}
+        d.metadata = {
+            'mnemonic': mnemonic,
+            'fullname': fullname,
+            'namespace': namespace,
+            'fraction': str(fraction),
+        }
+        return d
+
+    def test_create_commodity_inserts_into_table(self):
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            directive = self._commodity_directive()
+            GnuCashImporter.create_commodity(directive, book)
+            table = book.get_table()
+            result = table.lookup('CURRENCY', 'XTEST')
+            assert result is not None
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_create_commodity_already_exists_does_not_raise(self):
+        """Calling create_commodity twice for the same symbol must not raise."""
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            directive = self._commodity_directive()
+            GnuCashImporter.create_commodity(directive, book)
+            # Second call — commodity already exists
+            GnuCashImporter.create_commodity(directive, book)
+            # Still exactly one entry
+            table = book.get_table()
+            result = table.lookup('CURRENCY', 'XTEST')
+            assert result is not None
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_create_commodity_wrong_type_raises(self):
+        from services.gnucash_importer import GnuCashImporter
+        from services.plaintext_parser import DirectiveType, PlaintextDirective
+
+        session, book, path = _make_book()
+        try:
+            bad = PlaintextDirective(DirectiveType.TRANSACTION, 0, '')
+            bad.props = {}
+            bad.metadata = {}
+            with pytest.raises(ValueError, match="Expected CREATE_COMMODITY"):
+                GnuCashImporter.create_commodity(bad, book)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# create_account — idempotency and error paths
+# ---------------------------------------------------------------------------
+
+class TestCreateAccount:
+    def _account_directive(self, fullname, acct_type='Bank',
+                            namespace='CURRENCY', mnemonic='CAD'):
+        from services.plaintext_parser import DirectiveType, PlaintextDirective
+        d = PlaintextDirective(DirectiveType.OPEN_ACCOUNT, 0, '')
+        d.props = {'account': fullname, 'date': '2024-01-01'}
+        d.metadata = {
+            'type': acct_type,
+            'commodity.namespace': namespace,
+            'commodity.mnemonic': mnemonic,
+        }
+        return d
+
+    def test_create_account_creates_new(self):
+        from infrastructure.gnucash.utils import find_account
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            directive = self._account_directive('Assets:Bank:Savings')
+            GnuCashImporter.create_account(directive, book)
+            root = book.get_root_account()
+            assert find_account(root, 'Assets:Bank:Savings') is not None
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_create_account_idempotent(self):
+        """Calling create_account twice for the same name must not raise."""
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            directive = self._account_directive('Assets:Bank:Savings')
+            GnuCashImporter.create_account(directive, book)
+            GnuCashImporter.create_account(directive, book)  # second call — no error
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_create_account_unknown_parent_raises(self):
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            # Parent "NoParent" does not exist
+            directive = self._account_directive('NoParent:NewAccount')
+            with pytest.raises(Exception, match="NoParent"):
+                GnuCashImporter.create_account(directive, book)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_create_account_unknown_commodity_raises(self):
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_book()
+        try:
+            directive = self._account_directive(
+                'Assets:Bank:Savings',
+                namespace='CURRENCY',
+                mnemonic='NOTACURRENCY',
+            )
+            with pytest.raises(Exception, match="NOTACURRENCY"):
+                GnuCashImporter.create_account(directive, book)
+        finally:
+            session.end()
+            if os.path.exists(path):
+                os.unlink(path)

--- a/tests/unit/services/test_income_statement.py
+++ b/tests/unit/services/test_income_statement.py
@@ -389,3 +389,92 @@ class TestFiscalYearStart:
         from use_cases.generate_income_statement import fiscal_year_start
         # 2024-02-29 → one year ago = 2023-02-28 (fallback) → +1 day = 2023-03-01
         assert fiscal_year_start(date(2024, 2, 29)) == date(2023, 3, 1)
+
+
+# ---------------------------------------------------------------------------
+# TestGetBalanceInRange — additional branch coverage
+# ---------------------------------------------------------------------------
+
+class TestGetBalanceInRangeEdgeCases:
+
+    def test_account_with_no_splits_returns_zero(self, temp_gnucash_for_close_books):
+        """An account that exists but has zero splits returns Fraction(0)."""
+        from fractions import Fraction
+
+        from infrastructure.gnucash.utils import find_account
+        from services.income_statement import IncomeStatementService
+
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            # Income:Salary is a placeholder parent — it has no direct splits
+            acc = find_account(root, "Income:Salary")
+            svc = IncomeStatementService()
+            bal = svc.get_balance_in_range(acc, date(2024, 1, 1), date(2024, 12, 31))
+            assert bal == Fraction(0)
+        finally:
+            session.end()
+
+    def test_transaction_on_start_boundary_included(self, temp_gnucash_for_close_books):
+        """The start_date boundary is inclusive (start_date <= tx_date)."""
+        from fractions import Fraction
+
+        from infrastructure.gnucash.utils import find_account
+        from services.income_statement import IncomeStatementService
+
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            acc = find_account(root, "Income:Salary:Base")
+            svc = IncomeStatementService()
+            # Jan 31 salary: balance exactly on the boundary
+            bal_with = svc.get_balance_in_range(acc, date(2024, 1, 31), date(2024, 1, 31))
+            bal_after = svc.get_balance_in_range(acc, date(2024, 2, 1), date(2024, 2, 27))
+            assert bal_with != Fraction(0), "transaction on start date should be included"
+            assert bal_after == Fraction(0), "range Feb 1-27 excludes both Jan 31 and Feb 28 salaries"
+        finally:
+            session.end()
+
+    def test_transaction_on_end_boundary_included(self, temp_gnucash_for_close_books):
+        """The end_date boundary is inclusive (tx_date <= end_date)."""
+        from fractions import Fraction
+
+        from infrastructure.gnucash.utils import find_account
+        from services.income_statement import IncomeStatementService
+
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            acc = find_account(root, "Income:Salary:Base")
+            svc = IncomeStatementService()
+            # Jan 31 salary: should be included when end=Jan 31
+            bal_with = svc.get_balance_in_range(acc, date(2024, 1, 1), date(2024, 1, 31))
+            bal_before = svc.get_balance_in_range(acc, date(2024, 1, 1), date(2024, 1, 30))
+            assert bal_with != Fraction(0), "transaction on end date should be included"
+            assert bal_before == Fraction(0), "range ending before transaction should be empty"
+        finally:
+            session.end()
+
+
+# ---------------------------------------------------------------------------
+# TestComputeEdgeCases
+# ---------------------------------------------------------------------------
+
+class TestComputeEdgeCases:
+
+    def test_compute_empty_period_returns_empty_sections(self, temp_gnucash_for_close_books):
+        """When no transactions fall in the period, both sections are empty."""
+        from fractions import Fraction
+
+        from services.income_statement import IncomeStatementService
+
+        session = _open_read_only(temp_gnucash_for_close_books)
+        try:
+            root = session.book.get_root_account()
+            svc = IncomeStatementService()
+            result = svc.compute(root, date(2020, 1, 1), date(2020, 12, 31))
+            assert result.income.lines == []
+            assert result.expenses.lines == []
+            assert result.net_currency_totals == {}
+        finally:
+            session.end()

--- a/tests/unit/services/test_income_statement_renderer.py
+++ b/tests/unit/services/test_income_statement_renderer.py
@@ -1,0 +1,314 @@
+"""
+Unit tests for income_statement_renderer.
+
+These tests are pure Python — no GnuCash session required.
+They construct IncomeStatementResult objects directly and verify
+the text/HTML output.
+"""
+
+from datetime import date
+from fractions import Fraction
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers: build minimal IncomeStatementResult objects
+# ---------------------------------------------------------------------------
+
+def _make_result(
+    income_lines=None,
+    expense_lines=None,
+    fx_rates_provided=False,
+    start=date(2024, 1, 1),
+    end=date(2024, 12, 31),
+):
+    from fractions import Fraction
+
+    from services.income_statement import (
+        AccountLine,
+        IncomeStatementResult,
+        IncomeStatementSection,
+    )
+
+    def _section(title, lines):
+        currency_totals = {}
+        cad_total = Fraction(0) if fx_rates_provided else None
+        for line in (lines or []):
+            currency_totals[line.currency] = (
+                currency_totals.get(line.currency, Fraction(0)) + line.balance
+            )
+            if fx_rates_provided and line.cad_balance is not None:
+                cad_total += line.cad_balance
+        return IncomeStatementSection(
+            title=title,
+            lines=lines or [],
+            currency_totals=currency_totals,
+            cad_total=cad_total if fx_rates_provided else None,
+        )
+
+    income_section = _section("INCOME", income_lines)
+    expense_section = _section("EXPENSES", expense_lines)
+
+    # Net currency totals
+    all_currencies = set(income_section.currency_totals) | set(expense_section.currency_totals)
+    net_currency_totals = {
+        c: income_section.currency_totals.get(c, Fraction(0))
+          - expense_section.currency_totals.get(c, Fraction(0))
+        for c in all_currencies
+    }
+    net_cad_total = None
+    if fx_rates_provided:
+        inc_cad = income_section.cad_total or Fraction(0)
+        exp_cad = expense_section.cad_total or Fraction(0)
+        net_cad_total = inc_cad - exp_cad
+
+    return IncomeStatementResult(
+        start_date=start,
+        end_date=end,
+        income=income_section,
+        expenses=expense_section,
+        net_currency_totals=net_currency_totals,
+        net_cad_total=net_cad_total,
+        fx_rates_provided=fx_rates_provided,
+    )
+
+
+def _line(path, balance, currency="CAD", cad_balance=None):
+    from services.income_statement import AccountLine
+    parts = path.split(":")
+    return AccountLine(
+        path=path,
+        name=parts[-1],
+        depth=len(parts) - 1,
+        currency=currency,
+        balance=Fraction(balance),
+        cad_balance=Fraction(cad_balance) if cad_balance is not None else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# render_text
+# ---------------------------------------------------------------------------
+
+class TestRenderText:
+    def test_output_contains_section_titles(self):
+        from services.income_statement_renderer import render_text
+        result = _make_result(
+            income_lines=[_line("Income:Salary", 3000)],
+            expense_lines=[_line("Expenses:Groceries", 400)],
+        )
+        text = render_text(result)
+        assert "INCOME" in text
+        assert "EXPENSES" in text
+
+    def test_output_contains_account_names(self):
+        from services.income_statement_renderer import render_text
+        result = _make_result(
+            income_lines=[_line("Income:Salary", 3000)],
+            expense_lines=[_line("Expenses:Groceries", 400)],
+        )
+        text = render_text(result)
+        assert "Salary" in text
+        assert "Groceries" in text
+
+    def test_output_contains_amounts(self):
+        from services.income_statement_renderer import render_text
+        result = _make_result(
+            income_lines=[_line("Income:Salary", 3000)],
+            expense_lines=[_line("Expenses:Groceries", 400)],
+        )
+        text = render_text(result)
+        assert "3,000.00" in text
+        assert "400.00" in text
+
+    def test_no_fx_rates_shows_note(self):
+        from services.income_statement_renderer import render_text
+        result = _make_result(
+            income_lines=[_line("Income:Salary", 3000)],
+            expense_lines=[],
+        )
+        text = render_text(result)
+        assert "No FX rates" in text or "fx" in text.lower() or "CAD totals not available" in text
+
+    def test_fx_rates_provided_no_note(self):
+        from services.income_statement_renderer import render_text
+        result = _make_result(
+            income_lines=[_line("Income:Salary", 3000, cad_balance=3000)],
+            expense_lines=[],
+            fx_rates_provided=True,
+        )
+        text = render_text(result)
+        assert "No FX rates" not in text
+
+    def test_empty_sections_renders_without_crash(self):
+        from services.income_statement_renderer import render_text
+        result = _make_result(income_lines=[], expense_lines=[])
+        text = render_text(result)
+        assert "INCOME" in text
+        assert "EXPENSES" in text
+
+    def test_net_income_line_present(self):
+        from services.income_statement_renderer import render_text
+        result = _make_result(
+            income_lines=[_line("Income:Salary", 3000)],
+            expense_lines=[_line("Expenses:Groceries", 400)],
+        )
+        text = render_text(result)
+        assert "NET INCOME" in text
+
+    def test_net_loss_label_when_expenses_exceed_income(self):
+        from services.income_statement_renderer import render_text
+        result = _make_result(
+            income_lines=[_line("Income:Salary", 100, cad_balance=100)],
+            expense_lines=[_line("Expenses:Groceries", 500, cad_balance=500)],
+            fx_rates_provided=True,
+        )
+        text = render_text(result)
+        # With fx_rates_provided=True and net negative, renderer emits "NET INCOME (LOSS)"
+        assert "NET INCOME (LOSS)" in text
+
+    def test_period_dates_in_output(self):
+        from services.income_statement_renderer import render_text
+        result = _make_result(
+            start=date(2024, 1, 1),
+            end=date(2024, 3, 31),
+        )
+        text = render_text(result)
+        assert "2024-01-01" in text
+        assert "2024-03-31" in text
+
+    def test_zero_value_account_not_in_output(self):
+        """compute() skips zero-balance accounts, so they never reach the renderer."""
+        from services.income_statement_renderer import render_text
+        # If a zero-balance line somehow appears, it should still not crash.
+        result = _make_result(
+            income_lines=[_line("Income:Salary", 0)],
+            expense_lines=[],
+        )
+        text = render_text(result)
+        assert "INCOME" in text  # Section renders fine even with a zero line
+
+
+# ---------------------------------------------------------------------------
+# _render_section_text
+# ---------------------------------------------------------------------------
+
+class TestRenderSectionText:
+    def test_empty_section_renders_without_crash(self):
+        from services.income_statement import IncomeStatementSection
+        from services.income_statement_renderer import _render_section_text
+
+        section = IncomeStatementSection(
+            title="INCOME",
+            lines=[],
+            currency_totals={},
+            cad_total=None,
+        )
+        lines = _render_section_text(section, fx_rates_provided=False)
+        assert any("INCOME" in row for row in lines)
+
+    def test_section_with_single_line(self):
+        from services.income_statement_renderer import _render_section_text
+
+        section = _make_result(
+            income_lines=[_line("Income:Salary", 3000)],
+        ).income
+        lines = _render_section_text(section, fx_rates_provided=False)
+        assert any("Salary" in row for row in lines)
+        assert any("3,000.00" in row for row in lines)
+
+    def test_section_without_fx_rates_no_cad_column(self):
+        from services.income_statement_renderer import _render_section_text
+
+        section = _make_result(
+            income_lines=[_line("Income:Salary", 3000, cad_balance=3000)],
+            fx_rates_provided=False,
+        ).income
+        lines = _render_section_text(section, fx_rates_provided=False)
+        # CAD column should not appear when fx_rates_provided=False
+        combined = "\n".join(lines)
+        # The native amount is CAD, the second column would be duplicate —
+        # key check: no extra "CAD" after the native amount
+        assert "3,000.00 CAD" in combined
+
+
+# ---------------------------------------------------------------------------
+# render_html
+# ---------------------------------------------------------------------------
+
+class TestRenderHtml:
+    def test_html_contains_section_title(self):
+        from services.income_statement_renderer import render_html
+        result = _make_result(
+            income_lines=[_line("Income:Salary", 3000)],
+            expense_lines=[_line("Expenses:Groceries", 400)],
+        )
+        html = render_html(result)
+        assert "INCOME" in html
+        assert "EXPENSES" in html
+
+    def test_html_is_valid_structure(self):
+        from services.income_statement_renderer import render_html
+        result = _make_result(
+            income_lines=[_line("Income:Salary", 3000)],
+            expense_lines=[],
+        )
+        html = render_html(result)
+        assert "<html" in html.lower() or "<!doctype" in html.lower() or "<table" in html.lower()
+
+    def test_html_contains_account_names(self):
+        from services.income_statement_renderer import render_html
+        result = _make_result(
+            income_lines=[_line("Income:Salary", 3000)],
+            expense_lines=[_line("Expenses:Travel:Flight", 800)],
+        )
+        html = render_html(result)
+        assert "Salary" in html
+        assert "Flight" in html
+
+    def test_html_empty_sections_no_crash(self):
+        from services.income_statement_renderer import render_html
+        result = _make_result(income_lines=[], expense_lines=[])
+        html = render_html(result)
+        assert html  # non-empty string
+
+
+# ---------------------------------------------------------------------------
+# _build_rows
+# ---------------------------------------------------------------------------
+
+class TestBuildRows:
+    def test_line_rows_present(self):
+        from services.income_statement_renderer import _build_rows
+
+        section = _make_result(
+            income_lines=[_line("Income:Salary", 3000)],
+        ).income
+        rows = _build_rows(section, fx_rates_provided=False)
+        line_rows = [r for r in rows if r["kind"] == "line"]
+        assert len(line_rows) == 1
+        assert line_rows[0]["name"] == "Salary"
+
+    def test_total_row_present(self):
+        from services.income_statement_renderer import _build_rows
+
+        section = _make_result(
+            income_lines=[_line("Income:Salary", 3000)],
+        ).income
+        rows = _build_rows(section, fx_rates_provided=False)
+        total_rows = [r for r in rows if r["kind"] == "total"]
+        assert len(total_rows) == 1
+
+    def test_subtotal_row_for_nested_accounts(self):
+        from services.income_statement_renderer import _build_rows
+
+        # Two accounts under same parent → subtotal row expected
+        section = _make_result(
+            income_lines=[
+                _line("Income:Salary:Base",  3000),
+                _line("Income:Salary:Bonus", 1000),
+            ],
+        ).income
+        rows = _build_rows(section, fx_rates_provided=False)
+        subtotals = [r for r in rows if r["kind"] == "subtotal"]
+        assert len(subtotals) >= 1

--- a/tests/unit/services/test_ledger_validator.py
+++ b/tests/unit/services/test_ledger_validator.py
@@ -549,3 +549,161 @@ class TestReportFormatting:
 
         # Should indicate no issues
         assert "no issues" in report.lower()
+
+
+# ---------------------------------------------------------------------------
+# Additional branch coverage
+# ---------------------------------------------------------------------------
+
+class TestValidateTransactionEdgeCases:
+
+    def test_empty_splits_produces_no_splits_error(self, temp_gnucash_with_transactions):
+        """validate_transaction() on a transaction with no splits must produce NO_SPLITS error."""
+        from gnucash import GncNumeric, Session, Split, Transaction
+
+        from services.ledger_validator import LedgerValidator
+
+        try:
+            from gnucash import SessionOpenMode
+            session = Session(f'xml://{temp_gnucash_with_transactions}',
+                              SessionOpenMode.SESSION_NORMAL_OPEN)
+        except ImportError:
+            session = Session(f'xml://{temp_gnucash_with_transactions}')
+
+        try:
+            book = session.book
+            cad = book.get_table().lookup('CURRENCY', 'CAD')
+
+            # Create a transaction with no splits
+            tx = Transaction(book)
+            tx.BeginEdit()
+            tx.SetCurrency(cad)
+            tx.SetDate(15, 6, 2024)
+            tx.SetDescription("Empty splits transaction")
+            tx.CommitEdit()
+
+            validator = LedgerValidator()
+            result = validator.validate_transaction(tx)
+            error_codes = [e.code for e in result.errors]
+            assert 'NO_SPLITS' in error_codes
+        finally:
+            session.end()
+
+
+class TestCheckTransactionDateOrderEdgeCases:
+
+    def test_single_transaction_no_error(self, temp_gnucash_with_transactions):
+        """check_transaction_date_order() with only 1 transaction returns no errors."""
+        from gnucash import Query, Session, Transaction
+
+        from services.ledger_validator import LedgerValidator
+
+        try:
+            from gnucash import SessionOpenMode
+            session = Session(f'xml://{temp_gnucash_with_transactions}',
+                              SessionOpenMode.SESSION_NORMAL_OPEN)
+        except ImportError:
+            session = Session(f'xml://{temp_gnucash_with_transactions}')
+
+        try:
+            book = session.book
+            q = Query()
+            q.search_for('Trans')
+            q.set_book(book)
+            txs = [Transaction(instance=t) for t in q.run()][:1]  # only first
+
+            validator = LedgerValidator()
+            result = validator.check_transaction_date_order(txs)
+            assert result.errors == []
+            assert result.info == []
+        finally:
+            session.end()
+
+    def test_empty_list_no_error(self):
+        """check_transaction_date_order() with empty list returns clean result."""
+        from services.ledger_validator import LedgerValidator
+
+        validator = LedgerValidator()
+        result = validator.check_transaction_date_order([])
+        assert result.errors == []
+        assert result.warnings == []
+        assert result.info == []
+
+
+class TestCheckFutureTransactions:
+
+    def test_explicit_reference_date_past_transaction_no_flag(self, temp_gnucash_with_transactions):
+        """
+        When reference_date is set far in the future, no transaction should be flagged.
+        This exercises the explicit reference_date parameter branch.
+        """
+        from gnucash import Query, Session, Transaction
+
+        from services.ledger_validator import LedgerValidator
+
+        try:
+            from gnucash import SessionOpenMode
+            session = Session(f'xml://{temp_gnucash_with_transactions}',
+                              SessionOpenMode.SESSION_NORMAL_OPEN)
+        except ImportError:
+            session = Session(f'xml://{temp_gnucash_with_transactions}')
+
+        try:
+            book = session.book
+            q = Query()
+            q.search_for('Trans')
+            q.set_book(book)
+            txs = [Transaction(instance=t) for t in q.run()]
+
+            validator = LedgerValidator()
+            # All test transactions are in 2024; reference_date = 2030 → none are future
+            result = validator.check_future_transactions(txs, reference_date=datetime(2030, 1, 1))
+            assert result.info == []
+        finally:
+            session.end()
+
+    def test_explicit_reference_date_flags_future_transaction(self, temp_gnucash_with_transactions):
+        """
+        When reference_date is set before the transactions, they should all be flagged.
+        """
+        from gnucash import Query, Session, Transaction
+
+        from services.ledger_validator import LedgerValidator
+
+        try:
+            from gnucash import SessionOpenMode
+            session = Session(f'xml://{temp_gnucash_with_transactions}',
+                              SessionOpenMode.SESSION_NORMAL_OPEN)
+        except ImportError:
+            session = Session(f'xml://{temp_gnucash_with_transactions}')
+
+        try:
+            book = session.book
+            q = Query()
+            q.search_for('Trans')
+            q.set_book(book)
+            txs = [Transaction(instance=t) for t in q.run()]
+
+            validator = LedgerValidator()
+            # All test transactions are in 2024; reference_date = 2020 → all are future
+            result = validator.check_future_transactions(txs, reference_date=datetime(2020, 1, 1))
+            future_codes = [i.code for i in result.info]
+            assert all(c == 'FUTURE_DATE' for c in future_codes)
+            assert len(result.info) == len(txs)
+        finally:
+            session.end()
+
+
+class TestFormatValidationReportEdgeCases:
+
+    def test_empty_result_clean_output(self):
+        """format_validation_report() with no errors/warnings produces clean summary."""
+        from services.ledger_validator import LedgerValidator, ValidationResult
+
+        validator = LedgerValidator()
+        result = ValidationResult()
+        report = validator.format_validation_report(result)
+        assert "VALIDATION REPORT" in report
+        # No error/warning sections
+        assert "ERRORS:" not in report
+        assert "WARNINGS:" not in report

--- a/tests/unit/services/test_plaintext_parser.py
+++ b/tests/unit/services/test_plaintext_parser.py
@@ -1,0 +1,338 @@
+"""
+Unit tests for PlaintextParser and its line-level parse helpers.
+
+These tests are pure Python — no GnuCash session required.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse(text: str):
+    """Parse a plaintext string and return the root directive."""
+    from services.plaintext_parser import PlaintextParser
+    p = PlaintextParser()
+    p.parse_string(text)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# parse_transaction_head
+# ---------------------------------------------------------------------------
+
+class TestParseTransactionHead:
+    def test_date_and_description(self):
+        from services.plaintext_parser import parse_transaction_head
+        date, num, desc = parse_transaction_head('2024-03-01 * "Grocery shopping"')
+        assert date == '2024-03-01'
+        assert num is None
+        assert desc == 'Grocery shopping'
+
+    def test_date_num_and_description(self):
+        from services.plaintext_parser import parse_transaction_head
+        date, num, desc = parse_transaction_head('2024-03-01 * "42" "Grocery shopping"')
+        assert date == '2024-03-01'
+        assert num == '42'
+        assert desc == 'Grocery shopping'
+
+    def test_date_only(self):
+        from services.plaintext_parser import parse_transaction_head
+        date, num, desc = parse_transaction_head('2024-03-01 *')
+        assert date == '2024-03-01'
+        assert num is None
+        assert desc is None
+
+    def test_non_transaction_line_returns_none(self):
+        from services.plaintext_parser import parse_transaction_head
+        date, num, desc = parse_transaction_head('  Expenses:Dining  30.45 CAD')
+        assert date is None
+        assert num is None
+        assert desc is None
+
+
+# ---------------------------------------------------------------------------
+# parse_split
+# ---------------------------------------------------------------------------
+
+class TestParseSplit:
+    def test_basic_split(self):
+        from services.plaintext_parser import parse_split
+        account, amount, symbol = parse_split('  Expenses:Dining  30.45 CAD')
+        assert account == 'Expenses:Dining'
+        assert amount == '30.45'
+        assert symbol == 'CAD'
+
+    def test_negative_amount(self):
+        from services.plaintext_parser import parse_split
+        account, amount, symbol = parse_split('  Assets:Bank:Checking  -30.45 CAD')
+        assert account == 'Assets:Bank:Checking'
+        assert amount == '-30.45'
+        assert symbol == 'CAD'
+
+    def test_non_split_line_returns_none(self):
+        from services.plaintext_parser import parse_split
+        account, amount, symbol = parse_split('2024-03-01 * "Grocery shopping"')
+        assert account is None
+        assert amount is None
+        assert symbol is None
+
+
+# ---------------------------------------------------------------------------
+# parse_metadata
+# ---------------------------------------------------------------------------
+
+class TestParseMetadata:
+    def test_simple_key_value(self):
+        from services.plaintext_parser import parse_metadata
+        key, value = parse_metadata('  notes: some note here')
+        assert key == 'notes'
+        assert value == 'some note here'
+
+    def test_key_with_dots(self):
+        from services.plaintext_parser import parse_metadata
+        key, value = parse_metadata('  commodity.mnemonic: CAD')
+        assert key == 'commodity.mnemonic'
+        assert value == 'CAD'
+
+    def test_non_metadata_line_returns_none(self):
+        from services.plaintext_parser import parse_metadata
+        key, value = parse_metadata('  Expenses:Dining  30.45 CAD')
+        assert key is None
+        assert value is None
+
+    def test_quoted_value_decoded(self):
+        from services.plaintext_parser import parse_metadata
+        key, value = parse_metadata('  notes: "a quoted note"')
+        assert key == 'notes'
+        assert value == 'a quoted note'
+
+
+# ---------------------------------------------------------------------------
+# parse_open_account
+# ---------------------------------------------------------------------------
+
+class TestParseOpenAccount:
+    def test_basic_account(self):
+        from services.plaintext_parser import parse_open_account
+        # The open_account_pattern captures everything after "open " into the account
+        # group; the commodity symbol (if on the same line) is included in the name.
+        # Use the name-only form to test a clean result.
+        date, directive, name = parse_open_account('2024-01-01 open Assets:Bank:Checking')
+        assert date == '2024-01-01'
+        assert directive == 'open'
+        assert name == 'Assets:Bank:Checking'
+
+    def test_non_account_line_returns_none(self):
+        from services.plaintext_parser import parse_open_account
+        date, directive, name = parse_open_account('2024-03-01 * "Grocery shopping"')
+        assert date is None
+
+
+# ---------------------------------------------------------------------------
+# parse_commodity_directive
+# ---------------------------------------------------------------------------
+
+class TestParseCommodityDirective:
+    def test_commodity_line(self):
+        from services.plaintext_parser import parse_commodity_directive
+        date, directive, symbol = parse_commodity_directive('2024-01-01 commodity CAD')
+        assert date == '2024-01-01'
+        assert directive == 'commodity'
+        assert symbol == 'CAD'
+
+    def test_non_commodity_line_returns_none(self):
+        from services.plaintext_parser import parse_commodity_directive
+        date, directive, symbol = parse_commodity_directive('2024-03-01 * "Grocery shopping"')
+        assert date is None
+
+
+# ---------------------------------------------------------------------------
+# PlaintextParser.parse_string — full directive tree
+# ---------------------------------------------------------------------------
+
+class TestParseTransaction:
+    def test_transaction_with_splits_and_metadata(self):
+        text = """\
+2024-03-01 * "Grocery shopping"
+    notes: receipt #1234
+    guid: abcd1234
+    Expenses:Groceries  50.00 CAD
+    Assets:Bank:Checking  -50.00 CAD
+"""
+        p = _parse(text)
+        assert not p.errors
+        txs = [d for d in p.root_directive.children
+               if d.type.name == 'TRANSACTION']
+        assert len(txs) == 1
+        tx = txs[0]
+        assert tx.props['tx_desc'] == 'Grocery shopping'
+        assert tx.props['date'] == '2024-03-01'
+        assert tx.props['tx_num'] is None
+        assert tx.metadata['notes'] == 'receipt #1234'
+        assert tx.metadata['guid'] == 'abcd1234'
+        assert len(tx.children) == 2
+
+    def test_transaction_with_tx_num(self):
+        text = '2024-03-01 * "42" "Grocery shopping"\n    Expenses:Groceries  50.00 CAD\n    Assets:Bank:Checking  -50.00 CAD\n'
+        p = _parse(text)
+        tx = next(d for d in p.root_directive.children if d.type.name == 'TRANSACTION')
+        assert tx.props['tx_num'] == '42'
+        assert tx.props['tx_desc'] == 'Grocery shopping'
+
+    def test_transaction_without_tx_num(self):
+        text = '2024-03-01 * "Grocery shopping"\n    Expenses:Groceries  50.00 CAD\n    Assets:Bank:Checking  -50.00 CAD\n'
+        p = _parse(text)
+        tx = next(d for d in p.root_directive.children if d.type.name == 'TRANSACTION')
+        assert tx.props['tx_num'] is None
+
+    def test_two_splits_same_account(self):
+        """Duplicate-account splits both appear as children."""
+        text = """\
+2024-03-07 * "Restaurant meal"
+    Expenses:Dining  30.45 CAD
+    Expenses:Dining  5.00 CAD
+    Assets:Bank:Checking  -35.45 CAD
+"""
+        p = _parse(text)
+        tx = next(d for d in p.root_directive.children if d.type.name == 'TRANSACTION')
+        dining = [c for c in tx.children if c.props['account'] == 'Expenses:Dining']
+        assert len(dining) == 2
+        amounts = sorted(c.props['amount'] for c in dining)
+        assert amounts == ['30.45', '5.00']
+
+    def test_split_with_memo_and_action_metadata(self):
+        text = """\
+2024-03-01 * "Investment"
+    Assets:Broker  10 MSFT
+        memo: buy order
+        action: Buy
+        share_price: 150.00
+    Assets:Bank:Checking  -1500.00 CAD
+"""
+        p = _parse(text)
+        tx = next(d for d in p.root_directive.children if d.type.name == 'TRANSACTION')
+        broker_split = next(c for c in tx.children if c.props['account'] == 'Assets:Broker')
+        assert broker_split.metadata.get('memo') == 'buy order'
+        assert broker_split.metadata.get('action') == 'Buy'
+        assert broker_split.metadata.get('share_price') == 150.0
+
+    def test_split_with_value_metadata(self):
+        text = """\
+2024-03-01 * "FX purchase"
+    Assets:USD  100 USD
+        value: 135.00
+    Assets:Bank:Checking  -135.00 CAD
+"""
+        p = _parse(text)
+        tx = next(d for d in p.root_directive.children if d.type.name == 'TRANSACTION')
+        usd_split = next(c for c in tx.children if c.props['account'] == 'Assets:USD')
+        assert usd_split.metadata.get('value') == 135.0
+
+    def test_custom_metadata_on_transaction(self):
+        text = """\
+2024-03-01 * "Expense"
+    my_ref: REF-001
+    Expenses:Dining  25.00 CAD
+    Assets:Bank:Checking  -25.00 CAD
+"""
+        p = _parse(text)
+        tx = next(d for d in p.root_directive.children if d.type.name == 'TRANSACTION')
+        assert tx.metadata.get('my_ref') == 'REF-001'
+
+    def test_custom_metadata_on_split(self):
+        text = """\
+2024-03-01 * "Expense"
+    Expenses:Dining  25.00 CAD
+        vendor: Acme
+    Assets:Bank:Checking  -25.00 CAD
+"""
+        p = _parse(text)
+        tx = next(d for d in p.root_directive.children if d.type.name == 'TRANSACTION')
+        dining = next(c for c in tx.children if c.props['account'] == 'Expenses:Dining')
+        assert dining.metadata.get('vendor') == 'Acme'
+
+
+class TestParseAccount:
+    def test_open_account_directive(self):
+        text = '2024-01-01 open Assets:Bank:Checking\n    type: BANK\n    commodity.namespace: CURRENCY\n    commodity.mnemonic: CAD\n'
+        p = _parse(text)
+        accounts = [d for d in p.root_directive.children if d.type.name == 'OPEN_ACCOUNT']
+        assert len(accounts) == 1
+        assert accounts[0].props['account'] == 'Assets:Bank:Checking'
+        assert accounts[0].metadata.get('type') == 'BANK'
+
+    def test_account_registered_in_accounts_dict(self):
+        text = '2024-01-01 open Assets:Bank:Checking\n'
+        p = _parse(text)
+        assert 'Assets:Bank:Checking' in p.accounts
+
+
+class TestParseCommodity:
+    def test_commodity_directive(self):
+        text = '2024-01-01 commodity CAD\n    namespace: CURRENCY\n    mnemonic: CAD\n'
+        p = _parse(text)
+        commodities = [d for d in p.root_directive.children if d.type.name == 'CREATE_COMMODITY']
+        assert len(commodities) == 1
+        assert commodities[0].props['symbol'] == 'CAD'
+
+    def test_commodity_registered_in_commodities_dict(self):
+        text = '2024-01-01 commodity CAD\n    namespace: CURRENCY\n    mnemonic: CAD\n'
+        p = _parse(text)
+        assert 'CAD' in p.commodities
+
+
+class TestParseCustomerVendor:
+    def test_customer_directive(self):
+        text = 'customer "CUST-001"\n    name: Acme Corp\n    currency: CAD\n'
+        p = _parse(text)
+        customers = [d for d in p.root_directive.children if d.type.name == 'CUSTOMER']
+        assert len(customers) == 1
+        assert customers[0].props['id'] == 'CUST-001'
+
+    def test_vendor_directive(self):
+        text = 'vendor "VEND-001"\n    name: Supplier Inc\n    currency: CAD\n'
+        p = _parse(text)
+        vendors = [d for d in p.root_directive.children if d.type.name == 'VENDOR']
+        assert len(vendors) == 1
+        assert vendors[0].props['id'] == 'VEND-001'
+
+
+class TestParseFile:
+    def test_parse_file_matches_parse_string(self):
+        """parse_file() and parse_string() on the same content produce same result."""
+        content = '2024-03-01 * "Grocery shopping"\n    Expenses:Groceries  50.00 CAD\n    Assets:Bank:Checking  -50.00 CAD\n'
+
+        from services.plaintext_parser import PlaintextParser
+
+        p_string = PlaintextParser()
+        p_string.parse_string(content)
+
+        fd, path = tempfile.mkstemp(suffix='.txt')
+        try:
+            with os.fdopen(fd, 'w') as f:
+                f.write(content)
+            p_file = PlaintextParser()
+            p_file.parse_file(path)
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+        string_txs = [d for d in p_string.root_directive.children if d.type.name == 'TRANSACTION']
+        file_txs = [d for d in p_file.root_directive.children if d.type.name == 'TRANSACTION']
+        assert len(string_txs) == len(file_txs) == 1
+        assert string_txs[0].props['tx_desc'] == file_txs[0].props['tx_desc']
+
+
+class TestParseIndentationErrors:
+    def test_mixed_tabs_and_spaces_adds_error(self):
+        from services.plaintext_parser import PlaintextParser
+        # First indented line uses tabs, to trigger mixed-indent detection
+        text = '2024-03-01 * "Test"\n\t Expenses:Dining  25.00 CAD\n'
+        p = PlaintextParser()
+        p.parse_string(text)
+        assert len(p.errors) > 0


### PR DESCRIPTION
Add new test modules and extend existing ones to cover code paths that were missing from the test suite.

New test modules (pure Python, no GnuCash session required):
- tests/unit/services/test_plaintext_parser.py
  - parse_transaction_head, parse_split, parse_metadata, parse_open_account, parse_commodity_directive helpers
  - Full directive-tree tests: tx with metadata, tx_num, duplicate- account splits, split metadata (memo/action/share_price/value), custom metadata on tx and split
  - parse_file() vs parse_string() equivalence
  - Mixed-indentation error detection
- tests/unit/services/test_beancount_parser.py
  - Commodity: happy path, missing mnemonic/namespace raises
  - Account: happy path, missing metadata raises, opened_accounts tracking, get_account_mapping()
  - Transaction: happy path, posting amounts, missing guid raises, notes+doclink, posting memo+action, used_accounts tracking
  - Validation: implicit account raises, comments skipped
- tests/unit/services/test_income_statement_renderer.py
  - render_text: section titles, amounts, FX note, NET INCOME, NET INCOME (LOSS) label when expenses > income with fx rates, period dates
  - _render_section_text: empty section, single line, no-CAD column
  - render_html: structure, account names, empty sections
  - _build_rows: line rows, total row, subtotal for nested accounts

Extended existing test modules:
- test_gnucash_importer_errors.py: create_commodity idempotency, create_account idempotency and error paths (unknown parent/commodity)
- test_income_statement.py: zero-split account returns 0, date boundary inclusivity (Jan 31 boundary; Feb 1-27 range excludes both the Jan 31 and Feb 28 salary transactions), empty period
- test_ledger_validator.py: empty-splits NO_SPLITS error, single-tx and empty-list date-order checks, explicit reference_date branch for check_future_transactions, empty-result format
- test_conflict_resolver.py: empty conflict list with each resolution mode, amounts_differ with mismatched split counts and structurally equal splits (separate list objects)