### PR TITLE
feat: add --with-balance flag to export running account balances

### DIFF
--- a/cli/export_cmd.py
+++ b/cli/export_cmd.py
@@ -21,7 +21,9 @@ from use_cases.export_transactions import ExportTransactionsUseCase
 @click.option('--account', '-a', help='Filter by account path')
 @click.option('--all-accounts', 'all_accounts', is_flag=True, help='Export all accounts even if they have no transactions')
 @click.option('--include-business-objects', is_flag=True, help='Include business objects (customers, invoices, etc.)')
-def export_transactions(gnucash_file, output_file, input_file, output_path, start_date, end_date, account, all_accounts, include_business_objects):
+@click.option('--with-balance', 'with_balance', is_flag=True,
+              help='Append running account balance after each split (useful for bank reconciliation)')
+def export_transactions(gnucash_file, output_file, input_file, output_path, start_date, end_date, account, all_accounts, include_business_objects, with_balance):
     """
     Export transactions from GnuCash file to plaintext format.
 
@@ -44,6 +46,8 @@ def export_transactions(gnucash_file, output_file, input_file, output_path, star
         gnucash-plaintext export mybook.gnucash transactions.txt --start-date 2024-01-01
 
         gnucash-plaintext export -i mybook.gnucash -o transactions.txt --account "Expenses:Groceries"
+
+        gnucash-plaintext export mybook.gnucash transactions.txt --with-balance
     """
     # Support both positional and flag-based arguments
     gnucash_file = input_file or gnucash_file
@@ -78,7 +82,8 @@ def export_transactions(gnucash_file, output_file, input_file, output_path, star
                 start_date=start_date,
                 end_date=end_date,
                 account_filter=account,
-                all_accounts=all_accounts
+                all_accounts=all_accounts,
+                with_balance=with_balance,
             )
             count = len(result.transactions)
 

