### PR TITLE
fix+test: emit @ price annotations for cross-currency splits; add T-001/T-004/T-005 tests (Group 3)

### DIFF
--- a/docs/issues/T-001-print-invoice-no-dedicated-tests.md
+++ b/docs/issues/T-001-print-invoice-no-dedicated-tests.md
@@ -3,7 +3,7 @@ id: T-001
 title: print-invoice command has no dedicated test file
 category: tests
 severity: high
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/T-004-multi-currency-beancount-export-untested.md
+++ b/docs/issues/T-004-multi-currency-beancount-export-untested.md
@@ -3,7 +3,7 @@ id: T-004
 title: Multi-currency beancount export has no integration test
 category: tests
 severity: medium
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/T-005-multi-currency-close-books-untested.md
+++ b/docs/issues/T-005-multi-currency-close-books-untested.md
@@ -3,7 +3,7 @@ id: T-005
 title: Multi-currency close-books path has no test
 category: tests
 severity: medium
-status: open
+status: closed
 ---
 
 ## Problem

--- a/tests/integration/test_beancount_roundtrip.py
+++ b/tests/integration/test_beancount_roundtrip.py
@@ -595,3 +595,98 @@ class TestBeancountRoundtripFidelity:
             "Beancount output contains 'None:' — a beancount_converter bug "
             "is producing invalid account names"
         )
+
+    def test_multi_currency_export_contains_all_commodity_declarations(self, temp_gnucash_comprehensive):
+        """
+        Exporting a multi-currency book declares all commodities.
+
+        The comprehensive fixture uses CAD, USD, HKD, JPY, KRW and a
+        non-currency commodity.  The beancount output must have a 'commodity'
+        directive for each one so the file is self-contained.
+        """
+        repo = GnuCashRepository(temp_gnucash_comprehensive)
+        repo.open()
+        try:
+            beancount_content = ExportBeancountUseCase(repo).execute()
+        finally:
+            repo.close()
+
+        for currency in ('CAD', 'USD', 'HKD', 'JPY', 'KRW'):
+            assert f'commodity {currency}' in beancount_content, (
+                f"Multi-currency export should declare commodity {currency}"
+            )
+
+    def test_multi_currency_export_emits_price_annotations(self, temp_gnucash_comprehensive):
+        """
+        Cross-currency splits carry a beancount `@ price commodity` annotation.
+
+        The comprehensive fixture has FX transactions (e.g., buying USD with CAD,
+        buying HKD with CAD).  For each split whose account commodity differs from
+        the transaction currency, the exporter must emit an `@ price` annotation
+        so beancount tools can compute FX gains/losses and validate the transaction.
+        """
+        repo = GnuCashRepository(temp_gnucash_comprehensive)
+        repo.open()
+        try:
+            beancount_content = ExportBeancountUseCase(repo).execute()
+        finally:
+            repo.close()
+
+        lines = beancount_content.splitlines()
+        # Cross-currency posting lines have the form:
+        #   <account> <amount> <commodity> @ <price> <tx_commodity>
+        at_price_lines = [ln for ln in lines if ln.startswith('  ') and ' @ ' in ln]
+        assert len(at_price_lines) > 0, (
+            "Expected at least one posting with `@ price` annotation in multi-currency output"
+        )
+
+        # Spot-check: a CAD-funded transaction with a non-CAD account should have @ CAD
+        cad_price_lines = [ln for ln in at_price_lines if ln.endswith(' CAD')]
+        assert len(cad_price_lines) > 0, (
+            "Expected postings annotated with @ ... CAD for CAD-funded cross-currency transactions"
+        )
+
+    def test_multi_currency_roundtrip_preserves_transaction_count(self, temp_gnucash_comprehensive):
+        """
+        A multi-currency book round-trips through beancount without losing transactions.
+
+        Verifies that the full GnuCash → beancount → GnuCash pipeline handles
+        cross-currency splits (CAD/USD/HKD/JPY) without errors or data loss.
+        """
+        import os
+
+        repo1 = GnuCashRepository(temp_gnucash_comprehensive)
+        repo1.open()
+        try:
+            original_tx_count = len(repo1.get_all_transactions())
+            original_account_count = len(repo1.get_all_accounts())
+            use_case = ExportBeancountUseCase(repo1)
+            beancount_content = use_case.execute()
+        finally:
+            repo1.close()
+
+        assert original_tx_count > 0, "Comprehensive fixture should have transactions"
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.beancount', delete=False) as f:
+            f.write(beancount_content)
+            beancount_file = f.name
+
+        fd, new_gnucash = tempfile.mkstemp(suffix='.gnucash')
+        os.close(fd)
+        os.unlink(new_gnucash)
+
+        try:
+            GnuCashRepository.create_new_file(new_gnucash)
+            repo2 = GnuCashRepository(new_gnucash)
+            repo2.open()
+            try:
+                result = ImportBeancountUseCase(repo2).import_from_file(beancount_file)
+                assert not result.has_errors(), f"Round-trip import had errors: {result.errors}"
+                assert result.accounts_created == original_account_count
+                assert result.transactions_created == original_tx_count
+            finally:
+                repo2.close()
+        finally:
+            os.unlink(beancount_file)
+            if os.path.exists(new_gnucash):
+                os.unlink(new_gnucash)

