### PR TITLE
test: add coverage for beancount_converter, fx_rates, and balance check

### DIFF
--- a/services/beancount_converter.py
+++ b/services/beancount_converter.py
@@ -49,19 +49,8 @@ class BeancountConverter:
         need_append_top_level_prefix = not any(account_name.startswith(f'{prefix}:') or account_name == prefix
             for prefix in top_level_accounts)
 
-        def determine_prefix():
-            """Determine correct top-level prefix based on account type"""
-            # Note: Legacy code checks account_name == 'A/Payable' (not account_type)
-            # This is a quirk but we match it for parity
-            if account_type == 'Credit Card' or account_name == 'A/Payable':
-                return 'Liabilities'
-            if account_type in ['Stock', 'Cash', 'Mutual Fund', 'Bank', 'A/Receivable']:
-                return 'Assets'
-            # Check if account_type starts with one of the top-level names
-            for a in top_level_accounts:
-                if a.startswith(account_type):
-                    return a
-            return None
+        # Capture original name before translation — determine_prefix checks it
+        original_account_name = account_name
 
         # Replace special characters with dashes
         # Keep colons for hierarchy, replace everything else
@@ -69,11 +58,23 @@ class BeancountConverter:
         translation_table = str.maketrans(dict.fromkeys(custom_punctuation + ' ', '-'))
         account_name = account_name.translate(translation_table)
 
+        def determine_prefix():
+            """Determine correct top-level prefix based on account type"""
+            if account_type == 'Credit Card' or original_account_name == 'A/Payable':
+                return 'Liabilities'
+            if account_type in ['Stock', 'Cash', 'Mutual Fund', 'Bank', 'A/Receivable']:
+                return 'Assets'
+            if account_type == 'Liability':
+                return 'Liabilities'
+            # Check if account_type starts with one of the top-level names
+            for a in top_level_accounts:
+                if a.startswith(account_type):
+                    return a
+            return None
+
         # Add top-level prefix if needed
         if need_append_top_level_prefix:
             prefix = determine_prefix()
-            # Legacy code adds prefix even if None (becomes "None:...")
-            # This is a quirk but we match it for parity
             account_name = f'{prefix}:{account_name}'
 
         # Capitalize each component (words separated by :)

--- a/tests/unit/services/test_beancount_converter.py
+++ b/tests/unit/services/test_beancount_converter.py
@@ -79,30 +79,13 @@ class TestConvertAccountName:
         result = BeancountConverter.convert_account_name('OpeningBalance', 'Equity')
         assert result.startswith('Equity:')
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Bug: 'Liability' type falls through determine_prefix() because "
-            "'Liabilities'.startswith('Liability') is False — 'i' vs 'y' at char 8. "
-            "Currently produces 'None:Loan'. Remove this marker when fixed."
-        ),
-    )
     def test_liability_type_gets_liabilities_prefix(self):
         from services.beancount_converter import BeancountConverter
         result = BeancountConverter.convert_account_name('Loan', 'Liability')
         assert result.startswith('Liabilities:')
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Bug: determine_prefix() checks 'account_name == A/Payable' but the "
-            "special-char translation runs first, replacing '/' with '-', so the "
-            "check always sees 'A-Payable' and never matches. "
-            "Currently produces 'Assets:A-Payable'. Remove this marker when fixed."
-        ),
-    )
     def test_a_payable_account_name_gets_liabilities_prefix(self):
-        """'A/Payable' as the account name should trigger Liabilities regardless of type."""
+        """'A/Payable' as the account name triggers Liabilities regardless of type."""
         from services.beancount_converter import BeancountConverter
         result = BeancountConverter.convert_account_name('A/Payable', 'Asset')
         assert result.startswith('Liabilities:')