--- a/scripts/test-all-versions-parallel.sh
+++ b/scripts/test-all-versions-parallel.sh
@@ -94,9 +94,11 @@ run_test() {
     echo "[$version] Starting tests..." > "$log_file"
 
     if docker run --rm \
+        --user "$(id -u):$(id -g)" \
+        -e HOME=/tmp/home \
         -v "$workspace:/workspace" \
         gnucash-dev:$version \
-        sh -c "cd /workspace && python3 -m pip install -e '.[dev]' -q --break-system-packages && pytest tests/ -v --tb=short" \
+        sh -c "mkdir -p /tmp/home/.local && cd /workspace && python3 -m pip install -e '.[dev]' -q --break-system-packages --user && PATH=/tmp/home/.local/bin:\$PATH pytest tests/ -v --tb=short" \
         >> "$log_file" 2>&1; then
         echo "[$version] ✓ PASSED" >> "$log_file"
         return 0

--- a/tests/integration/test_cli_export.py
+++ b/tests/integration/test_cli_export.py
@@ -273,3 +273,81 @@ class TestExportCLI:
         finally:
             if os.path.exists(output_path):
                 os.unlink(output_path)
+
+    def test_export_with_balance_flag_adds_balance_lines(self, temp_gnucash_with_transactions):
+        """--with-balance flag causes each split to include a balance: line"""
+        runner = CliRunner()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            output_path = f.name
+
+        try:
+            result = runner.invoke(export_transactions, [
+                temp_gnucash_with_transactions,
+                output_path,
+                '--with-balance',
+            ])
+
+            assert result.exit_code == 0, result.output
+            assert "Exported 3 transaction(s)" in result.output
+
+            with open(output_path) as f:
+                content = f.read()
+
+            assert 'balance:' in content
+
+        finally:
+            if os.path.exists(output_path):
+                os.unlink(output_path)
+
+    def test_export_without_balance_flag_has_no_balance_lines(self, temp_gnucash_with_transactions):
+        """Without --with-balance, no balance: lines appear in the output"""
+        runner = CliRunner()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            output_path = f.name
+
+        try:
+            result = runner.invoke(export_transactions, [
+                temp_gnucash_with_transactions,
+                output_path,
+            ])
+
+            assert result.exit_code == 0
+            with open(output_path) as f:
+                content = f.read()
+            assert 'balance:' not in content
+
+        finally:
+            if os.path.exists(output_path):
+                os.unlink(output_path)
+
+    def test_export_with_balance_and_date_filter(self, temp_gnucash_with_transactions):
+        """--with-balance with a date filter shows correct cumulative balance"""
+        runner = CliRunner()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:
+            output_path = f.name
+
+        try:
+            result = runner.invoke(export_transactions, [
+                temp_gnucash_with_transactions,
+                output_path,
+                '--with-balance',
+                '--start-date', '2024-01-25',
+                '--end-date', '2024-01-25',
+            ])
+
+            assert result.exit_code == 0
+            assert "Exported 1 transaction(s)" in result.output
+
+            with open(output_path) as f:
+                content = f.read()
+
+            # Checking balance after all 3 transactions = -125.00 CAD, not just -45.00
+            assert '"-125.00 CAD"' in content
+            assert 'balance:' in content
+
+        finally:
+            if os.path.exists(output_path):
+                os.unlink(output_path)

--- a/tests/unit/use_cases/test_export_transactions.py
+++ b/tests/unit/use_cases/test_export_transactions.py
@@ -186,6 +186,191 @@ class TestExportTransactions:
             assert dates == sorted(dates)
 
 
+class TestFormatFractionAsDecimal:
+    """Unit tests for _format_fraction_as_decimal helper (no GnuCash needed)"""
+
+    def test_whole_number(self):
+        from fractions import Fraction
+
+        from use_cases.export_transactions import _format_fraction_as_decimal
+        assert _format_fraction_as_decimal(Fraction(12345, 1), 0) == "12345"
+
+    def test_two_decimal_places_positive(self):
+        from fractions import Fraction
+
+        from use_cases.export_transactions import _format_fraction_as_decimal
+        assert _format_fraction_as_decimal(Fraction(123456, 100), 2) == "1234.56"
+
+    def test_two_decimal_places_negative(self):
+        from fractions import Fraction
+
+        from use_cases.export_transactions import _format_fraction_as_decimal
+        assert _format_fraction_as_decimal(Fraction(-5000, 100), 2) == "-50.00"
+
+    def test_less_than_one(self):
+        from fractions import Fraction
+
+        from use_cases.export_transactions import _format_fraction_as_decimal
+        assert _format_fraction_as_decimal(Fraction(50, 100), 2) == "0.50"
+
+    def test_negative_less_than_one(self):
+        from fractions import Fraction
+
+        from use_cases.export_transactions import _format_fraction_as_decimal
+        assert _format_fraction_as_decimal(Fraction(-50, 100), 2) == "-0.50"
+
+    def test_zero(self):
+        from fractions import Fraction
+
+        from use_cases.export_transactions import _format_fraction_as_decimal
+        assert _format_fraction_as_decimal(Fraction(0), 2) == "0.00"
+
+    def test_jpy_no_decimal(self):
+        from fractions import Fraction
+
+        from use_cases.export_transactions import _format_fraction_as_decimal
+        # JPY fraction=1, decimal_places=0
+        assert _format_fraction_as_decimal(Fraction(12345, 1), 0) == "12345"
+
+
+class TestRunningBalance:
+    """Tests for with_balance=True export functionality"""
+
+    def test_execute_with_balance_populates_balance_map(self, temp_gnucash_with_transactions):
+        """execute(with_balance=True) populates account_balances_after_tx"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute(with_balance=True)
+
+            assert result.account_balances_after_tx != {}
+            assert len(result.account_balances_after_tx) == 3  # one entry per transaction
+
+    def test_execute_without_balance_leaves_map_empty(self, temp_gnucash_with_transactions):
+        """execute() without with_balance leaves account_balances_after_tx empty"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute()
+
+            assert result.account_balances_after_tx == {}
+
+    def test_running_balance_accumulates_correctly(self, temp_gnucash_with_transactions):
+        """Checking account balance after 3 transactions: -50 -30 -45 = -125"""
+        from fractions import Fraction
+
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute(with_balance=True)
+
+            # Transactions are sorted by date; the last one is 2024-01-25 Groceries $45
+            last_tx = result.transactions[-1]
+            last_tx_guid = last_tx.GetGUID().to_string()
+            balances = result.account_balances_after_tx[last_tx_guid]
+
+            # Find Checking account guid
+            checking_guid = None
+            for split in last_tx.GetSplitList():
+                acct = split.GetAccount()
+                if acct.GetName() == 'Checking':
+                    checking_guid = acct.GetGUID().to_string()
+                    break
+            assert checking_guid is not None
+
+            # Checking: -50 -30 -45 = -125.00 CAD
+            checking_balance = balances[checking_guid]
+            assert checking_balance == Fraction(-12500, 100)
+
+    def test_format_as_plaintext_with_balance_emits_balance_lines(self, temp_gnucash_with_transactions):
+        """format_as_plaintext on a with_balance result includes 'balance:' lines"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute(with_balance=True)
+            plaintext = use_case.format_as_plaintext(result)
+
+            assert 'balance:' in plaintext
+
+    def test_format_as_plaintext_without_balance_has_no_balance_lines(self, temp_gnucash_with_transactions):
+        """format_as_plaintext without with_balance emits no 'balance:' lines"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute()
+            plaintext = use_case.format_as_plaintext(result)
+
+            assert 'balance:' not in plaintext
+
+    def test_balance_values_are_correct_in_plaintext(self, temp_gnucash_with_transactions):
+        """Balance lines in plaintext reflect accurate cumulative amounts"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            result = use_case.execute(with_balance=True)
+            plaintext = use_case.format_as_plaintext(result)
+
+            # After tx1 (Groceries $50): Checking = -50.00, Groceries = 50.00
+            # After tx2 (Dining $30): Checking = -80.00, Dining = 30.00
+            # After tx3 (Groceries $45): Checking = -125.00, Groceries = 95.00
+            assert '"50.00 CAD"' in plaintext   # Groceries after tx1
+            assert '"-50.00 CAD"' in plaintext  # Checking after tx1
+            assert '"-125.00 CAD"' in plaintext  # Checking after tx3
+
+    def test_balance_with_date_filter_shows_correct_cumulative_balance(
+        self, temp_gnucash_with_transactions
+    ):
+        """When date filter is applied, balance still reflects all prior transactions"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+            use_case = ExportTransactionsUseCase(repo)
+            # Only export the last transaction, but balance should include all prior ones
+            result = use_case.execute(
+                start_date="2024-01-25",
+                end_date="2024-01-25",
+                with_balance=True,
+            )
+            assert len(result.transactions) == 1
+            plaintext = use_case.format_as_plaintext(result)
+
+            # The single exported transaction is 2024-01-25 (-45 CAD from Checking)
+            # Cumulative Checking balance after all 3 txns = -125.00 CAD (not just -45)
+            assert '"-125.00 CAD"' in plaintext
+
+    def test_export_to_file_with_balance(self, temp_gnucash_with_transactions):
+        """export_to_file with with_balance=True writes balance lines to file"""
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        fd, output_path = tempfile.mkstemp(suffix='.txt')
+        os.close(fd)
+        try:
+            with GnuCashRepository(temp_gnucash_with_transactions) as repo:
+                use_case = ExportTransactionsUseCase(repo)
+                use_case.export_to_file(output_path, with_balance=True)
+
+            with open(output_path) as f:
+                content = f.read()
+            assert 'balance:' in content
+        finally:
+            if os.path.exists(output_path):
+                os.unlink(output_path)
+
+
 class TestExportByGuid:
     """Test execute_by_guid — single-transaction export"""
 

--- a/use_cases/export_transactions.py
+++ b/use_cases/export_transactions.py
@@ -7,6 +7,7 @@ with all metadata required for round-trip import.
 
 import datetime
 import os
+from fractions import Fraction
 from typing import Optional, Sequence
 
 from gnucash import Transaction
@@ -29,6 +30,34 @@ from infrastructure.gnucash.utils import (
 from repositories.gnucash_repository import GnuCashRepository
 
 
+def _format_fraction_as_decimal(f: Fraction, decimal_places: int) -> str:
+    """
+    Format a Fraction as a fixed-point decimal string.
+
+    GnuCash amounts always use power-of-10 denominators (100 for CAD, 1 for
+    JPY, etc.), so multiplying by 10**decimal_places always yields an exact
+    integer — no rounding is needed.
+
+    Args:
+        f: Fraction value to format
+        decimal_places: Number of digits after the decimal point (0 for JPY, 2
+            for CAD/USD, etc.)
+
+    Returns:
+        Formatted string, e.g. "1234.56", "-0.50", "12345"
+    """
+    if decimal_places == 0:
+        return str(int(f))
+    scale = 10 ** decimal_places
+    scaled_int = int(f * scale)
+    sign = '-' if scaled_int < 0 else ''
+    abs_str = str(abs(scaled_int))
+    if len(abs_str) > decimal_places:
+        return sign + abs_str[:-decimal_places] + '.' + abs_str[-decimal_places:]
+    else:
+        return sign + '0.' + '0' * (decimal_places - len(abs_str)) + abs_str
+
+
 class ExportResult:
     """Container for export data"""
     def __init__(self):
@@ -37,6 +66,9 @@ class ExportResult:
         self.transactions = [] # List of transactions
         self.commodity_seen = set()
         self.account_seen = set()
+        # Running balance data: tx_guid -> {account_guid -> Fraction}
+        # Populated by execute(with_balance=True); empty dict means no balances.
+        self.account_balances_after_tx: dict = {}
 
 
 class ExportTransactionsUseCase:
@@ -56,7 +88,8 @@ class ExportTransactionsUseCase:
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
         account_filter: Optional[str] = None,
-        all_accounts: bool = False
+        all_accounts: bool = False,
+        with_balance: bool = False,
     ) -> ExportResult:
         """
         Export transactions with ALL commodities and accounts.
@@ -71,12 +104,18 @@ class ExportTransactionsUseCase:
             end_date: Optional end date for filtering TRANSACTIONS only
             account_filter: Optional account path for filtering TRANSACTIONS only
             all_accounts: If True, export ALL accounts regardless of transactions
+            with_balance: If True, compute running per-account balances so that
+                format_as_plaintext() can emit a ``balance:`` line on every
+                split.  Balances are calculated over ALL transactions (not just
+                the filtered subset) so the values are always correct even when
+                a date or account filter is in effect.
 
         Returns:
             ExportResult with:
             - ALL commodities (not filtered, or all from accounts if all_accounts=True)
             - ALL accounts (not filtered, or all from repository if all_accounts=True)
             - Filtered transactions (by date/account if specified)
+            - account_balances_after_tx populated when with_balance=True
         """
         # Get ALL transactions first (we'll filter them later)
         all_transactions = self.repository.get_all_transactions()
@@ -132,6 +171,52 @@ class ExportTransactionsUseCase:
         # Only include the filtered transactions in the result
         result.transactions = transactions
 
+        # Pre-compute running balances across ALL transactions when requested so
+        # that filtered exports still show correct cumulative account balances.
+        if with_balance:
+            result.account_balances_after_tx = self._compute_running_balances(
+                all_transactions
+            )
+
+        return result
+
+    def _compute_running_balances(self, all_transactions_sorted: list) -> dict:
+        """
+        Compute the per-account running balance after each transaction.
+
+        Iterates every transaction in chronological order (caller must pre-sort)
+        and accumulates split amounts using exact Fraction arithmetic.  The
+        result is a mapping from tx_guid to a nested dict of
+        {account_guid -> Fraction} holding the account balance *after* that
+        transaction has been applied.
+
+        Only accounts that appear in a given transaction are stored for that
+        transaction; the caller looks up the balance for (tx_guid, account_guid)
+        at format time.
+
+        Args:
+            all_transactions_sorted: All transactions, already sorted by date.
+
+        Returns:
+            dict mapping tx_guid (str) -> dict[account_guid (str) -> Fraction]
+        """
+        running: dict = {}   # account_guid -> Fraction (cumulative)
+        result: dict = {}    # tx_guid -> {account_guid -> Fraction}
+
+        for tx in all_transactions_sorted:
+            tx_guid = tx.GetGUID().to_string()
+            tx_accounts: set = set()
+
+            for split in tx.GetSplitList():
+                account = split.GetAccount()
+                account_guid = account.GetGUID().to_string()
+                amount = split.GetAmount()
+                delta = Fraction(int(amount.num()), int(amount.denom()))
+                running[account_guid] = running.get(account_guid, Fraction(0)) + delta
+                tx_accounts.add(account_guid)
+
+            result[tx_guid] = {guid: running[guid] for guid in tx_accounts}
+
         return result
 
     def _collect_transaction_data(self, transaction, result: ExportResult):
@@ -170,6 +255,11 @@ class ExportTransactionsUseCase:
         """
         Format export result as plaintext string with full legacy format.
 
+        When result.account_balances_after_tx is non-empty (i.e. execute() was
+        called with with_balance=True), each split line will be followed by a
+        ``balance:`` metadata line showing the cumulative account balance after
+        that transaction, expressed in the account's own commodity.
+
         Args:
             result: ExportResult with commodities, accounts, and transactions
 
@@ -188,7 +278,9 @@ class ExportTransactionsUseCase:
 
         # Output transactions
         for transaction in result.transactions:
-            self._format_transaction(transaction, lines)
+            tx_guid = transaction.GetGUID().to_string()
+            balance_map = result.account_balances_after_tx.get(tx_guid)
+            self._format_transaction(transaction, lines, balance_map=balance_map)
 
         # Join lines and add trailing newline to match legacy format
         return '\n'.join(lines) + '\n' if lines else ''
@@ -244,7 +336,9 @@ class ExportTransactionsUseCase:
         """Format only transactions (no commodities or accounts)."""
         lines = []
         for transaction in result.transactions:
-            self._format_transaction(transaction, lines)
+            tx_guid = transaction.GetGUID().to_string()
+            balance_map = result.account_balances_after_tx.get(tx_guid)
+            self._format_transaction(transaction, lines, balance_map=balance_map)
         return '\n'.join(lines) + '\n' if lines else ''
 
     def format_transaction_list(self, transactions: list) -> str:
@@ -334,8 +428,22 @@ class ExportTransactionsUseCase:
         if commodity_scu != fraction:
             lines.append(f'\tcommodity_scu: {encode_value_as_string(commodity_scu)}')
 
-    def _format_transaction(self, transaction, lines: list):
-        """Format transaction with all metadata"""
+    def _format_transaction(
+        self,
+        transaction,
+        lines: list,
+        balance_map: Optional[dict] = None,
+    ):
+        """
+        Format transaction with all metadata.
+
+        Args:
+            transaction: GnuCash Transaction object
+            lines: Output lines list to append to
+            balance_map: Optional {account_guid -> Fraction} of running balances
+                after this transaction.  When provided, each split gets a
+                ``balance:`` metadata line.
+        """
         tx_guid = transaction.GetGUID()
         tx_splits = transaction.GetSplitList()
         date_str = transaction.GetDate().strftime("%Y-%m-%d")
@@ -388,10 +496,35 @@ class ExportTransactionsUseCase:
 
         # Splits
         for split in tx_splits:
-            self._format_split(split, tx_currency_namespace, tx_currency_symbol, lines)
+            balance: Optional[Fraction] = None
+            if balance_map is not None:
+                account_guid = split.GetAccount().GetGUID().to_string()
+                balance = balance_map.get(account_guid)
+            self._format_split(
+                split, tx_currency_namespace, tx_currency_symbol, lines,
+                balance=balance,
+            )
 
-    def _format_split(self, split, tx_currency_namespace, tx_currency_symbol, lines: list):
-        """Format split with all metadata"""
+    def _format_split(
+        self,
+        split,
+        tx_currency_namespace,
+        tx_currency_symbol,
+        lines: list,
+        balance: Optional[Fraction] = None,
+    ):
+        """
+        Format split with all metadata.
+
+        Args:
+            split: GnuCash Split object
+            tx_currency_namespace: Transaction currency namespace
+            tx_currency_symbol: Transaction currency mnemonic
+            lines: Output lines list to append to
+            balance: Optional running balance (Fraction) of this account after
+                the parent transaction.  When provided, a ``balance:`` metadata
+                line is emitted as the last item of the split's metadata block.
+        """
         split_account = split.GetAccount()
         split_currency = split_account.GetCommodity()
         split_currency_namespace = split_currency.get_namespace()
@@ -438,6 +571,14 @@ class ExportTransactionsUseCase:
         custom_split_meta = get_custom_metadata(split)
         for key, value in sorted(custom_split_meta.items()):
             lines.append(f'\t\t{key}: {encode_value_as_string(value)}')
+
+        # Running balance — emitted last so it reads as a post-transaction annotation
+        if balance is not None:
+            fraction = split_currency.get_fraction()
+            decimal_places = len(str(fraction)) - 1
+            balance_str = _format_fraction_as_decimal(balance, decimal_places)
+            balance_ticker = get_commodity_ticker(split_currency)
+            lines.append(f'\t\tbalance: "{balance_str} {balance_ticker}"')
 
     def execute_by_guids(self, guids: Sequence[str]) -> ExportResult:
         """
@@ -501,7 +642,8 @@ class ExportTransactionsUseCase:
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
         account_filter: Optional[str] = None,
-        all_accounts: bool = False
+        all_accounts: bool = False,
+        with_balance: bool = False,
     ) -> int:
         """
         Export transactions to file.
@@ -512,11 +654,15 @@ class ExportTransactionsUseCase:
             end_date: Optional end date
             account_filter: Optional account filter
             all_accounts: If True, export all accounts even without transactions
+            with_balance: If True, include running account balance per split
 
         Returns:
             Number of transactions exported
         """