--- a/tests/integration/test_cli_print_invoice.py
+++ b/tests/integration/test_cli_print_invoice.py
@@ -1,0 +1,116 @@
+"""
+Integration tests for the print-invoice CLI command.
+
+Requires Docker (real GnuCash session + lxml/weasyprint).
+Uses the business_objects.txt fixture which already contains posted invoices.
+"""
+
+import os
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+
+@pytest.fixture
+def gnucash_with_invoice(tmp_path):
+    """
+    GnuCash file with a posted invoice (INV-2026-001).
+
+    Imports from tests/fixtures/business_objects.txt which contains a full
+    set of customers, vendors, and invoices including INV-2026-001 (posted,
+    unpaid) suitable for PDF rendering tests.
+    """
+    gnucash_file = tmp_path / "invoices.gnucash"
+    input_file = "tests/fixtures/business_objects.txt"
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        "import", "--new", str(gnucash_file), input_file,
+        "--include-business-objects",
+    ])
+    assert result.exit_code == 0, f"Fixture import failed:\n{result.output}"
+    return str(gnucash_file)
+
+
+# ---------------------------------------------------------------------------
+# Happy-path tests
+# ---------------------------------------------------------------------------
+
+class TestPrintInvoiceSuccess:
+
+    def test_prints_posted_invoice_to_pdf(self, gnucash_with_invoice, tmp_path):
+        """A valid posted invoice ID produces a non-empty PDF file."""
+        pdf_file = tmp_path / "invoice.pdf"
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "print-invoice", gnucash_with_invoice,
+            "--invoice-id", "INV-2026-001",
+            "-o", str(pdf_file),
+        ])
+        assert result.exit_code == 0, f"print-invoice failed:\n{result.output}"
+        assert os.path.exists(pdf_file), "PDF file was not created"
+        assert os.path.getsize(pdf_file) > 0, "PDF file is empty"
+
+    def test_success_message_contains_output_path(self, gnucash_with_invoice, tmp_path):
+        """Success output includes the PDF output path."""
+        pdf_file = tmp_path / "out.pdf"
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "print-invoice", gnucash_with_invoice,
+            "--invoice-id", "INV-2026-001",
+            "-o", str(pdf_file),
+        ])
+        assert result.exit_code == 0
+        assert str(pdf_file) in result.output
+
+
+# ---------------------------------------------------------------------------
+# Error-case tests
+# ---------------------------------------------------------------------------
+
+class TestPrintInvoiceErrors:
+
+    def test_nonexistent_invoice_id_exits_nonzero(self, gnucash_with_invoice, tmp_path):
+        """An invoice ID that does not exist in the book exits with a non-zero code."""
+        pdf_file = tmp_path / "no.pdf"
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "print-invoice", gnucash_with_invoice,
+            "--invoice-id", "DOES-NOT-EXIST",
+            "-o", str(pdf_file),
+        ])
+        assert result.exit_code != 0, (
+            "Expected non-zero exit for unknown invoice ID, got 0"
+        )
+        assert not os.path.exists(pdf_file), "PDF should not be created for unknown invoice"
+
+    def test_missing_invoice_id_flag_exits_2(self, gnucash_with_invoice, tmp_path):
+        """Omitting --invoice-id exits with code 2 (Click UsageError)."""
+        pdf_file = tmp_path / "no.pdf"
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "print-invoice", gnucash_with_invoice,
+            "-o", str(pdf_file),
+        ])
+        assert result.exit_code == 2
+
+    def test_missing_output_flag_exits_2(self, gnucash_with_invoice):
+        """Omitting -o exits with code 2 (Click UsageError)."""
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "print-invoice", gnucash_with_invoice,
+            "--invoice-id", "INV-2026-001",
+        ])
+        assert result.exit_code == 2
+
+    def test_nonexistent_gnucash_file_exits_2(self, tmp_path):
+        """A GnuCash file that does not exist exits with code 2."""
+        pdf_file = tmp_path / "no.pdf"
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "print-invoice", "/nonexistent/path/book.gnucash",
+            "--invoice-id", "INV-2026-001",
+            "-o", str(pdf_file),
+        ])
+        assert result.exit_code == 2

