### PR TITLE
test: add disk-persistence tests for account-balance pricedb and close-books

### DIFF
--- a/tests/integration/test_cli_account_balance.py
+++ b/tests/integration/test_cli_account_balance.py
@@ -263,3 +263,59 @@ class TestAccountBalanceFxRates:
         # No sub-account breakdown (default, no --with-children)
         assert "Assets:Bank:Checking" not in result.output
         assert "Assets:Bank:HKD" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Pricedb persistence
+# ---------------------------------------------------------------------------
+
+
+class TestAccountBalancePricedbPersistence:
+    """Verify that --fx-rates actually saves price entries to disk.
+
+    Gap identified: all other tests verify the CLI output, which is computed
+    from the in-memory YAML rates within the same session. If repo.save() were
+    silently skipped, the output would be identical but the pricedb entries
+    would not survive the session close.
+    """
+
+    def test_fx_rates_written_to_pricedb_on_disk(self, temp_gnucash_account_balance, tmp_path):
+        """HKD/CAD price entry appears in a fresh session opened after the CLI run."""
+        import time
+
+        from gnucash.gnucash_core_c import gnc_pricedb_get_db, gnc_pricedb_lookup_latest
+
+        from repositories.gnucash_repository import GnuCashRepository, SessionMode
+
+        # GnuCash backup filenames are timestamp-based (second resolution).
+        # The fixture saves during setup; without this sleep the CLI save would
+        # collide with the same-second backup → ERR_FILEIO_BACKUP_ERROR → no save.
+        time.sleep(1)
+
+        fx = _fx_file(tmp_path)
+        result = run_cli(temp_gnucash_account_balance, "--as-of", "2024-12-31",
+                         "--fx-rates", fx)
+        assert result.exit_code == 0, result.output
+
+        # Open a brand-new session from disk — no shared state with the CLI run.
+        repo = GnuCashRepository(temp_gnucash_account_balance)
+        repo.open(mode=SessionMode.READ_ONLY)
+        try:
+            book = repo.book
+            commod_table = book.get_table()
+            hkd = commod_table.lookup("CURRENCY", "HKD")
+            cad = commod_table.lookup("CURRENCY", "CAD")
+
+            assert hkd is not None, "HKD commodity not found in book"
+            assert cad is not None, "CAD commodity not found in book"
+
+            pricedb = gnc_pricedb_get_db(book.instance)
+            price = gnc_pricedb_lookup_latest(pricedb, hkd.instance, cad.instance)
+
+            assert price is not None, (
+                "No HKD/CAD price entry found in pricedb after account-balance "
+                "--fx-rates run. repo.save() was not called or the pricedb write "
+                "was not persisted to disk."
+            )
+        finally:
+            repo.close()

--- a/tests/integration/test_cli_close_books.py
+++ b/tests/integration/test_cli_close_books.py
@@ -595,3 +595,63 @@ class TestCloseBooksCLI:
         ])
         assert result.exit_code == 0, f"Exit {result.exit_code}: {result.output}"
         assert "Books closed as of" in result.output
+
+
+class TestCloseBooksDisks:
+    """Verify closing transactions actually persist to disk after CLI run.
+
+    Gap identified: all use-case tests (TestCloseSuccessCriteria,
+    TestMultiCurrencyCorrectness) open a repo, call use_case.execute(), call
+    repo.save() manually, and check balances in THE SAME open session. They
+    confirm the accounting logic is correct in memory, but nothing re-opens
+    the file from disk to prove the save actually persisted.
+    """
+
+    def test_closing_transactions_persist_to_disk(self, temp_gnucash_for_close_books):
+        """Income accounts are zero in a fresh session opened after close-books CLI run."""
+        from click.testing import CliRunner
+
+        from cli.close_books_cmd import close_books
+        from repositories.gnucash_repository import GnuCashRepository, SessionMode
+
+        runner = CliRunner()
+        result = runner.invoke(close_books, [
+            temp_gnucash_for_close_books, "--closing-date", "2024-12-31"
+        ])
+        assert result.exit_code == 0, f"close-books failed:\n{result.output}"
+
+        # Open a completely fresh session from disk — no shared state with CLI run.
+        repo = GnuCashRepository(temp_gnucash_for_close_books)
+        repo.open(mode=SessionMode.READ_ONLY)
+        try:
+            # If repo.save() was called, the closing transactions are on disk and
+            # Income/Expense accounts have zero balance as of the closing date.
+            # If repo.save() was not called, these accounts still hold their
+            # pre-close values (-6000 CAD, -500 USD, etc.).
+            cad_income = get_balance(repo, "Income:Salary:Base", CLOSING_DATE)
+            assert cad_income == Fraction(0), (
+                f"Income:Salary:Base = {cad_income} after close — expected 0. "
+                "Closing transactions were not persisted to disk."
+            )
+
+            usd_income = get_balance(repo, "Income:Freelance", CLOSING_DATE)
+            assert usd_income == Fraction(0), (
+                f"Income:Freelance = {usd_income} after close — expected 0. "
+                "Closing transactions were not persisted to disk."
+            )
+
+            # Equity accounts are created by close-books. If they are missing or
+            # zero, the closing entry was not saved.
+            cad_equity = get_balance(repo, "Equity:Retained Earnings:CAD", CLOSING_DATE)
+            assert cad_equity == -CAD_NET_INCOME, (
+                f"Equity:Retained Earnings:CAD = {cad_equity}, "
+                f"expected {-CAD_NET_INCOME}. Disk not updated."
+            )
+
+            usd_equity = get_balance(repo, "Equity:Retained Earnings:USD", CLOSING_DATE)
+            assert usd_equity == -USD_NET_INCOME, (
+                f"Equity:Retained Earnings:USD = {usd_equity}, "
+                f"expected {-USD_NET_INCOME}. Disk not updated."
+            )
+        finally:
+            repo.close()


### PR DESCRIPTION
Two test gaps identified where tests only verified in-memory state, not whether writes survived session close (repo.save() actually called and file updated on disk).

Gap 1 — account-balance --fx-rates pricedb persistence All existing tests pass --fx-rates and verify the CLI output, but the output is computed from in-memory YAML rates in the same session. If repo.save() were silently skipped, every test would still pass. TestAccountBalancePricedbPersistence adds:
  test_fx_rates_written_to_pricedb_on_disk
  - Sleeps 1s to avoid same-second backup collision (fixture saves on setup; GnuCash refuses to overwrite without a backup → ERR_FILEIO_BACKUP_ERROR → pricedb not persisted if collision happens)
  - Runs account-balance --fx-rates via CLI
  - Opens fresh READ_ONLY session from disk
  - Queries gnc_pricedb_lookup_latest(pricedb, HKD, CAD)
  - Asserts the entry is not None

Gap 2 — close-books disk persistence
TestCloseSuccessCriteria / TestMultiCurrencyCorrectness open a repo, call use_case.execute(), call repo.save() manually, then check balances in the SAME session. They confirm accounting logic in memory but nothing re-opens from disk to prove the save persisted. TestCloseBooksDisks adds:
  test_closing_transactions_persist_to_disk
  - Runs close-books via CLI (its own repo.save())
  - Opens fresh READ_ONLY session from disk
  - Checks Income:Salary:Base and Income:Freelance are zero
  - Checks Equity:Retained Earnings:CAD = -5850 and :USD = -400
  - Pre-close values would be non-zero if save was skipped