-        result = self.execute(start_date, end_date, account_filter, all_accounts)
+        result = self.execute(
+            start_date, end_date, account_filter, all_accounts,
+            with_balance=with_balance,
+        )
         plaintext = self.format_as_plaintext(result)
 
         with open(output_path, 'w') as f:


### PR DESCRIPTION
Adds a `--with-balance` CLI flag (and corresponding `with_balance=True` parameter in the use-case API) that annotates each split in the export with a `balance:` metadata line showing the cumulative balance of that account after the transaction is committed.

What changed:
- use_cases/export_transactions.py
  - New module-level helper `_format_fraction_as_decimal(f, decimal_places)` formats a Fraction as a fixed-point string with correct negative and sub-unity handling.
  - ExportResult gains `account_balances_after_tx: dict` (tx_guid -> {account_guid -> Fraction}) populated by execute().
  - execute() accepts `with_balance=False`; when True it calls the new `_compute_running_balances()` over ALL transactions (regardless of date/account filters) so balances are always the true cumulative total.
  - _format_transaction() and _format_split() accept an optional balance map/value; when present a `balance: "X.XX TICKER"` line is appended as the last item in each split's metadata block.
  - export_to_file() threads the new flag through.

- cli/export_cmd.py
  - New `--with-balance` flag passed through to execute().

- scripts/test-all-versions-parallel.sh
  - Run Docker containers as the current host user (--user $(id -u):$(id -g)) so that __pycache__ and other files created during tests are owned by the host user, not root. This fixes the cleanup trap failing with "Permission denied" when rm -rf tries to delete root-owned files.
  - Set HOME=/tmp/home and pass --user to pip install so pip has a writable user-local directory.

Why:
Users reconciling their GnuCash book against bank statements need to see the per-account running balance after each transaction, matching the "balance" column in online banking. The flag is opt-in so the default export format (used for round-trip import) is unchanged.

Design notes:
- Exact Fraction arithmetic avoids float rounding.
- Balances are computed over ALL transactions, not just the filtered subset, so `--with-balance --start-date 2024-06-01` still shows the correct cumulative balance at each point in time.
- The `balance:` key is unknown to the current parser; callers should not round-trip a `--with-balance` export back through import without adding parser support for this field.