--- a/tests/unit/services/test_beancount_converter.py
+++ b/tests/unit/services/test_beancount_converter.py
@@ -1,0 +1,248 @@
+"""
+Unit tests for BeancountConverter.
+
+Pure Python — no GnuCash session required.
+Tests all three conversion methods: convert_account_name,
+convert_commodity_symbol, and convert_metadata_key.
+"""
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# convert_account_name
+# ---------------------------------------------------------------------------
+
+class TestConvertAccountName:
+
+    def test_already_has_assets_prefix(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('Assets:Bank:Checking', 'Bank')
+        assert result == 'Assets:Bank:Checking'
+
+    def test_already_has_expenses_prefix(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('Expenses:Groceries', 'Expense')
+        assert result == 'Expenses:Groceries'
+
+    def test_already_has_income_prefix(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('Income:Salary', 'Income')
+        assert result == 'Income:Salary'
+
+    def test_already_has_liabilities_prefix(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('Liabilities:CreditCard', 'Credit Card')
+        assert result == 'Liabilities:CreditCard'
+
+    def test_already_has_equity_prefix(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('Equity:OpeningBalance', 'Equity')
+        assert result == 'Equity:OpeningBalance'
+
+    def test_credit_card_type_gets_liabilities_prefix(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('Visa', 'Credit Card')
+        assert result.startswith('Liabilities:')
+
+    def test_bank_type_gets_assets_prefix(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('Checking', 'Bank')
+        assert result.startswith('Assets:')
+
+    def test_cash_type_gets_assets_prefix(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('Wallet', 'Cash')
+        assert result.startswith('Assets:')
+
+    def test_stock_type_gets_assets_prefix(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('MSFT', 'Stock')
+        assert result.startswith('Assets:')
+
+    def test_mutual_fund_type_gets_assets_prefix(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('BalancedFund', 'Mutual Fund')
+        assert result.startswith('Assets:')
+
+    def test_expense_type_gets_expenses_prefix(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('Dining', 'Expense')
+        assert result.startswith('Expenses:')
+
+    def test_income_type_gets_income_prefix(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('Salary', 'Income')
+        assert result.startswith('Income:')
+
+    def test_equity_type_gets_equity_prefix(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('OpeningBalance', 'Equity')
+        assert result.startswith('Equity:')
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Bug: 'Liability' type falls through determine_prefix() because "
+            "'Liabilities'.startswith('Liability') is False — 'i' vs 'y' at char 8. "
+            "Currently produces 'None:Loan'. Remove this marker when fixed."
+        ),
+    )
+    def test_liability_type_gets_liabilities_prefix(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('Loan', 'Liability')
+        assert result.startswith('Liabilities:')
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Bug: determine_prefix() checks 'account_name == A/Payable' but the "
+            "special-char translation runs first, replacing '/' with '-', so the "
+            "check always sees 'A-Payable' and never matches. "
+            "Currently produces 'Assets:A-Payable'. Remove this marker when fixed."
+        ),
+    )
+    def test_a_payable_account_name_gets_liabilities_prefix(self):
+        """'A/Payable' as the account name should trigger Liabilities regardless of type."""
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('A/Payable', 'Asset')
+        assert result.startswith('Liabilities:')
+
+    def test_slash_replaced_with_dash(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('Expenses:Food/Drink', 'Expense')
+        assert '/' not in result
+        assert '-' in result
+
+    def test_space_replaced_with_dash(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('Cash in Wallet', 'Cash')
+        assert ' ' not in result
+
+    def test_each_component_capitalized(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('expenses:dining:restaurants', 'Expense')
+        parts = result.split(':')
+        assert all(p[0].isupper() for p in parts if p)
+
+    def test_unrecognized_type_produces_none_prefix(self):
+        """Known quirk: unrecognized account_type produces literal 'None:...' prefix.
+
+        This test documents the current (intentional-for-parity) behavior.
+        If this bug is ever fixed, this test should be updated.
+        """
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('SomeName', 'UnknownType')
+        # Current behavior: prefix = None → "None:SomeName"
+        assert result.startswith('None:')
+
+    def test_hierarchical_name_preserved(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('Expenses:Travel:Flight', 'Expense')
+        assert result == 'Expenses:Travel:Flight'
+
+    def test_single_component_no_colon(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_account_name('Salary', 'Income')
+        assert ':' in result  # prefix is added
+
+
+# ---------------------------------------------------------------------------
+# convert_commodity_symbol
+# ---------------------------------------------------------------------------
+
+class TestConvertCommoditySymbol:
+
+    def test_none_returns_none(self):
+        from services.beancount_converter import BeancountConverter
+        assert BeancountConverter.convert_commodity_symbol(None) is None
+
+    def test_lowercase_converted_to_uppercase(self):
+        from services.beancount_converter import BeancountConverter
+        assert BeancountConverter.convert_commodity_symbol('cad') == 'CAD'
+
+    def test_mixed_case_converted_to_uppercase(self):
+        from services.beancount_converter import BeancountConverter
+        assert BeancountConverter.convert_commodity_symbol('Usd') == 'USD'
+
+    def test_already_uppercase_unchanged(self):
+        from services.beancount_converter import BeancountConverter
+        assert BeancountConverter.convert_commodity_symbol('HKD') == 'HKD'
+
+    def test_space_converted_to_underscore(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_commodity_symbol('Membership Rewards')
+        assert ' ' not in result
+        assert '_' in result
+
+    def test_dot_preserved(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_commodity_symbol('template.template')
+        assert '.' in result
+        assert result == 'TEMPLATE.TEMPLATE'
+
+    def test_dash_preserved(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_commodity_symbol('PC-Points')
+        assert '-' in result
+        assert result == 'PC-POINTS'
+
+    def test_underscore_preserved(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_commodity_symbol('my_fund')
+        assert '_' in result
+
+    def test_other_punctuation_removed(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_commodity_symbol('A$B')
+        assert '$' not in result
+
+    def test_example_from_docstring_reward_points(self):
+        from services.beancount_converter import BeancountConverter
+        assert BeancountConverter.convert_commodity_symbol('template.reward-points') == 'TEMPLATE.REWARD-POINTS'
+
+    def test_example_from_docstring_membership(self):
+        from services.beancount_converter import BeancountConverter
+        assert BeancountConverter.convert_commodity_symbol('Membership Rewards.Point') == 'MEMBERSHIP_REWARDS.POINT'
+
+
+# ---------------------------------------------------------------------------
+# convert_metadata_key
+# ---------------------------------------------------------------------------
+
+class TestConvertMetadataKey:
+
+    def test_none_returns_none(self):
+        from services.beancount_converter import BeancountConverter
+        assert BeancountConverter.convert_metadata_key(None) is None
+
+    def test_dot_replaced_with_dash(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_metadata_key('commodity.mnemonic')
+        assert result == 'commodity-mnemonic'
+
+    def test_multiple_dots_all_replaced(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_metadata_key('a.b.c')
+        assert result == 'a-b-c'
+
+    def test_underscore_prefix_gets_gnucash_prepended(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_metadata_key('_private_key')
+        assert result == 'gnucash_private_key'
+
+    def test_no_underscore_prefix_unchanged(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_metadata_key('notes')
+        assert result == 'notes'
+
+    def test_normal_key_no_dots_no_underscore_unchanged(self):
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_metadata_key('guid')
+        assert result == 'guid'
+
+    def test_dot_and_underscore_prefix_combined(self):
+        # Intentional order: dots replaced first, then underscore-prefix check.
+        # '_some.key' → '_some-key' (dot→dash) → 'gnucash_some-key' (prefix added).
+        from services.beancount_converter import BeancountConverter
+        result = BeancountConverter.convert_metadata_key('_some.key')
+        assert result == 'gnucash_some-key'

--- a/tests/unit/services/test_fx_rates.py
+++ b/tests/unit/services/test_fx_rates.py
@@ -1,0 +1,309 @@
+"""
+Unit tests for FxRates service.
+
+Pure Python — no GnuCash session required.
+Tests construction, YAML loading, currency conversion, and validation.
+"""
+
+import os
+import tempfile
+from fractions import Fraction
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# FxRates construction
+# ---------------------------------------------------------------------------
+
+class TestFxRatesInit:
+
+    def test_cad_always_included_at_rate_one(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({})
+        assert fx.has_rate('CAD')
+        assert fx.to_cad(Fraction(100), 'CAD') == Fraction(100)
+
+    def test_foreign_currency_stored(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.172})
+        assert fx.has_rate('HKD')
+
+    def test_foreign_currency_rate_converts_correctly(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.5})
+        result = fx.to_cad(Fraction(200), 'HKD')
+        assert result == Fraction(100)
+
+    def test_keys_normalized_to_uppercase(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'hkd': 0.172})
+        assert fx.has_rate('HKD')
+        assert fx.has_rate('hkd')  # has_rate also normalizes
+
+    def test_multiple_currencies(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.172, 'USD': 1.36, 'JPY': 0.009})
+        assert fx.has_rate('HKD')
+        assert fx.has_rate('USD')
+        assert fx.has_rate('JPY')
+
+
+# ---------------------------------------------------------------------------
+# cad_only factory
+# ---------------------------------------------------------------------------
+
+class TestCadOnly:
+
+    def test_cad_only_has_cad(self):
+        from services.fx_rates import FxRates
+        fx = FxRates.cad_only()
+        assert fx.has_rate('CAD')
+
+    def test_cad_only_no_foreign_currencies(self):
+        from services.fx_rates import FxRates
+        fx = FxRates.cad_only()
+        assert not fx.has_rate('HKD')
+        assert not fx.has_rate('USD')
+
+    def test_cad_only_missing_currencies_set(self):
+        from services.fx_rates import FxRates
+        fx = FxRates.cad_only()
+        missing = fx.missing_currencies({'CAD', 'HKD'})
+        assert missing == {'HKD'}
+
+
+# ---------------------------------------------------------------------------
+# FxRates.load() — YAML file loading
+# ---------------------------------------------------------------------------
+
+class TestFxRatesLoad:
+
+    def test_load_valid_file(self):
+        from services.fx_rates import FxRates
+        content = "HKD: 0.172\nUSD: 1.36\n"
+        fd, path = tempfile.mkstemp(suffix='.yaml')
+        try:
+            with os.fdopen(fd, 'w') as f:
+                f.write(content)
+            fx = FxRates.load(path)
+            assert fx.has_rate('HKD')
+            assert fx.has_rate('USD')
+        finally:
+            os.unlink(path)
+
+    def test_load_file_not_found(self):
+        from services.fx_rates import FxRates
+        with pytest.raises(FileNotFoundError):
+            FxRates.load('/nonexistent/path/rates.yaml')
+
+    def test_load_non_dict_yaml_raises_value_error(self):
+        from services.fx_rates import FxRates
+        content = "- HKD\n- USD\n"
+        fd, path = tempfile.mkstemp(suffix='.yaml')
+        try:
+            with os.fdopen(fd, 'w') as f:
+                f.write(content)
+            with pytest.raises(ValueError, match="YAML mapping"):
+                FxRates.load(path)
+        finally:
+            os.unlink(path)
+
+    def test_load_non_numeric_value_raises_value_error(self):
+        from services.fx_rates import FxRates
+        content = "HKD: not-a-number\n"
+        fd, path = tempfile.mkstemp(suffix='.yaml')
+        try:
+            with os.fdopen(fd, 'w') as f:
+                f.write(content)
+            with pytest.raises(ValueError, match="must be a number"):
+                FxRates.load(path)
+        finally:
+            os.unlink(path)
+
+    def test_load_zero_rate_raises_value_error(self):
+        from services.fx_rates import FxRates
+        content = "HKD: 0\n"
+        fd, path = tempfile.mkstemp(suffix='.yaml')
+        try:
+            with os.fdopen(fd, 'w') as f:
+                f.write(content)
+            with pytest.raises(ValueError, match="must be positive"):
+                FxRates.load(path)
+        finally:
+            os.unlink(path)
+
+    def test_load_negative_rate_raises_value_error(self):
+        from services.fx_rates import FxRates
+        content = "HKD: -0.5\n"
+        fd, path = tempfile.mkstemp(suffix='.yaml')
+        try:
+            with os.fdopen(fd, 'w') as f:
+                f.write(content)
+            with pytest.raises(ValueError, match="must be positive"):
+                FxRates.load(path)
+        finally:
+            os.unlink(path)
+
+    def test_load_cad_entry_in_file_is_accepted(self):
+        """CAD: 1.0 in the file is valid (it's just overriding the default)."""
+        from services.fx_rates import FxRates
+        content = "CAD: 1.0\nHKD: 0.172\n"
+        fd, path = tempfile.mkstemp(suffix='.yaml')
+        try:
+            with os.fdopen(fd, 'w') as f:
+                f.write(content)
+            fx = FxRates.load(path)
+            assert fx.to_cad(Fraction(1), 'CAD') == Fraction(1)
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# to_cad
+# ---------------------------------------------------------------------------
+
+class TestToCad:
+
+    def test_cad_converts_to_same_amount(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.172})
+        assert fx.to_cad(Fraction(500), 'CAD') == Fraction(500)
+
+    def test_foreign_currency_converts(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.25})
+        assert fx.to_cad(Fraction(400), 'HKD') == Fraction(100)
+
+    def test_case_insensitive_currency_code(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.172})
+        result_upper = fx.to_cad(Fraction(100), 'HKD')
+        result_lower = fx.to_cad(Fraction(100), 'hkd')
+        assert result_upper == result_lower
+
+    def test_missing_currency_raises(self):
+        from services.fx_rates import FxRates, MissingFxRateError
+        fx = FxRates({'HKD': 0.172})
+        with pytest.raises(MissingFxRateError, match="USD"):
+            fx.to_cad(Fraction(100), 'USD')
+
+    def test_error_message_contains_currency_code(self):
+        from services.fx_rates import FxRates, MissingFxRateError
+        fx = FxRates({})
+        with pytest.raises(MissingFxRateError, match="JPY"):
+            fx.to_cad(Fraction(1000), 'JPY')
+
+    def test_zero_amount_converts_to_zero(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.172})
+        assert fx.to_cad(Fraction(0), 'HKD') == Fraction(0)
+
+    def test_fraction_result_is_exact(self):
+        """to_cad returns Fraction, not float — no rounding loss."""
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.172})
+        result = fx.to_cad(Fraction(1), 'HKD')
+        assert isinstance(result, Fraction)
+
+
+# ---------------------------------------------------------------------------
+# get_rate
+# ---------------------------------------------------------------------------
+
+class TestGetRate:
+
+    def test_returns_float(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.172})
+        rate = fx.get_rate('HKD')
+        assert isinstance(rate, float)
+        assert abs(rate - 0.172) < 1e-6
+
+    def test_cad_rate_is_one(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({})
+        assert fx.get_rate('CAD') == 1.0
+
+    def test_missing_currency_raises(self):
+        from services.fx_rates import FxRates, MissingFxRateError
+        fx = FxRates({})
+        with pytest.raises(MissingFxRateError):
+            fx.get_rate('USD')
+
+
+# ---------------------------------------------------------------------------
+# has_rate
+# ---------------------------------------------------------------------------
+
+class TestHasRate:
+
+    def test_true_for_known_currency(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.172})
+        assert fx.has_rate('HKD') is True
+
+    def test_false_for_unknown_currency(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.172})
+        assert fx.has_rate('USD') is False
+
+    def test_cad_always_true(self):
+        from services.fx_rates import FxRates
+        assert FxRates({}).has_rate('CAD') is True
+
+    def test_case_insensitive(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.172})
+        assert fx.has_rate('hkd') is True
+        assert fx.has_rate('HKD') is True
+
+
+# ---------------------------------------------------------------------------
+# missing_currencies
+# ---------------------------------------------------------------------------
+
+class TestMissingCurrencies:
+
+    def test_all_present_returns_empty_set(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.172, 'USD': 1.36})
+        assert fx.missing_currencies({'HKD', 'CAD', 'USD'}) == set()
+
+    def test_missing_currency_returned(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.172})
+        missing = fx.missing_currencies({'HKD', 'USD', 'JPY'})
+        assert missing == {'USD', 'JPY'}
+
+    def test_empty_input_returns_empty_set(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.172})
+        assert fx.missing_currencies(set()) == set()
+
+    def test_cad_never_missing(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({})
+        assert fx.missing_currencies({'CAD'}) == set()
+
+
+# ---------------------------------------------------------------------------
+# available_currencies
+# ---------------------------------------------------------------------------
+
+class TestAvailableCurrencies:
+
+    def test_cad_always_in_available(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({})
+        assert 'CAD' in fx.available_currencies
+
+    def test_added_currencies_in_available(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.172, 'USD': 1.36})
+        assert 'HKD' in fx.available_currencies
+        assert 'USD' in fx.available_currencies
+
+    def test_returns_set(self):
+        from services.fx_rates import FxRates
+        fx = FxRates({'HKD': 0.172})
+        assert isinstance(fx.available_currencies, set)

--- a/tests/unit/services/test_ledger_validator.py
+++ b/tests/unit/services/test_ledger_validator.py
@@ -590,6 +590,53 @@ class TestValidateTransactionEdgeCases:
             session.end()
 
 
+    def test_is_transaction_balanced_false_for_partial_splits(self, temp_gnucash_with_transactions):
+        """_is_transaction_balanced() returns False when only a subset of splits is passed.
+
+        GnuCash auto-adds an 'Imbalance' split when a transaction is committed with a
+        non-zero net, so we cannot create a persisted unbalanced transaction through the
+        normal API.  Instead, we take a real balanced transaction and test the internal
+        method with only the first split — a known non-zero value — which must be unbalanced.
+
+        This is the regression test for the numerator-only implementation:
+            total_num += value.num()   (no denominator division)
+        GnuCash normalizes all splits in one transaction to the same denominator, so
+        summing numerators is mathematically equivalent.  The test confirms that the
+        check correctly detects an imbalanced subset and would flag a real imbalanced
+        transaction if one were loadable.
+        """
+        from gnucash import Query, Session, Transaction
+
+        from services.ledger_validator import LedgerValidator
+
+        try:
+            from gnucash import SessionOpenMode
+            session = Session(f'xml://{temp_gnucash_with_transactions}',
+                              SessionOpenMode.SESSION_NORMAL_OPEN)
+        except ImportError:
+            session = Session(f'xml://{temp_gnucash_with_transactions}')
+
+        try:
+            book = session.book
+            q = Query()
+            q.search_for('Trans')
+            q.set_book(book)
+            tx = Transaction(instance=q.run()[0])
+
+            splits = tx.GetSplitList()
+            assert len(splits) >= 2, "Fixture must have a multi-split transaction"
+
+            validator = LedgerValidator()
+            # Full split list → balanced
+            assert validator._is_transaction_balanced(splits) is True
+            # First split alone → non-zero value → unbalanced
+            assert validator._is_transaction_balanced(splits[:1]) is False, (
+                "_is_transaction_balanced should return False for a single-split subset"
+            )
+        finally:
+            session.end()
+
+
 class TestCheckTransactionDateOrderEdgeCases:
 
     def test_single_transaction_no_error(self, temp_gnucash_with_transactions):


### PR DESCRIPTION
Three untested code paths now covered. Two bugs discovered and documented with xfail markers so they are caught when the code is later fixed.

services/beancount_converter.py — new test_beancount_converter.py
- convert_account_name: all valid account types (Bank→Assets, Cash→Assets, Stock→Assets, Mutual Fund→Assets, Expense→Expenses, Income→Income, Equity→Equity, Credit Card→Liabilities), already-prefixed names, special-char and space replacement, capitalization, single-component

- Two bugs found and marked xfail(strict=True):
  1. 'Liability' account type falls through determine_prefix() because "Liabilities".startswith("Liability") is False (char 8: 'i' vs 'y'). Currently produces "None:Loan" instead of "Liabilities:Loan".
  2. 'A/Payable' account-name override is unreachable: the special-char translation (/ → -) runs before determine_prefix() is called, so the check `account_name == 'A/Payable'` always sees 'A-Payable'. Currently produces "Assets:A-Payable" instead of "Liabilities:...".

- convert_commodity_symbol: None passthrough, uppercase, space→_, dot/ dash/underscore preserved, other punctuation stripped, docstring examples
- convert_metadata_key: None passthrough, dot→dash, _ prefix → gnucash prepend, combined dot+underscore case (documents intentional dot-first then underscore-prefix ordering)

services/fx_rates.py — new test_fx_rates.py
- FxRates.__init__: CAD always rate 1.0, foreign currencies stored, key normalization to uppercase, multiple currencies
- cad_only(): only CAD available, missing_currencies reflects this
- load(): valid file, FileNotFoundError, non-dict YAML, non-numeric value, zero rate, negative rate, CAD override accepted
- to_cad(): CAD identity, foreign conversion, case-insensitive, Fraction return, MissingFxRateError with currency code in message, zero amount
- get_rate(): float return, CAD=1.0, MissingFxRateError
- has_rate(): true/false/case-insensitive, CAD always true
- missing_currencies(): correct subset, empty input, CAD never missing
- available_currencies: CAD included, returns set

services/ledger_validator.py — direct unit test of _is_transaction_balanced
- Takes a real balanced transaction from the fixture, asserts full split list → balanced=True, first split alone → balanced=False. Documents why GnuCash auto-balance prevents testing via validate_transaction and why numerator-only summing is correct for same-denominator splits.