### PR TITLE
test: add beancount roundtrip data-fidelity tests

### DIFF
--- a/tests/integration/test_beancount_roundtrip.py
+++ b/tests/integration/test_beancount_roundtrip.py
@@ -171,3 +171,427 @@ class TestBeancountRoundtrip:
         parser = BeancountParser()
         with pytest.raises(BeancountValidationError, match="missing required"):
             parser.parse_file(beancount_file)
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by data-fidelity tests below
+# ---------------------------------------------------------------------------
+
+def _do_roundtrip(source_path: str) -> tuple:
+    """
+    Export *source_path* to beancount then import into a fresh GnuCash file.
+
+    Returns (repo2, new_path) — caller must repo2.close() and os.unlink(new_path).
+    """
+    import os
+
+    repo1 = GnuCashRepository(source_path)
+    repo1.open()
+    try:
+        beancount_content = ExportBeancountUseCase(repo1).execute()
+    finally:
+        repo1.close()
+
+    fd, beancount_path = tempfile.mkstemp(suffix='.beancount')
+    with os.fdopen(fd, 'w') as f:
+        f.write(beancount_content)
+
+    fd2, new_path = tempfile.mkstemp(suffix='.gnucash')
+    os.close(fd2)
+    os.unlink(new_path)
+
+    repo2 = None
+    try:
+        GnuCashRepository.create_new_file(new_path)
+        repo2 = GnuCashRepository(new_path)
+        repo2.open()
+        result = ImportBeancountUseCase(repo2).import_from_file(beancount_path)
+        assert not result.has_errors(), f"Import had errors: {result.errors}"
+        repo2.save()
+    except Exception:
+        # Clean up on failure so caller never receives an open repo or stale file
+        import contextlib
+        if repo2 is not None:
+            with contextlib.suppress(Exception):
+                repo2.close()
+        with contextlib.suppress(OSError):
+            os.unlink(new_path)
+        raise
+    finally:
+        os.unlink(beancount_path)
+
+    return repo2, new_path
+
+
+def _make_roundtrip_book():
+    """
+    Build a minimal GnuCash file with a rich variety of accounts and one
+    transaction that exercises every field the roundtrip must preserve:
+
+    Accounts (all referenced by at least one transaction so they get exported):
+        Assets:Bank:Checking   BANK    CAD
+        Expenses:Groceries     EXPENSE CAD
+        Income:Salary          INCOME  CAD
+        PersonalLoan           LIABILITY CAD  ← ROOT-LEVEL, no 'Liabilities:' prefix
+                                               → exercises the 'Liability' bug fix
+
+    The PersonalLoan account is created at the root to ensure
+    need_append_top_level_prefix=True so determine_prefix() is actually called.
+    Accounts already under 'Liabilities:...' skip that code path entirely.
+
+    Transactions:
+      2024-03-15  "Work expense reimbursement"  num="42"  notes="Expense report #99"
+          Expenses:Groceries   +75.00  (memo="team lunch", action="expense")
+          Assets:Bank:Checking -75.00
+
+      2024-03-01  "March salary"
+          Assets:Bank:Checking +3000.00
+          Income:Salary        -3000.00
+
+      2024-03-05  "Loan repayment"
+          PersonalLoan         +200.00
+          Assets:Bank:Checking -200.00
+
+    Returns path.  Caller must unlink(path).
+    """
+    import os
+
+    import gnucash
+    from gnucash import Account, GncNumeric, Session, Split, Transaction
+
+    fd, path = tempfile.mkstemp(suffix='.gnucash')
+    os.close(fd)
+    os.unlink(path)
+
+    try:
+        from gnucash import SessionOpenMode
+        session = Session(f'xml://{path}', SessionOpenMode.SESSION_NEW_STORE)
+    except ImportError:
+        session = Session(f'xml://{path}', is_new=True)
+
+    book = session.book
+    root = book.get_root_account()
+    cad = book.get_table().lookup('CURRENCY', 'CAD')
+
+    def _acct(name, atype, parent):
+        a = Account(book)
+        a.SetName(name)
+        a.SetType(atype)
+        a.SetCommodity(cad)
+        parent.append_child(a)
+        return a
+
+    assets = _acct('Assets', gnucash.ACCT_TYPE_ASSET, root)
+    bank = _acct('Bank', gnucash.ACCT_TYPE_BANK, assets)
+    checking = _acct('Checking', gnucash.ACCT_TYPE_BANK, bank)
+
+    expenses = _acct('Expenses', gnucash.ACCT_TYPE_EXPENSE, root)
+    groceries = _acct('Groceries', gnucash.ACCT_TYPE_EXPENSE, expenses)
+
+    income = _acct('Income', gnucash.ACCT_TYPE_INCOME, root)
+    salary = _acct('Salary', gnucash.ACCT_TYPE_INCOME, income)
+
+    # Root-level LIABILITY account (full name = "PersonalLoan", no "Liabilities:" prefix).
+    # This is the account type that triggered the None-prefix bug before the fix.
+    personal_loan = _acct('PersonalLoan', gnucash.ACCT_TYPE_LIABILITY, root)
+
+    def _tx(date_d, date_m, date_y, desc, num=None, notes=None, splits=None):
+        t = Transaction(book)
+        t.BeginEdit()
+        t.SetCurrency(cad)
+        t.SetDate(date_d, date_m, date_y)
+        t.SetDescription(desc)
+        if num:
+            t.SetNum(num)
+        if notes:
+            t.SetNotes(notes)
+        for acct, num_val, memo, action in (splits or []):
+            s = Split(book)
+            s.SetParent(t)
+            s.SetAccount(acct)
+            s.SetValue(GncNumeric(num_val, 100))
+            s.SetAmount(GncNumeric(num_val, 100))
+            if memo:
+                s.SetMemo(memo)
+            if action:
+                s.SetAction(action)
+        t.CommitEdit()
+
+    _tx(15, 3, 2024, "Work expense reimbursement", num="42",
+        notes="Expense report #99",
+        splits=[
+            (groceries,  7500, "team lunch", "expense"),
+            (checking,  -7500, None, None),
+        ])
+
+    _tx(1, 3, 2024, "March salary", splits=[
+        (checking,   300000, None, None),
+        (salary,    -300000, None, None),
+    ])
+
+    _tx(5, 3, 2024, "Loan repayment", splits=[
+        (personal_loan,  20000, None, None),
+        (checking,      -20000, None, None),
+    ])
+
+    session.save()
+    session.end()
+
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Data-fidelity roundtrip tests
+# ---------------------------------------------------------------------------
+
+class TestBeancountRoundtripFidelity:
+    """
+    Verify that specific field VALUES (not just counts) survive the
+    GnuCash → Beancount → GnuCash cycle.
+    """
+
+    def test_transaction_amounts_preserved(self):
+        """Split amounts survive export→import with exact numeric fidelity."""
+        import os
+
+        from infrastructure.gnucash.utils import find_account, get_account_full_name
+
+        path = _make_roundtrip_book()
+        try:
+            repo2, new_path = _do_roundtrip(path)
+            try:
+                root = repo2.get_root_account()
+                groceries = find_account(root, 'Expenses:Groceries')
+                assert groceries is not None
+
+                txs = repo2.get_all_transactions()
+                # Find the split for Groceries
+                grocery_splits = [
+                    s for tx in txs
+                    for s in tx.GetSplitList()
+                    if get_account_full_name(s.GetAccount()) == 'Expenses:Groceries'
+                ]
+                assert len(grocery_splits) == 1
+                val = grocery_splits[0].GetValue()
+                # 75.00 CAD stored as 7500/100
+                assert val.num() == 7500
+                assert val.denom() == 100
+            finally:
+                repo2.close()
+                os.unlink(new_path)
+        finally:
+            os.unlink(path)
+
+    def test_transaction_description_and_num_preserved(self):
+        """Transaction description (narration) and num (payee) survive the round-trip."""
+        import os
+
+        path = _make_roundtrip_book()
+        try:
+            repo2, new_path = _do_roundtrip(path)
+            try:
+                txs = repo2.get_all_transactions()
+                expense_tx = next(
+                    t for t in txs
+                    if t.GetDescription() == "Work expense reimbursement"
+                )
+                assert expense_tx.GetNum() == "42"
+            finally:
+                repo2.close()
+                os.unlink(new_path)
+        finally:
+            os.unlink(path)
+
+    def test_transaction_notes_preserved(self):
+        """Transaction notes survive the round-trip."""
+        import os
+
+        path = _make_roundtrip_book()
+        try:
+            repo2, new_path = _do_roundtrip(path)
+            try:
+                txs = repo2.get_all_transactions()
+                expense_tx = next(
+                    t for t in txs
+                    if t.GetDescription() == "Work expense reimbursement"
+                )
+                assert expense_tx.GetNotes() == "Expense report #99"
+            finally:
+                repo2.close()
+                os.unlink(new_path)
+        finally:
+            os.unlink(path)
+
+    def test_transaction_date_preserved(self):
+        """Transaction date survives the round-trip."""
+        import os
+
+        path = _make_roundtrip_book()
+        try:
+            repo2, new_path = _do_roundtrip(path)
+            try:
+                txs = repo2.get_all_transactions()
+                expense_tx = next(
+                    t for t in txs
+                    if t.GetDescription() == "Work expense reimbursement"
+                )
+                d = expense_tx.GetDate()
+                # GetDate() returns datetime on newer GnuCash bindings;
+                # older bindings (GnuCash 3.8-4.4) return time.struct_time.
+                year  = d.year  if hasattr(d, 'year')  else d.tm_year
+                month = d.month if hasattr(d, 'month') else d.tm_mon
+                day   = d.day   if hasattr(d, 'day')   else d.tm_mday
+                assert year == 2024
+                assert month == 3
+                assert day == 15
+            finally:
+                repo2.close()
+                os.unlink(new_path)
+        finally:
+            os.unlink(path)
+
+    def test_split_memo_and_action_preserved(self):
+        """Split-level memo and action survive the round-trip."""
+        import os
+
+        from infrastructure.gnucash.utils import get_account_full_name
+
+        path = _make_roundtrip_book()
+        try:
+            repo2, new_path = _do_roundtrip(path)
+            try:
+                txs = repo2.get_all_transactions()
+                grocery_split = next(
+                    s for tx in txs
+                    for s in tx.GetSplitList()
+                    if get_account_full_name(s.GetAccount()) == 'Expenses:Groceries'
+                )
+                assert grocery_split.GetMemo() == "team lunch"
+                assert grocery_split.GetAction() == "expense"
+            finally:
+                repo2.close()
+                os.unlink(new_path)
+        finally:
+            os.unlink(path)
+
+    def test_account_types_preserved(self):
+        """Account types (BANK, EXPENSE, INCOME) survive the round-trip."""
+        import os
+
+        import gnucash
+
+        from infrastructure.gnucash.utils import find_account
+
+        path = _make_roundtrip_book()
+        try:
+            repo2, new_path = _do_roundtrip(path)
+            try:
+                root = repo2.get_root_account()
+                checking = find_account(root, 'Assets:Bank:Checking')
+                groceries = find_account(root, 'Expenses:Groceries')
+                salary = find_account(root, 'Income:Salary')
+
+                assert checking is not None
+                assert groceries is not None
+                assert salary is not None
+                assert checking.GetType() == gnucash.ACCT_TYPE_BANK
+                assert groceries.GetType() == gnucash.ACCT_TYPE_EXPENSE
+                assert salary.GetType() == gnucash.ACCT_TYPE_INCOME
+            finally:
+                repo2.close()
+                os.unlink(new_path)
+        finally:
+            os.unlink(path)
+
+    def test_liability_account_type_preserved(self):
+        """
+        Liability-type account survives export→import with correct type.
+
+        This is the regression test for the beancount_converter bug where
+        'Liability' account type fell through determine_prefix() and produced
+        a 'None:...' beancount name, causing silent data corruption on export.
+
+        After the fix, 'Liability' type correctly maps to the 'Liabilities:'
+        beancount prefix.
+        """
+        import os
+
+        import gnucash
+
+        from infrastructure.gnucash.utils import find_account
+
+        path = _make_roundtrip_book()
+        try:
+            # Verify the beancount output uses correct prefix (not None:)
+            repo1 = GnuCashRepository(path)
+            repo1.open()
+            try:
+                beancount_content = ExportBeancountUseCase(repo1).execute()
+            finally:
+                repo1.close()
+
+            # The root-level 'PersonalLoan' account (type LIABILITY) has no 'Liabilities:'
+            # prefix, so determine_prefix() must be called.  Before the fix it returned
+            # None → "None:PersonalLoan". After the fix it returns "Liabilities".
+            assert 'Liabilities:PersonalLoan' in beancount_content, (
+                "Root-level Liability account should export with 'Liabilities:' prefix"
+            )
+            assert 'None:' not in beancount_content, (
+                "No beancount output should contain 'None:' — that indicates a broken "
+                "account-type prefix mapping in beancount_converter"
+            )
+
+            # Verify the account reimports at its original GnuCash path with correct type.
+            # On export: "PersonalLoan" → "Liabilities:PersonalLoan" beancount name,
+            # but gnucash-name metadata stores "PersonalLoan" (the original root-level path).
+            # On import: gnucash-name "PersonalLoan" is used for account creation,
+            # so the account is restored at root level as "PersonalLoan", not nested
+            # under a "Liabilities" parent.
+            repo2, new_path = _do_roundtrip(path)
+            try:
+                root = repo2.get_root_account()
+                loan = find_account(root, 'PersonalLoan')
+                assert loan is not None, \
+                    "'PersonalLoan' should be recreated at root level after roundtrip"
+                assert loan.GetType() == gnucash.ACCT_TYPE_LIABILITY
+            finally:
+                repo2.close()
+                os.unlink(new_path)
+        finally:
+            os.unlink(path)
+
+    def test_commodity_fraction_preserved(self):
+        """Commodity fraction (decimal places) survives the round-trip."""
+        import os
+
+        path = _make_roundtrip_book()
+        try:
+            repo2, new_path = _do_roundtrip(path)
+            try:
+                cad = repo2.get_commodity('CURRENCY', 'CAD')
+                assert cad is not None
+                assert cad.get_fraction() == 100
+            finally:
+                repo2.close()
+                os.unlink(new_path)
+        finally:
+            os.unlink(path)
+
+    def test_no_none_prefix_in_beancount_output(self, temp_gnucash_with_transactions):
+        """
+        Exporting the standard fixture must never produce 'None:' account names.
+
+        Regression for: beancount_converter.determine_prefix() returning None
+        for unrecognised account types, silently producing 'None:<name>'.
+        """
+        repo = GnuCashRepository(temp_gnucash_with_transactions)
+        repo.open()
+        try:
+            beancount_content = ExportBeancountUseCase(repo).execute()
+        finally:
+            repo.close()
+
+        assert 'None:' not in beancount_content, (
+            "Beancount output contains 'None:' — a beancount_converter bug "
+            "is producing invalid account names"
+        )


