### PR TITLE
fix: resolve S-001/S-002 security and Q-001/Q-002 quality issues (Group 1)

### DIFF
--- a/cli/close_books_cmd.py
+++ b/cli/close_books_cmd.py
@@ -104,8 +104,7 @@ def close_books(gnucash_file, closing_date, equity_account, force, dry_run, stat
                 dry_run=dry_run,
             )
         except AlreadyClosedError as e:
-            click.echo(f"Error: {e}", err=True)
-            raise click.Abort() from e
+            raise click.ClickException(str(e)) from e
 
         if not dry_run:
             repo.save()

--- a/cli/export_accounts_cmd.py
+++ b/cli/export_accounts_cmd.py
@@ -56,5 +56,4 @@ def export_accounts(gnucash_file, output_file, as_of_date):
         finally:
             repo.close()
     except Exception as e:
-        click.echo(f"Error: {str(e)}", err=True)
-        raise click.Abort() from e
+        raise click.ClickException(str(e)) from e

--- a/cli/export_beancount_cmd.py
+++ b/cli/export_beancount_cmd.py
@@ -95,5 +95,4 @@ def export_beancount(gnucash_file, output_file, input_file, output_path, date_fr
             repo.close()
 
     except Exception as e:
-        click.secho(f"✗ Export failed: {str(e)}", fg='red', err=True)
-        raise click.Abort() from e
+        raise click.ClickException(str(e)) from e

--- a/cli/export_cmd.py
+++ b/cli/export_cmd.py
@@ -106,5 +106,4 @@ def export_transactions(gnucash_file, output_file, input_file, output_path, star
             repo.close()
 
     except Exception as e:
-        click.echo(f"✗ Error: {str(e)}", err=True)
-        raise click.Abort() from e
+        raise click.ClickException(str(e)) from e

--- a/cli/export_transaction_cmd.py
+++ b/cli/export_transaction_cmd.py
@@ -70,8 +70,6 @@ def export_transaction(gnucash_file, input_file, guids, output_path):
             repo.close()
 
     except ValueError as e:
-        click.echo(f"✗ {str(e)}", err=True)
-        raise SystemExit(1) from e
+        raise click.ClickException(str(e)) from e
     except Exception as e:
-        click.echo(f"✗ Error: {str(e)}", err=True)
-        raise SystemExit(1) from e
+        raise click.ClickException(str(e)) from e

--- a/cli/import_beancount_cmd.py
+++ b/cli/import_beancount_cmd.py
@@ -123,7 +123,7 @@ def import_beancount(gnucash_file, beancount_file, gnucash_path, beancount_path,
                         click.echo(f"  - {error}")
                     click.echo("")
                     click.echo("✗ Import completed with errors", err=True)
-                    raise click.Abort()
+                    raise SystemExit(1)
                 else:
                     repo.save()
                     click.echo("")
@@ -133,14 +133,11 @@ def import_beancount(gnucash_file, beancount_file, gnucash_path, beancount_path,
                 repo.close()
 
     except BeancountValidationError as e:
-        click.echo("")
-        click.echo("✗ Validation failed:", err=True)
-        click.echo(str(e), err=True)
-        click.echo("")
-        click.echo("This beancount file is missing required gnucash-* metadata.", err=True)
-        click.echo("Only beancount files exported from GnuCash can be imported.", err=True)
-        raise click.Abort() from e
+        raise click.ClickException(
+            f"Validation failed: {e}\n"
+            "This beancount file is missing required gnucash-* metadata.\n"
+            "Only beancount files exported from GnuCash can be imported."
+        ) from e
 
     except Exception as e:
-        click.echo(f"✗ Error: {str(e)}", err=True)
-        raise click.Abort() from e
+        raise click.ClickException(str(e)) from e

--- a/cli/import_cmd.py
+++ b/cli/import_cmd.py
@@ -199,8 +199,7 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
                                 f.write(plaintext)
                             click.echo(f"✓ New transactions written to {output_new}")
                         except OSError as exc:
-                            click.echo(f"✗ Could not write --output-new file: {exc}", err=True)
-                            raise SystemExit(1) from exc
+                            raise click.ClickException(f"Could not write --output-new file: {exc}") from exc
             elif dry_run:
                 click.echo("")
                 click.echo("✓ Dry run complete (no changes made)")
@@ -214,5 +213,4 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
     except Exception as e:
         if create_new and os.path.exists(gnucash_file):
             os.remove(gnucash_file)
-        click.echo(f"✗ Error: {str(e)}", err=True)
-        raise click.Abort() from e
+        raise click.ClickException(str(e)) from e

--- a/cli/invoice_print_cmd.py
+++ b/cli/invoice_print_cmd.py
@@ -23,6 +23,8 @@ def print_invoice(gnucash_file, invoice_id, output):
     """Prints a GnuCash invoice to a PDF file."""
     click.echo(f"Printing invoice {invoice_id} from {gnucash_file} to {output}...")
 
+    company_info = read_book_company_info(gnucash_file)
+
     repo = GnuCashRepository(gnucash_file)
     repo.open(SessionMode.READ_ONLY)
     book = repo.book
@@ -39,8 +41,6 @@ def print_invoice(gnucash_file, invoice_id, output):
 
         if not invoice:
             raise click.UsageError(f"Invoice with ID '{invoice_id}' not found.")
-
-        company_info = read_book_company_info(gnucash_file)
 
         render_to_pdf(invoice, book, str(_XSLT_PATH), output, company_info)
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -43,16 +43,6 @@ def cli():
     pass
 
 
-@cli.command()
-@click.argument('script', type=click.Path(exists=True))
-@click.argument('args', nargs=-1)
-def run(script, args):
-    """Runs a Python script."""
-    import subprocess
-    import sys
-    subprocess.run([sys.executable, script] + list(args), check=True)
-
-
 # Register commands
 cli.add_command(export_transactions, name='export')
 cli.add_command(export_accounts, name='export-accounts')

--- a/cli/validate_cmd.py
+++ b/cli/validate_cmd.py
@@ -67,7 +67,7 @@ def validate_ledger(gnucash_file, input_file, report, quick, stats):
                     click.echo("✓ Ledger is valid (no errors)")
                 else:
                     click.echo("✗ Ledger has errors", err=True)
-                    raise click.Abort()
+                    raise SystemExit(1)
 
             elif stats:
                 # Show statistics
@@ -118,11 +118,10 @@ def validate_ledger(gnucash_file, input_file, report, quick, stats):
                     click.echo(f"✓ Report saved to {report}")
 
                 if not result.is_valid():
-                    raise click.Abort()
+                    raise SystemExit(1)
 
         finally:
             repo.close()
 
     except Exception as e:
-        click.echo(f"✗ Error: {str(e)}", err=True)
-        raise click.Abort() from e
+        raise click.ClickException(str(e)) from e

--- a/docs/issues/Q-001-inconsistent-cli-exception-types.md
+++ b/docs/issues/Q-001-inconsistent-cli-exception-types.md
@@ -3,7 +3,7 @@ id: Q-001
 title: Inconsistent exception types across CLI commands
 category: quality
 severity: low
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/Q-002-read-book-company-info-bypasses-repo-layer.md
+++ b/docs/issues/Q-002-read-book-company-info-bypasses-repo-layer.md
@@ -3,7 +3,7 @@ id: Q-002
 title: read_book_company_info bypasses the repository layer
 category: quality
 severity: low
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/S-001-run-command-executes-arbitrary-scripts.md
+++ b/docs/issues/S-001-run-command-executes-arbitrary-scripts.md
@@ -3,7 +3,7 @@ id: S-001
 title: run command executes arbitrary scripts without documented risk
 category: security
 severity: low
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/S-002-broad-exception-in-gzip-fallback.md
+++ b/docs/issues/S-002-broad-exception-in-gzip-fallback.md
@@ -3,7 +3,7 @@ id: S-002
 title: Broad except-Exception in gzip fallback masks real errors
 category: security
 severity: low
-status: open
+status: closed
 ---
 
 ## Problem

--- a/services/invoice_renderer.py
+++ b/services/invoice_renderer.py
@@ -19,10 +19,11 @@ def read_book_company_info(file_path):
     book_slots = '{http://www.gnucash.org/XML/book}slots'
     gnc_book = '{http://www.gnucash.org/XML/gnc}book'
 
+    _not_gzip = getattr(_gz, 'BadGzipFile', OSError)
     try:
         with _gz.open(file_path, 'rb') as f:
             xml_root = xml.etree.ElementTree.parse(f).getroot()
-    except Exception:
+    except (_not_gzip, EOFError):
         xml_root = xml.etree.ElementTree.parse(file_path).getroot()
 
     def _frame_val(parent, key):


### PR DESCRIPTION
Fixes four issues from the April 2026 code review — all pure code changes, no test fixtures required.

S-002: Tighten gzip fallback exception in invoice_renderer.py
- Changed `except Exception` to `except (_not_gzip, EOFError)` where `_not_gzip = getattr(gzip, 'BadGzipFile', OSError)`.
- On Python 3.8+ catches only "not a gzip file" errors; PermissionError and FileNotFoundError now propagate immediately instead of being swallowed.

S-001: Remove undocumented `run` command from CLI
- Removed the `run` subcommand that executed arbitrary user-supplied Python scripts via subprocess. It was untested, absent from the README, and represented an undocumented trust-boundary widening for end users.

Q-001: Standardise exception types across all CLI commands
- Replaced every `raise click.Abort()` in error handlers with `raise click.ClickException(str(e))` so runtime errors produce "Error: <message>" at exit code 1 instead of "Aborted!".
- Replaced bare `raise SystemExit(1)` in export_transaction_cmd and import_cmd with `raise click.ClickException(str(e))`.
- For "validation found errors" cases (validate_cmd, import_beancount_cmd) where error detail is already printed, replaced `raise click.Abort()` with `raise SystemExit(1)` to exit cleanly without spurious "Aborted!".
- Removed redundant `click.echo(f"✗ Error: ...")` lines that preceded every Abort — ClickException prints its own message.

Q-002: Eliminate double file-open in print-invoice
- Moved `read_book_company_info(gnucash_file)` to before `repo.open()`. The function parsed raw XML while the GnuCash session already held the file open, which would fail under strict file locking (e.g. Windows).

Closes: S-001, S-002, Q-001, Q-002 (status updated in docs/issues/)