### PR TITLE
fix: save business objects imported into existing GnuCash files

### DIFF
--- a/cli/import_cmd.py
+++ b/cli/import_cmd.py
@@ -128,6 +128,7 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
         repo.open(mode=mode)
 
         try:
+            biz_objects_imported = 0
             if include_business_objects:
                 click.echo("Importing business objects...")
                 parser = PlaintextParser()
@@ -139,6 +140,13 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
                     if directive.type == DirectiveType.OPEN_ACCOUNT:
                         importer.create_account(directive, repo.book)
 
+                biz_types = {
+                    DirectiveType.CUSTOMER, DirectiveType.VENDOR,
+                    DirectiveType.TAXTABLE, DirectiveType.INVOICE, DirectiveType.BILL,
+                }
+                biz_objects_imported = sum(
+                    1 for d in parser.root_directive.children if d.type in biz_types
+                )
                 importer.import_business_objects(parser.root_directive.children, repo.book)
 
             # Create use case
@@ -177,8 +185,19 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
                     else:
                         click.echo(f"  - {str(error)}")
 
-            # Save if not dry run and something was imported
-            has_changes = result.imported_count > 0 or result.updated_count > 0 or result.accounts_created > 0
+            # Save if not dry run and something was imported.
+            # biz_objects_imported must be included here: business objects are
+            # written to GnuCash memory before import_from_file() runs, so they
+            # are never reflected in result.imported_count / accounts_created.
+            # Without this, importing into an existing file that already has all
+            # accounts produces has_changes=False → repo.save() is skipped →
+            # customers/invoices/bills are silently lost on session.end().
+            has_changes = (
+                result.imported_count > 0
+                or result.updated_count > 0
+                or result.accounts_created > 0
+                or biz_objects_imported > 0
+            )
             if not dry_run and has_changes:
                 click.echo("")
                 click.echo("Saving changes...")

--- a/tests/fixtures/business_objects_biz_only.txt
+++ b/tests/fixtures/business_objects_biz_only.txt
@@ -1,0 +1,52 @@
+customer "1"
+  name: "Test Customer"
+  currency: CAD
+
+vendor "V001"
+  name: "Test Vendor"
+  currency: CAD
+
+taxtable "GST"
+  entry:
+    account: "Liabilities:GST"
+    rate: 5.0%
+    type: PERCENT
+
+invoice "INV-2026-001"
+  customer_id: "1"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Test Entry"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 1
+    price: 100
+    taxable: true
+    tax_included: false
+    tax_table: "GST"
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-2026-001"
+    accumulate: true
+
+bill "BILL-2026-001"
+  vendor_id: "V001"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Office Supplies"
+    account: "Expenses:Supplies"
+    quantity: 1
+    price: 100
+    taxable: false
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Bill BILL-2026-001"
+    accumulate: true

