### PR TITLE
feat: add export-accounts command for transaction-free account export

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,24 @@ gnucash-plaintext export mybook.gnucash transactions.txt \
   --account "Assets:Bank"
 ```
 
+### Export account structure only
+
+Export all accounts and commodities without loading any transactions.
+Useful when you need the chart of accounts for reference or bootstrapping
+another tool, and don't want to wait for a full transaction scan:
+
+```bash
+gnucash-plaintext export-accounts mybook.gnucash accounts.txt
+```
+
+By default the open date on each account/commodity declaration is taken from
+the GnuCash file's modification time. Supply `--as-of` to use a specific date
+instead:
+
+```bash
+gnucash-plaintext export-accounts mybook.gnucash accounts.txt --as-of 2024-01-01
+```
+
 ### Export transactions by GUID
 
 Export one or more transactions to plaintext (useful for AI-assisted editing or review):

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,28 @@
 # Release Notes
 
+## v0.3.2 - export-accounts command (2026-04-08)
+
+### What's new
+
+#### Export account structure without loading transactions
+
+A new `export-accounts` command exports all accounts and commodities directly
+from the book without scanning the transaction log. This is significantly
+faster on large files when only the chart of accounts is needed.
+
+```bash
+gnucash-plaintext export-accounts mybook.gnucash accounts.txt
+```
+
+Use `--as-of` to stamp a specific date on every `open`/`commodity`
+declaration (defaults to the file modification date):
+
+```bash
+gnucash-plaintext export-accounts mybook.gnucash accounts.txt --as-of 2024-01-01
+```
+
+---
+
 ## v0.3.1 - Bill payment bug fixes and test coverage (2026-04-02)
 
 ### Bug fixes

--- a/cli/export_accounts_cmd.py
+++ b/cli/export_accounts_cmd.py
@@ -1,0 +1,60 @@
+"""
+CLI command for exporting GnuCash account structure to plaintext.
+
+Unlike the 'export' command, this never loads transactions — it reads accounts
+directly from the book and is therefore much faster on large files.
+"""
+
+import os
+
+import click
+
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from use_cases.export_transactions import ExportTransactionsUseCase
+
+
+@click.command()
+@click.argument('gnucash_file', type=click.Path())
+@click.argument('output_file', type=click.Path())
+@click.option(
+    '--as-of',
+    'as_of_date',
+    default=None,
+    metavar='YYYY-MM-DD',
+    help='Date to stamp each open/commodity declaration. Defaults to the file modification date.',
+)
+def export_accounts(gnucash_file, output_file, as_of_date):
+    """
+    Export account structure from a GnuCash file to plaintext.
+
+    Writes commodity and account declarations only — no transactions are loaded
+    or written.  Use this when you need the account chart without the full
+    transaction history.
+
+    \b
+    Examples:
+        gnucash-plaintext export-accounts mybook.gnucash accounts.txt
+        gnucash-plaintext export-accounts mybook.gnucash accounts.txt --as-of 2024-01-01
+    """
+    if not os.path.exists(gnucash_file):
+        raise click.UsageError(f"Input file does not exist: {gnucash_file}")
+
+    try:
+        repo = GnuCashRepository(gnucash_file)
+        repo.open(mode=SessionMode.READ_ONLY)
+        try:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute_accounts_only()
+            output = use_case.format_accounts_only(result, as_of_date=as_of_date)
+
+            with open(output_file, 'w') as f:
+                f.write(output)
+
+            n_accounts = len(result.accounts)
+            n_commodities = len(result.commodities)
+            click.echo(f"Exported {n_accounts} account(s) and {n_commodities} commodity/ies to {output_file}")
+        finally:
+            repo.close()
+    except Exception as e:
+        click.echo(f"Error: {str(e)}", err=True)
+        raise click.Abort() from e

--- a/cli/main.py
+++ b/cli/main.py
@@ -10,6 +10,7 @@ import click
 from cli.account_balance_cmd import account_balance
 from cli.close_books_cmd import close_books
 from cli.delete_transaction_cmd import delete_transaction_by_guid
+from cli.export_accounts_cmd import export_accounts
 from cli.export_beancount_cmd import export_beancount
 from cli.export_cmd import export_transactions
 from cli.export_transaction_cmd import export_transaction
@@ -54,6 +55,7 @@ def run(script, args):
 
 # Register commands
 cli.add_command(export_transactions, name='export')
+cli.add_command(export_accounts, name='export-accounts')
 cli.add_command(import_transactions, name='import')
 cli.add_command(validate_ledger, name='validate')
 cli.add_command(export_beancount, name='export-beancount')

--- a/tests/integration/test_cli_export_accounts.py
+++ b/tests/integration/test_cli_export_accounts.py
@@ -1,0 +1,149 @@
+"""
+Integration tests for the export-accounts CLI command.
+
+Verifies end-to-end behaviour of:
+    gnucash-plaintext export-accounts <file> <output> [--as-of DATE]
+"""
+
+import os
+import tempfile
+
+from click.testing import CliRunner
+
+from cli.export_accounts_cmd import export_accounts
+
+
+class TestExportAccountsCLI:
+    """Integration tests for the export-accounts command."""
+
+    def test_basic_export(self, temp_gnucash_file):
+        """Command exits 0 and writes account declarations to the output file."""
+        runner = CliRunner()
+        with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as f:
+            output_path = f.name
+
+        try:
+            result = runner.invoke(export_accounts, [temp_gnucash_file, output_path])
+
+            assert result.exit_code == 0, result.output
+            assert os.path.exists(output_path)
+
+            with open(output_path) as f:
+                content = f.read()
+
+            assert "open Assets:Bank:Checking" in content
+            assert "open Expenses:Groceries" in content
+            assert "open Expenses:Dining" in content
+            assert "commodity" in content
+
+        finally:
+            if os.path.exists(output_path):
+                os.unlink(output_path)
+
+    def test_no_transaction_lines_in_output(self, temp_gnucash_with_transactions):
+        """Output never contains transaction header lines even when the book has transactions."""
+        runner = CliRunner()
+        with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as f:
+            output_path = f.name
+
+        try:
+            result = runner.invoke(
+                export_accounts, [temp_gnucash_with_transactions, output_path]
+            )
+
+            assert result.exit_code == 0, result.output
+
+            with open(output_path) as f:
+                content = f.read()
+
+            assert " * " not in content
+
+        finally:
+            if os.path.exists(output_path):
+                os.unlink(output_path)
+
+    def test_as_of_date_applied(self, temp_gnucash_file):
+        """--as-of DATE stamps every open and commodity line with the given date."""
+        runner = CliRunner()
+        as_of = "2019-03-01"
+        with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as f:
+            output_path = f.name
+
+        try:
+            result = runner.invoke(
+                export_accounts, [temp_gnucash_file, output_path, '--as-of', as_of]
+            )
+
+            assert result.exit_code == 0, result.output
+
+            with open(output_path) as f:
+                content = f.read()
+
+            open_lines = [line for line in content.splitlines() if " open " in line]
+            commodity_lines = [line for line in content.splitlines() if " commodity " in line]
+
+            assert len(open_lines) > 0
+            assert len(commodity_lines) > 0
+
+            for line in open_lines + commodity_lines:
+                assert line.startswith(as_of), f"Expected {as_of} prefix, got: {line}"
+
+        finally:
+            if os.path.exists(output_path):
+                os.unlink(output_path)
+
+    def test_all_accounts_exported_but_no_transactions(self, temp_gnucash_with_transactions):
+        """All accounts are present in output but transaction lines are absent."""
+        runner = CliRunner()
+        with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as f:
+            output_path = f.name
+
+        try:
+            result = runner.invoke(
+                export_accounts, [temp_gnucash_with_transactions, output_path]
+            )
+
+            assert result.exit_code == 0, result.output
+
+            with open(output_path) as f:
+                content = f.read()
+
+            # All accounts must be present
+            assert "open Assets:Bank:Checking" in content
+            assert "open Expenses:Groceries" in content
+            assert "open Expenses:Dining" in content
+
+            # Transaction content must not appear
+            assert " * " not in content
+            assert "Grocery shopping" not in content
+            assert "Restaurant" not in content
+
+        finally:
+            if os.path.exists(output_path):
+                os.unlink(output_path)
+
+    def test_success_message_shows_counts(self, temp_gnucash_file):
+        """Success output reports account and commodity counts."""
+        runner = CliRunner()
+        with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as f:
+            output_path = f.name
+
+        try:
+            result = runner.invoke(export_accounts, [temp_gnucash_file, output_path])
+
+            assert result.exit_code == 0, result.output
+            assert "account" in result.output
+            assert "commodity" in result.output
+
+        finally:
+            if os.path.exists(output_path):
+                os.unlink(output_path)
+
+    def test_nonexistent_input_file_errors(self):
+        """Command fails with a clear error when the input file does not exist."""
+        runner = CliRunner()
+        result = runner.invoke(
+            export_accounts, ['/nonexistent/file.gnucash', '/tmp/out.txt']
+        )
+
+        assert result.exit_code != 0

--- a/tests/unit/use_cases/test_export_accounts.py
+++ b/tests/unit/use_cases/test_export_accounts.py
@@ -1,0 +1,191 @@
+"""
+Tests for execute_accounts_only / format_accounts_only in ExportTransactionsUseCase.
+
+These tests confirm that:
+- execute_accounts_only never loads transactions
+- All accounts and commodities are present in the result
+- as_of_date is stamped correctly on every open/commodity line
+- file mtime is used when as_of_date is omitted
+"""
+
+import pytest
+
+
+class TestExecuteAccountsOnly:
+    """execute_accounts_only returns accounts without touching transactions."""
+
+    def test_returns_all_accounts(self, temp_gnucash_file):
+        """All accounts in the book appear in the result."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_file) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute_accounts_only()
+
+        account_names = [
+            acct.GetName() for acct, _ in result.accounts
+        ]
+        assert "Checking" in account_names
+        assert "Groceries" in account_names
+        assert "Dining" in account_names
+
+    def test_result_has_no_transactions(self, temp_gnucash_file):
+        """Result contains zero transactions — transaction log is never loaded."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_file) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute_accounts_only()
+
+        assert result.transactions == []
+
+    def test_result_has_no_transactions_even_when_file_has_transactions(
+        self, temp_gnucash_with_transactions
+    ):
+        """execute_accounts_only ignores transactions even when the book has some."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute_accounts_only()
+
+        assert result.transactions == []
+
+    def test_commodities_not_duplicated(self, temp_gnucash_file):
+        """Each commodity appears exactly once in the result."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_file) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute_accounts_only()
+
+        tickers = [c.get_mnemonic() for c, _ in result.commodities]
+        assert len(tickers) == len(set(tickers))
+
+    def test_accounts_not_duplicated(self, temp_gnucash_file):
+        """Each account GUID appears exactly once in the result."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_file) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute_accounts_only()
+
+        guids = [acct.GetGUID().to_string() for acct, _ in result.accounts]
+        assert len(guids) == len(set(guids))
+
+    def test_accounts_without_transactions_are_included(self, temp_gnucash_file):
+        """Accounts that have no transactions still appear (unlike transaction-driven export)."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_file) as repo:
+            # Baseline: transaction-driven export finds nothing (no transactions)
+            use_case = ExportTransactionsUseCase(repo)
+            tx_driven = use_case.execute()
+            assert tx_driven.accounts == [], "fixture should have no transactions"
+
+            # execute_accounts_only must still find all accounts
+            result = use_case.execute_accounts_only()
+
+        assert len(result.accounts) > 0
+
+
+class TestFormatAccountsOnly:
+    """format_accounts_only stamps dates correctly and omits transactions."""
+
+    def test_no_transaction_lines_in_output(self, temp_gnucash_file):
+        """Output contains no transaction header lines (lines with ' * ')."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_file) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute_accounts_only()
+            output = use_case.format_accounts_only(result)
+
+        assert " * " not in output
+
+    def test_output_contains_open_declarations(self, temp_gnucash_file):
+        """Output contains account open declarations for all accounts."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_file) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute_accounts_only()
+            output = use_case.format_accounts_only(result)
+
+        assert "open Assets:Bank:Checking" in output
+        assert "open Expenses:Groceries" in output
+        assert "open Expenses:Dining" in output
+
+    def test_output_contains_commodity_declarations(self, temp_gnucash_file):
+        """Output contains commodity declarations."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_file) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute_accounts_only()
+            output = use_case.format_accounts_only(result)
+
+        assert "commodity" in output
+        assert "CAD" in output
+
+    def test_as_of_date_stamped_on_open_lines(self, temp_gnucash_file):
+        """When as_of_date is provided, every open line starts with that date."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        as_of = "2020-06-15"
+        with GnuCashRepository(temp_gnucash_file) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute_accounts_only()
+            output = use_case.format_accounts_only(result, as_of_date=as_of)
+
+        open_lines = [line for line in output.splitlines() if " open " in line]
+        assert len(open_lines) > 0
+        for line in open_lines:
+            assert line.startswith(as_of), f"Expected {as_of} prefix, got: {line}"
+
+    def test_as_of_date_stamped_on_commodity_lines(self, temp_gnucash_file):
+        """When as_of_date is provided, every commodity line starts with that date."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        as_of = "2020-06-15"
+        with GnuCashRepository(temp_gnucash_file) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute_accounts_only()
+            output = use_case.format_accounts_only(result, as_of_date=as_of)
+
+        commodity_lines = [line for line in output.splitlines() if " commodity " in line]
+        assert len(commodity_lines) > 0
+        for line in commodity_lines:
+            assert line.startswith(as_of), f"Expected {as_of} prefix, got: {line}"
+
+    def test_file_mtime_used_when_no_as_of_date(self, temp_gnucash_file):
+        """When as_of_date is omitted, the date on open lines matches file mtime."""
+        import datetime
+        import os
+
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_file) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute_accounts_only()
+            output = use_case.format_accounts_only(result)
+
+        mtime = os.path.getmtime(temp_gnucash_file)
+        expected_date = datetime.date.fromtimestamp(mtime).strftime("%Y-%m-%d")
+
+        open_lines = [line for line in output.splitlines() if " open " in line]
+        assert len(open_lines) > 0
+        for line in open_lines:
+            assert line.startswith(expected_date), f"Expected {expected_date} prefix, got: {line}"

--- a/use_cases/export_transactions.py
+++ b/use_cases/export_transactions.py
@@ -193,6 +193,44 @@ class ExportTransactionsUseCase:
         # Join lines and add trailing newline to match legacy format
         return '\n'.join(lines) + '\n' if lines else ''
 
+    def execute_accounts_only(self) -> ExportResult:
+        """
+        Export all accounts and their commodities without loading any transactions.
+
+        Much faster than execute() for account-structure-only exports since it
+        never touches the transaction log.
+
+        The open date for each declaration is determined at format time by
+        format_accounts_only(as_of_date=...).  This method only populates the
+        account and commodity lists — it carries no date information.
+
+        Returns:
+            ExportResult with all accounts and commodities; no transactions.
+        """
+        result = ExportResult()
+        for account in self.repository.get_all_accounts():
+            commodity = account.GetCommodity()
+            if commodity is None:
+                continue
+            ticker = get_commodity_ticker(commodity)
+            if ticker not in result.commodity_seen:
+                result.commodity_seen.add(ticker)
+                result.commodities.append((commodity, None))
+            account_guid = account.GetGUID().to_string()
+            if account_guid not in result.account_seen:
+                result.account_seen.add(account_guid)
+                result.accounts.append((account, None))
+        return result
+
+    def format_accounts_only(self, result: ExportResult, as_of_date: Optional[str] = None) -> str:
+        """Format commodities and accounts using as_of_date (or file mtime) for open dates."""
+        lines = []
+        for commodity, transaction in result.commodities:
+            self._format_commodity(commodity, transaction, lines, date_override=as_of_date)
+        for account, transaction in result.accounts:
+            self._format_account(account, transaction, lines, date_override=as_of_date)
+        return '\n'.join(lines) + '\n' if lines else ''
+
     def format_accounts_section(self, result: ExportResult) -> str:
         """Format only commodities and accounts (no transactions)."""
         lines = []
@@ -227,14 +265,16 @@ class ExportTransactionsUseCase:
         mtime = os.path.getmtime(self.repository.file_path)
         return datetime.date.fromtimestamp(mtime).strftime("%Y-%m-%d")
 
-    def _format_commodity(self, commodity, transaction, lines: list):
+    def _format_commodity(self, commodity, transaction, lines: list, date_override: Optional[str] = None):
         """Format commodity declaration"""
         mnemonic = commodity.get_mnemonic()
         namespace = commodity.get_namespace()
         fraction = commodity.get_fraction()
         fullname = commodity.get_fullname()
 
-        if transaction is not None:
+        if date_override is not None:
+            date_str = date_override
+        elif transaction is not None:
             date_str = transaction.GetDate().strftime("%Y-%m-%d")
         else:
             date_str = self._file_date_str()
@@ -246,7 +286,7 @@ class ExportTransactionsUseCase:
         lines.append(f'\tnamespace: {encode_value_as_string(namespace)}')
         lines.append(f'\tfraction: {fraction}')
 
-    def _format_account(self, account, transaction, lines: list):
+    def _format_account(self, account, transaction, lines: list, date_override: Optional[str] = None):
         """Format account declaration"""
         commodity = account.GetCommodity()
         if commodity is None:
@@ -257,7 +297,9 @@ class ExportTransactionsUseCase:
         fraction = commodity.get_fraction()
         commodity_scu = account.GetCommoditySCU()
 
-        if transaction is not None:
+        if date_override is not None:
+            date_str = date_override
+        elif transaction is not None:
             date_str = transaction.GetDate().strftime("%Y-%m-%d")
         else:
             date_str = self._file_date_str()


### PR DESCRIPTION
Previously the only way to export accounts was via the 'export' command, which always loads all transactions from the book — even when only the account chart was needed. On large files this is unnecessarily slow.

Changes:
- Add ExportTransactionsUseCase.execute_accounts_only() Loads accounts directly from the repository without touching the transaction log. Returns an ExportResult with zero transactions.
- Add format_accounts_only(result, as_of_date=None) Formats commodity and account declarations using the supplied date (or file mtime when omitted) for every open/commodity header line.
- Add date_override param to _format_commodity and _format_account Allows callers to stamp a specific date without a transaction object. Priority: date_override > transaction date > file mtime.
- Add cli/export_accounts_cmd.py: new 'export-accounts' CLI command gnucash-plaintext export-accounts <file> <output> [--as-of YYYY-MM-DD]
- Register export-accounts in cli/main.py
- Add unit tests (tests/unit/use_cases/test_export_accounts.py) Covers: no transactions in result, all accounts present, no duplicates, as_of_date stamped on open/commodity lines, file mtime fallback.
- Add integration tests (tests/integration/test_cli_export_accounts.py) Covers: basic export, no transaction lines despite book having them, --as-of flag, all accounts present, error on missing file.
- Update README.md with export-accounts usage and --as-of option
- Update RELEASE_NOTES.md with v0.3.2 entry