--- a/use_cases/export_beancount.py
+++ b/use_cases/export_beancount.py
@@ -5,6 +5,7 @@ Exports GnuCash data to beancount-compatible format with proper account names,
 commodity symbols, and metadata keys following beancount conventions.
 """
 
+from fractions import Fraction
 from typing import Optional
 
 from gnucash.gnucash_core_c import xaccAccountGetTypeStr
@@ -262,8 +263,14 @@ class ExportBeancountUseCase:
 
         formatted_amount = to_string_with_decimal_point_placed(split.GetAmount())
 
-        # Beancount posting format: <indent><account> <amount> <commodity>
-        lines.append(f'  {beancount_account} {formatted_amount} {beancount_commodity}')
+        # For cross-currency splits emit `@ price tx_commodity` so beancount
+        # tools know the exchange rate used for this posting.
+        tx_currency = split.GetParent().GetCurrency()
+        price_annotation = ''
+        if tx_currency.get_mnemonic() != split_currency.get_mnemonic():
+            price_annotation = self._price_annotation(split, tx_currency)
+
+        lines.append(f'  {beancount_account} {formatted_amount} {beancount_commodity}{price_annotation}')
 
         # Add split-level GnuCash metadata (indented under the posting)
         memo = split.GetMemo()
@@ -275,6 +282,32 @@ class ExportBeancountUseCase:
         if action:
             escaped_action = action.replace('"', '\\"').replace('\n', '\\n')
             lines.append(f'      gnucash-action: "{escaped_action}"')
+
+    def _price_annotation(self, split, tx_currency) -> str:
+        """
+        Return the beancount `@ price commodity` string for a cross-currency split.
+
+        price = |GetValue()| / |GetAmount()|  (tx_currency per unit of split commodity)
+        Returns '' when the amount is zero or when price cannot be determined.
+        """
+        amount = split.GetAmount()
+        value = split.GetValue()
+
+        amount_num = int(amount.num())
+        if amount_num == 0:
+            return ''
+
+        value_frac = Fraction(int(value.num()), int(value.denom()))
+        amount_frac = Fraction(abs(amount_num), int(amount.denom()))
+        price = abs(value_frac) / amount_frac
+
+        # Format as a clean decimal string (strip trailing zeros)
+        from decimal import Decimal
+        price_decimal = Decimal(price.numerator) / Decimal(price.denominator)
+        price_str = f'{price_decimal:.8f}'.rstrip('0').rstrip('.')
+
+        tx_beancount = self.converter.convert_commodity_symbol(tx_currency.get_mnemonic())
+        return f' @ {price_str} {tx_beancount}'
 
     def export_to_file(
         self,


### PR DESCRIPTION
Fixes a missing feature in the beancount exporter and adds the Group 3 integration tests covering print-invoice and multi-currency beancount export.

Bug fix — export_beancount.py: emit @ price annotations for cross-currency splits When a split's account commodity differs from the transaction currency (e.g. a 1000 JPY debit in a CAD-denominated transaction), the beancount exporter now appends `@ {price} {tx_currency}` to the posting line:

    Assets:Prepaid-Card:Suica  1000 JPY @ 0.00857 CAD
    Liabilities:CreditCard:HSBC  -8.57 CAD

Previously, both amounts were emitted without any rate annotation, leaving beancount tools unable to verify or process FX gains/losses.

Implementation: _price_annotation() computes abs(GetValue()) / abs(GetAmount()) as a Fraction and formats it as a clean decimal string. GetValue() is the amount in the transaction currency; GetAmount() is the amount in the account commodity. The beancount parser ignores the @ annotation during import (its regex only captures account, amount, commodity) so existing roundtrips are unaffected.

T-001: New tests/integration/test_cli_print_invoice.py Fixture imports business_objects.txt which contains posted invoice INV-2026-001. Success: valid ID produces non-empty PDF; output path appears in success message. Errors: unknown ID → non-zero exit; missing flags → exit 2; bad file → exit 2.

T-004: New multi-currency tests in test_beancount_roundtrip.py
- test_multi_currency_export_contains_all_commodity_declarations: all 5 currencies (CAD/USD/HKD/JPY/KRW) have a commodity directive.
- test_multi_currency_export_emits_price_annotations: cross-currency postings carry `@ price` annotations; spot-checks that @ CAD lines exist.
- test_multi_currency_roundtrip_preserves_transaction_count: full round-trip (GnuCash → beancount → GnuCash) preserves account and transaction counts.

T-005: Closed without new tests
TestMultiCurrencyCorrectness in test_cli_close_books.py already covers:
- test_b_usd_equity_gets_exact_net_income
- test_two_closing_transactions_created
- test_cad_closing_transaction_only_touches_cad_accounts

Closes: T-001, T-004, T-005 (status updated in docs/issues/)