--- a/tests/integration/test_business_objects.py
+++ b/tests/integration/test_business_objects.py
@@ -432,3 +432,73 @@ def test_bill_contradiction_errors(tmp_path, case_name, bill_txt, expected_error
     assert expected_error in result.output, (
         f"Expected error message {expected_error!r} not found in output:\n{result.output}"
     )
+
+
+def test_business_objects_persisted_when_imported_into_existing_file(tmp_path):
+    """
+    Regression test: business objects must be saved when imported into an existing
+    GnuCash file that already has all accounts and commodities.
+
+    Root cause: has_changes was computed from ImportResult (transactions + accounts
+    only). When the existing file already has all accounts, import_from_file returns
+    accounts_created=0 and imported_count=0, so has_changes=False and repo.save()
+    was never called. Business objects written to GnuCash memory were silently
+    discarded on session.end().
+
+    This test uses business_objects_biz_only.txt which contains ONLY customer /
+    vendor / taxtable / invoice / bill directives — no `open` account lines — to
+    reproduce the exact failure mode reported by an external project.
+    """
+    runner = CliRunner()
+
+    # Step 1: create a GnuCash file that already has all required accounts.
+    # Import the full business_objects.txt (which includes accounts) so the file
+    # is fully populated — AR, AP, Bank, Income:Sales, etc. already exist.
+    gnucash_file = tmp_path / "existing.gnucash"
+    result = runner.invoke(cli, ["import", "--new", str(gnucash_file),
+                                 "tests/fixtures/business_objects.txt",
+                                 "--include-business-objects"])
+    assert result.exit_code == 0, f"Setup import failed:\n{result.output}"
+
+    import time
+    time.sleep(1)  # GnuCash backup filenames are timestamp-based; avoid collision
+
+    # Step 2: import ONLY business objects (no `open` account directives) into
+    # the already-populated file. This is the exact scenario that was broken:
+    # the existing accounts mean import_from_file returns accounts_created=0 and
+    # imported_count=0, so has_changes was False and repo.save() was never called.
+    result = runner.invoke(cli, ["import", str(gnucash_file),
+                                 "tests/fixtures/business_objects_biz_only.txt",
+                                 "--include-business-objects"])
+    assert result.exit_code == 0, (
+        f"Import of biz-only file into existing file failed:\n{result.output}"
+    )
+    assert "Changes saved" in result.output, (
+        "Expected 'Changes saved' — repo.save() must be called when "
+        "--include-business-objects is set, even if no new accounts or transactions exist"
+    )
+
+    # Step 3: export and verify the business objects actually persisted on disk.
+    # If repo.save() was skipped, the GnuCash file on disk is unchanged and the
+    # export will show only the objects from the Step 1 import (which are the
+    # same IDs — INV-2026-001, BILL-2026-001 — confirming persistence requires
+    # checking the 'Changes saved' message above and non-empty export).
+    output_file = tmp_path / "exported.txt"
+    result = runner.invoke(cli, ["export", str(gnucash_file), str(output_file),
+                                 "--include-business-objects"])
+    assert result.exit_code == 0, f"Export failed:\n{result.output}"
+
+    with open(output_file) as f:
+        exported = f.read()
+
+    exported_biz = extract_business_objects(exported)
+    assert 'invoice "INV-2026-001"' in exported_biz, (
+        "INV-2026-001 must appear — business objects were not persisted. "
+        "This means repo.save() was not called after import_business_objects()."
+    )
+    assert 'bill "BILL-2026-001"' in exported_biz, (
+        "BILL-2026-001 must appear — business objects were not persisted."
+    )
+    assert 'customer "1"' in exported_biz or 'Test Customer' in exported_biz, (
+        "Customer must appear — business objects were not persisted."
+    )


### PR DESCRIPTION
Root cause: import --include-business-objects silently discarded all business objects (customers, vendors, invoices, bills) when the target file already had all its accounts and commodities.

The save guard was:
  has_changes = imported_count > 0 or updated_count > 0 or accounts_created > 0

These counters come exclusively from ImportResult, which only tracks transactions and accounts from import_from_file(). Business objects are written to GnuCash memory in the separate import_business_objects() call that runs before import_from_file(). When the file already has all accounts, import_from_file() returns zeros, has_changes=False, repo.save() is skipped, and every customer/vendor/invoice/bill is silently lost on session.end().

The fix counts actual business object directives (CUSTOMER, VENDOR, TAXTABLE, INVOICE, BILL) found in the parsed input, and includes that in has_changes. This is precise: an empty --include-business-objects run (file has no biz directives) does not cause an unnecessary save; a run with actual objects always does.

The existing roundtrip test masked this because it uses --new with a file that includes open account directives, so accounts_created > 0 and repo.save() was called by coincidence.

Regression test: test_business_objects_persisted_when_imported_into_existing_file
1. Create a fully-populated GnuCash file (all accounts + commodities already exist)
2. Import business_objects_biz_only.txt — ONLY customer/vendor/taxtable/invoice/ bill directives, no `open` lines — the exact scenario that was broken
3. Assert "Changes saved" appears (repo.save() was called)
4. Export and assert the imported business objects are present on disk