### PR DESCRIPTION
Adds TestBeancountRoundtripFidelity class to test_beancount_roundtrip.py with 9 integration tests that verify the full GnuCash → Beancount → GnuCash cycle preserves all data correctly.

Tests added:
- test_transaction_amounts_preserved: split numeric values (num/denom) survive the roundtrip with exact Fraction fidelity
- test_transaction_description_and_num_preserved: narration and payee (mapped from GnuCash num field) survive the roundtrip
- test_transaction_date_preserved: date (year/month/day) survives; handles both datetime (new GnuCash) and time.struct_time (GnuCash 3.8-4.4)
- test_split_memo_and_action_preserved: split-level memo and action fields survive the roundtrip
- test_transaction_notes_preserved: transaction notes metadata survives
- test_account_type_preserved: account type (BANK, EXPENSE, INCOME) is correctly reconstructed from gnucash-type metadata
- test_liability_account_type_preserved: regression test for the beancount_converter bug where 'Liability' account type fell through determine_prefix() and produced 'None:AccountName'. A root-level LIABILITY account ("PersonalLoan") is used to exercise that code path. After roundtrip the account is correctly restored at root level under its original GnuCash name (gnucash-name metadata preserves the original hierarchy, not the beancount hierarchy).
- test_commodity_fraction_preserved: commodity SCU (100 for CAD) survives
- test_no_none_prefix_in_beancount_output: exporting the standard fixture must never produce 'None:' prefixed account names

Helpers added:
- _do_roundtrip(source_path): exports to beancount then imports to a new GnuCash file; includes proper cleanup on failure via contextlib.suppress
- _make_roundtrip_book(): builds a minimal GnuCash file with 4 account types and 3 transactions covering every field under test

Bug fixes included in test helpers:
- _do_roundtrip: resource leak on import failure; repo2 and new_path are now cleaned up via contextlib.suppress before re-raising
- test_transaction_date_preserved: GetDate() returns time.struct_time on GnuCash 3.8-4.4 (Debian 11 / Ubuntu 20.04); use hasattr to select correct attribute names across versions