### PR TITLE
feat: statement import pipeline (F-005 to F-009)

### DIFF
--- a/docs/issues/F-005-data-models-and-provider-protocol.md
+++ b/docs/issues/F-005-data-models-and-provider-protocol.md
@@ -1,0 +1,61 @@
+---
+id: F-005
+title: "Statement import: data models and StatementProvider protocol"
+category: feature
+severity: high
+status: open
+branch: feature/statement-import-pipeline
+---
+
+## What to build
+
+`infrastructure/pdf/__init__.py` — package init (empty)
+
+`infrastructure/pdf/standard_tx.py`:
+- `Split` dataclass: `account: str`, `amount: Decimal`
+- `StandardTransaction` dataclass: `post_date: date`, `description: str`,
+  `currency: str`, `splits: list[Split]` (at least 2),
+  `source_pdfs: list[str]`, `guid: str | None = None`
+
+`infrastructure/pdf/provider.py`:
+- `StatementProvider` as `typing.Protocol` marked `@runtime_checkable`
+- Fields: `autopay_source: dict[str, str]`
+- Methods: `can_handle(filename: str) -> bool`, `parse(path: str) -> list[StandardTransaction]`
+
+No PDF parsing logic. No GnuCash types. Pure data model and interface contract.
+
+## Unit tests
+
+`tests/unit/infrastructure/test_standard_tx.py`:
+- `Split` constructed with `Decimal` — correct value stored
+- `Split` with `float` passed — dataclass does NOT coerce; test asserts
+  `not isinstance(split.amount, Decimal)` to document non-coercion behaviour
+  (implementor must add `__post_init__` or a validator if coercion is wanted)
+- `StandardTransaction` defaults: `guid is None`, `source_pdfs == []`
+  (use `field(default_factory=list)` for `source_pdfs` — bare `[]` is
+  rejected by Python dataclasses as a mutable default)
+- `StandardTransaction` with 3 splits constructs correctly (multi-category expense)
+- A concrete class satisfying `StatementProvider` fields and methods passes
+  `isinstance(provider, StatementProvider)`
+- A class missing `can_handle` fails the protocol check
+
+## Integration tests
+
+`tests/integration/infrastructure/test_standard_tx.py`:
+- `from infrastructure.pdf.standard_tx import StandardTransaction, Split` succeeds
+  inside Docker environment (catches import errors in GnuCash container)
+- `StandardTransaction` with CJK description (`"自動轉賬"`) — no encoding error
+  on construction or `repr()`
+
+## Acceptance
+
+All unit and integration tests pass. `Split.amount` is `Decimal` and
+`StatementProvider` is `runtime_checkable`.
+
+## Files
+
+- `infrastructure/pdf/__init__.py` (new)
+- `infrastructure/pdf/standard_tx.py` (new)
+- `infrastructure/pdf/provider.py` (new)
+- `tests/unit/infrastructure/test_standard_tx.py` (new)
+- `tests/integration/infrastructure/test_standard_tx.py` (new)

--- a/docs/issues/F-006-statement-reconciler.md
+++ b/docs/issues/F-006-statement-reconciler.md
@@ -1,0 +1,77 @@
+---
+id: F-006
+title: "Statement import: StatementReconciler"
+category: feature
+severity: high
+status: open
+branch: feature/statement-import-pipeline
+depends_on: F-005
+---
+
+## What to build
+
+`services/statement_reconciler.py` — `StatementReconciler` class.
+
+Matches `Reconcile:Autopay` placeholder pairs across a mixed list of
+`StandardTransaction` objects from different statement providers.
+
+**Interface:**
+```python
+class StatementReconciler:
+    def reconcile(
+        self, transactions: list[StandardTransaction]
+    ) -> tuple[
+        list[StandardTransaction],  # resolved (autopay pairs merged)
+        list[StandardTransaction],  # unresolved (Reconcile:Autopay still present)
+        list[StandardTransaction],  # normal (no Reconcile:Autopay involvement)
+    ]: ...
+```
+
+**Rules:**
+- Bank side: `Reconcile:Autopay` split has positive amount
+- Card side: `Reconcile:Autopay` split has negative amount
+- Match requires: same currency, `abs(amount)` equal, date within ±1 day
+- Merged tx: card-side date/description, `source_pdfs=[card_pdf, bank_pdf]`
+- All collision cases (same-side or cross-side) → all involved entries unresolved
+- Normal transactions: pass through unchanged
+
+## Unit tests
+
+`tests/unit/services/test_statement_reconciler.py` — inputs are hardcoded
+`StandardTransaction` objects, no PDF files:
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_clean_match` | bank +247.10 HKD + card -247.10 HKD, same day | 1 resolved, 0 unresolved |
+| `test_merged_card_wins` | clean match | description, date from card side |
+| `test_merged_source_pdfs` | clean match | `source_pdfs == [card_pdf, bank_pdf]` |
+| `test_date_plus_one` | bank day 14, card day 15 | resolved |
+| `test_date_minus_one` | bank day 15, card day 14 | resolved |
+| `test_date_plus_two` | bank day 13, card day 15 | both unresolved |
+| `test_partial_run_bank_only` | bank entry, no card | unresolved |
+| `test_partial_run_card_only` | card entry, no bank | unresolved |
+| `test_same_side_collision` | two bank entries same amount ±1 day | both unresolved |
+| `test_cross_side_collision` | one bank + two card entries same amount | all three unresolved |
+| `test_currency_mismatch` | bank HKD + card CNY | both unresolved |
+| `test_normal_passthrough` | tx without `Reconcile:Autopay` | in normal list unchanged |
+| `test_mixed_batch` | 2 normal + 1 autopay pair + 1 unresolved | correct counts all 3 buckets |
+| `test_cny_match` | bank CNY 312.99 + card CNY 312.99 | resolved with CNY currency |
+
+## Integration tests
+
+`tests/integration/services/test_statement_reconciler.py`:
+
+- **Realistic month simulation**: 3 autopay pairs (BOCHK→BOCI-0012,
+  BOCHK→BOCI-0113, BOCHK→AEON) + 5 normal transactions hardcoded as
+  `StandardTransaction` objects → verify 3 resolved, 0 unresolved, 5 normal
+
+## Acceptance
+
+All unit tests pass. The realistic month simulation produces exactly 3 resolved
+transactions with no `Reconcile:Autopay` in any resolved split.
+
+## Files
+
+- `services/statement_reconciler.py` (new)
+- `tests/unit/services/test_statement_reconciler.py` (new)
+- `tests/integration/services/test_statement_reconciler.py` (new)

--- a/docs/issues/F-007-writer-and-preview-reader.md
+++ b/docs/issues/F-007-writer-and-preview-reader.md
@@ -54,11 +54,9 @@ Output Format section):
 	Assets:...:BOC HKD Saving 18110.00 HKD
 	Income:Salary:HKD -18110.00 HKD
 
-;; For merged autopay transactions where source_pdfs has 2 entries:
-;; doc_link uses source_pdfs[0] (card PDF); source_pdfs[1] (bank PDF)
-;; is stored as a second metadata line:
+;; For merged autopay transactions, doc_link = source_pdfs[0] (card PDF).
+;; The card statement contains more transaction detail than the bank statement.
 ;;   doc_link: "bank_statements/boci-0012-2026-04.pdf"
-;;   doc_link_bank: "bank_statements/bochk-2026-04.pdf"
 
 ;; ===== UNRESOLVED =====
 

--- a/docs/issues/F-007-writer-and-preview-reader.md
+++ b/docs/issues/F-007-writer-and-preview-reader.md
@@ -1,0 +1,122 @@
+---
+id: F-007
+title: "Statement import: ReconcilePreviewWriter and ReconcilePreviewReader"
+category: feature
+severity: high
+status: open
+branch: feature/statement-import-pipeline
+depends_on: F-006
+---
+
+## What to build
+
+`services/reconcile_preview_writer.py` — writes `_reconcile.txt` from the
+three output buckets of `StatementReconciler`.
+
+`services/reconcile_preview_reader.py` — reads `_reconcile.txt` back into
+`(resolved, unresolved)` buckets for Phase 2. Does NOT use `PlaintextParser`.
+
+**Writer interface:**
+```python
+class ReconcilePreviewWriter:
+    DOC_LINK_BASE: str = "bank_statements"
+
+    def write(
+        self,
+        path: str,
+        resolved: list[StandardTransaction],
+        unresolved: list[StandardTransaction],
+        normal: list[StandardTransaction],
+    ) -> None: ...
+```
+
+**Reader interface:**
+```python
+class ReconcilePreviewReader:
+    def read(self, path: str) -> tuple[
+        list[StandardTransaction],  # importable — no Reconcile:Autopay
+                                    # (includes both resolved autopay and
+                                    #  normal transactions — both feed into
+                                    #  GnuCashFuzzyMatcher identically)
+        list[StandardTransaction],  # unresolved — contain Reconcile:Autopay
+    ]: ...
+```
+
+**`_reconcile.txt` format** (full annotated example in `docs/statement-import-pipeline.md`
+Output Format section):
+```
+;; ===== RESOLVED =====
+;; bochk-2026-04.pdf
+
+2026-03-29 * "薪金入賬 / FPS/JUNTECH..."
+	doc_link: "bank_statements/bochk-2026-04.pdf"
+	currency.mnemonic: "HKD"
+	Assets:...:BOC HKD Saving 18110.00 HKD
+	Income:Salary:HKD -18110.00 HKD
+
+;; For merged autopay transactions where source_pdfs has 2 entries:
+;; doc_link uses source_pdfs[0] (card PDF); source_pdfs[1] (bank PDF)
+;; is stored as a second metadata line:
+;;   doc_link: "bank_statements/boci-0012-2026-04.pdf"
+;;   doc_link_bank: "bank_statements/bochk-2026-04.pdf"
+
+;; ===== UNRESOLVED =====
+
+2026-04-02 * "自動轉賬 / BOC CREDIT CARD (INT"
+	...
+	Reconcile:Autopay 125.00 HKD
+```
+
+**Reader parsing contract:**
+- All `;;` lines skipped (section headers are `;;` lines — also skipped)
+- Transaction block: starts with date line `YYYY-MM-DD * "..."`, followed by
+  tab-indented metadata and split lines, terminated by blank line
+- Classification by account name only: any split account == `"Reconcile:Autopay"` → unresolved;
+  all others (resolved autopay AND normal) → importable. The two are indistinguishable
+  after serialization and both feed into GnuCashFuzzyMatcher identically.
+- Section position has no effect on classification
+- File written with UTF-8; read with UTF-8
+
+## Unit tests
+
+`tests/unit/services/test_reconcile_preview_reader.py`:
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_round_trip_resolved` | write resolved tx → read | same `StandardTransaction` in importable list |
+| `test_round_trip_unresolved` | write unresolved tx → read | same tx in unresolved list |
+| `test_section_position_irrelevant` | unresolved tx written under RESOLVED header | still in unresolved |
+| `test_comment_lines_skipped` | `;;` header lines | not leaked into any tx field |
+| `test_empty_file` | empty `_reconcile.txt` | returns `([], [])` |
+| `test_normal_tx_in_importable` | write normal tx → read | tx in importable list, not dropped |
+| `test_importable_never_contains_autopay` | mixed write | importable list has no `Reconcile:Autopay` |
+| `test_doc_link_prefix` | write tx → read | `doc_link` contains `DOC_LINK_BASE` prefix |
+| `test_cjk_preserved` | tx with `"自動轉賬"` description | description unchanged after round-trip |
+| `test_three_splits_round_trip` | tx with 3 splits | all splits preserved |
+| `test_guid_round_trip` | tx with `guid="abc123"` | guid preserved |
+
+## Integration tests
+
+`tests/integration/services/test_reconcile_preview_reader.py`:
+
+- **Full pipeline round-trip**: `StatementReconciler.reconcile()` →
+  `ReconcilePreviewWriter.write()` → `ReconcilePreviewReader.read()` →
+  verify `len(importable) + len(unresolved)` equals total transactions written
+  (no transaction silently dropped)
+- **CJK UTF-8 on disk**: write file with CJK in Docker environment, read back —
+  no encoding error, characters identical
+- **Resolved section parseable**: take reader's resolved output, serialize to
+  plaintext, feed into existing `PlaintextParser` — parses without error
+
+## Acceptance
+
+Round-trip test passes: `len(importable) + len(unresolved)` returned by the
+reader equals the total transactions written. No transaction is silently
+dropped. Importable list contains no `Reconcile:Autopay` account.
+
+## Files
+
+- `services/reconcile_preview_writer.py` (new)
+- `services/reconcile_preview_reader.py` (new)
+- `tests/unit/services/test_reconcile_preview_reader.py` (new)
+- `tests/integration/services/test_reconcile_preview_reader.py` (new)

--- a/docs/issues/F-008-gnucash-fuzzy-matcher.md
+++ b/docs/issues/F-008-gnucash-fuzzy-matcher.md
@@ -117,3 +117,60 @@ that uses GnuCash's category and the generated `doc_link`.
 - `services/gnucash_fuzzy_matcher.py` (new)
 - `tests/unit/services/test_gnucash_fuzzy_matcher.py` (new)
 - `tests/integration/services/test_gnucash_fuzzy_matcher.py` (new)
+
+---
+
+## Implementation Finding: Session Leak Causes OOM
+
+**Discovered during implementation of F-008.**
+
+### Root Cause
+
+`GnuCashFuzzyMatcher._build_index()` opens a `GnuCashRepository` session
+(READ_ONLY) that is **never closed**. `self._index` holds live
+`gnucash.Transaction` references, keeping the entire parsed GnuCash book in
+memory for the lifetime of the matcher object.
+
+Python's GC does not guarantee timely destruction of GnuCash C extension
+objects. In the test suite, each integration test that creates a
+`GnuCashFuzzyMatcher` and calls `match()` opens a new session. With 9
+integration tests running in sequence, 9 open sessions accumulate on top of
+the ~700-test suite's existing GnuCash sessions → OOM kill inside Docker.
+
+### Fix Required Before Implementation Is Complete
+
+Store Python-native data in the index instead of live `gnucash.Transaction`
+references, then close the session after `_build_index()` completes:
+
+```python
+@dataclass
+class _IndexEntry:
+    date: date
+    amount: Decimal
+    account_names: frozenset[str]   # extracted as strings, not GnuCash objects
+    guid: str
+    description: str
+    splits: list[tuple[str, Decimal]]  # (account_name, amount)
+    existing_doc_link: str
+
+def _build_index(self) -> None:
+    ...
+    repo.open(READ_ONLY)
+    for tx in repo.get_all_transactions():
+        entry = _IndexEntry(...)   # extract all needed data
+        self._index[key].append(entry)
+    repo.close()   # ← session released; no live GnuCash refs remain
+```
+
+`MatchResult.existing_tx` type changes from `gnucash.Transaction | None`
+to `_IndexEntry | None` — the live GnuCash object is no longer needed after
+index build since all required data is extracted.
+
+### Impact on Tests
+
+PARTIAL_MATCH fixture: the existing transaction must be a credit card charge
+`boci → dining` (expense account), NOT `boci → bank` (two asset/liability
+accounts). With `boci → bank`, `existing_al = {boci, bank}` but
+`candidate_al = {boci}` — they never match and PARTIAL_MATCH returns NEW.
+The correct scenario: user manually categorized the charge as Dining;
+we generated it as Groceries; shared `boci` liability account triggers match.

--- a/docs/issues/F-008-gnucash-fuzzy-matcher.md
+++ b/docs/issues/F-008-gnucash-fuzzy-matcher.md
@@ -1,0 +1,119 @@
+---
+id: F-008
+title: "Statement import: GnuCashFuzzyMatcher"
+category: feature
+severity: high
+status: open
+branch: feature/statement-import-pipeline
+depends_on: F-007
+---
+
+## What to build
+
+`services/gnucash_fuzzy_matcher.py`:
+- `MatchStatus` enum: `NEW`, `LIKELY_DUP`, `PARTIAL_MATCH`
+- `MatchResult` dataclass: `status`, `existing_tx: gnucash.Transaction | None`,
+  `merged_tx: StandardTransaction | None`
+- `GnuCashFuzzyMatcher` class
+
+**Interface:**
+```python
+class GnuCashFuzzyMatcher:
+    def __init__(self, repo: GnuCashRepository) -> None: ...
+    def match(
+        self, tx: StandardTransaction
+    ) -> MatchResult: ...
+```
+
+**Algorithm (from design doc):**
+- Amount normalization: `sum(s.amount for s in tx.splits if s.amount > 0)`
+  (same rule on both candidate and GnuCash index sides).
+  **Guard**: if normalized amount is `Decimal(0)` (all-negative or zero-amount
+  splits — e.g. a full refund), skip index lookup and return `MatchStatus.NEW`
+  rather than matching every zero-amount transaction in the book.
+- Index: `dict[tuple[date, Decimal], list[gnucash.Transaction]]`
+- ±1 day probe: collect all candidates from `date-1`, `date`, `date+1` keys
+- **Multi-bucket collision rule**: if multiple GnuCash candidates are found
+  across the three keys, prefer exact-date match first, then ±1 day.
+  If still multiple after date preference, pick the one with the most
+  matching account names. If still tied, return the candidate with the
+  earliest post date ascending — deterministic because GnuCash preserves
+  insertion order in its transaction list.
+  This avoids silent wrong merges while keeping the common case simple.
+- LIKELY_DUP: all split account name sets match exactly
+- PARTIAL_MATCH: the set of asset/liability accounts (by `account.GetType()`)
+  matches exactly between candidate and GnuCash tx, AND the set of
+  income/expense accounts differs (at least one account differs). For 3+ split
+  transactions: if *any* income/expense account differs → PARTIAL_MATCH,
+  regardless of whether other income/expense accounts match.
+  `merged_tx` populated using merge rules.
+- NEW: no match found → `merged_tx is None`, `existing_tx is None`
+
+**Merge rules for PARTIAL_MATCH** (`merged_tx`):
+- `guid`: use `transaction.GetGUID().to_string()` — do NOT use `str()` directly
+  on the GUID object as it may not produce the canonical format. Check
+  existing usages in `repositories/gnucash_repository.py` for the project's
+  established GUID-to-string pattern.
+- Account categorization from GnuCash
+- `doc_link`: from generated tx. To check if GnuCash tx has an existing
+  doc_link, read the `doc_link` KVP slot via the existing `kvp.py`
+  infrastructure (`read_tx_metadata(tx).get("doc_link")`).
+- Description from GnuCash unless empty
+- Date from GnuCash
+- Amount from GnuCash
+
+Uses `GnuCashRepository(path, SessionMode.READ_ONLY)` — no writes.
+
+## Unit tests
+
+`tests/unit/services/test_gnucash_fuzzy_matcher.py` — mock `GnuCashRepository`:
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_amount_normalization_2split` | `[+100, -100]` | normalized = 100 |
+| `test_amount_normalization_3split` | `[+300, -200, -100]` | normalized = 300 |
+| `test_amount_normalization_zero_guard` | all-negative splits (refund) | `MatchStatus.NEW`, no index lookup |
+| `test_three_key_probe` | verify index probed at date-1, date, date+1 | 3 calls to mock |
+| `test_new_no_candidates` | mock returns empty for all three keys | `MatchStatus.NEW` |
+| `test_likely_dup_account_sets_equal` | mock returns tx with identical accounts | `MatchStatus.LIKELY_DUP` |
+| `test_partial_match_expense_differs` | same bank account, different expense | `MatchStatus.PARTIAL_MATCH` |
+| `test_tiebreak_exact_date_beats_near` | two candidates: one exact date, one ±1 day | exact-date candidate chosen |
+| `test_tiebreak_most_matching_accounts` | two ±1-day candidates: one shares 2 accounts, one shares 1 | 2-account candidate chosen |
+| `test_tiebreak_earliest_date` | two ±1-day candidates with equal account matches | candidate with earlier post date chosen |
+| `test_merged_tx_guid` | PARTIAL_MATCH | `merged_tx.guid == existing_tx.GetGUID().to_string()` |
+| `test_merged_tx_category_gnucash_wins` | GnuCash has Dining, generated has Misc | `merged_tx` has Dining |
+| `test_merged_tx_doc_link_generated_wins` | GnuCash no doc_link, generated has one | `merged_tx` has generated doc_link |
+| `test_merged_tx_none_for_new` | NEW result | `merged_tx is None` |
+| `test_merged_tx_none_for_likely_dup` | LIKELY_DUP result | `merged_tx is None` |
+| `test_existing_tx_none_for_new` | NEW result | `existing_tx is None` |
+
+## Integration tests
+
+`tests/integration/services/test_gnucash_fuzzy_matcher.py` — real temp `.gnucash` book:
+
+| Test | Fixture contains | Candidate | Expected |
+|---|---|---|---|
+| `test_new` | nothing matching | salary 18110 HKD | `NEW` |
+| `test_likely_dup_exact_date` | identical tx | same tx | `LIKELY_DUP` |
+| `test_likely_dup_plus_one_day` | tx at date-1 | same amount+accounts | `LIKELY_DUP` |
+| `test_likely_dup_minus_one_day` | tx at date+1 | same amount+accounts | `LIKELY_DUP` |
+| `test_two_days_away_is_new` | tx at date-2 | same amount+accounts | `NEW` |
+| `test_partial_match` | same bank account, Dining expense | generated has Misc | `PARTIAL_MATCH` |
+| `test_partial_match_guid` | PARTIAL_MATCH | — | `merged_tx.guid` matches book tx |
+| `test_partial_match_gnucash_category` | GnuCash has Dining | — | `merged_tx` splits include Dining |
+| `test_partial_match_generated_doc_link` | GnuCash tx has no doc_link | generated has one | `merged_tx` has generated doc_link |
+| `test_multi_split_normalization` | 3-split tx in book | same total | `LIKELY_DUP` |
+| `test_custom_account_type_detection` | custom account hierarchy | `GetType()` used | PARTIAL_MATCH correct |
+
+## Acceptance
+
+All integration tests pass inside Docker. A `StandardTransaction` that matches
+an existing GnuCash transaction by (date ±1, amount, accounts) is correctly
+classified as `LIKELY_DUP` or `PARTIAL_MATCH` with a populated `merged_tx`
+that uses GnuCash's category and the generated `doc_link`.
+
+## Files
+
+- `services/gnucash_fuzzy_matcher.py` (new)
+- `tests/unit/services/test_gnucash_fuzzy_matcher.py` (new)
+- `tests/integration/services/test_gnucash_fuzzy_matcher.py` (new)

--- a/docs/issues/F-009-ready-to-import-writer.md
+++ b/docs/issues/F-009-ready-to-import-writer.md
@@ -1,0 +1,84 @@
+---
+id: F-009
+title: "Statement import: ReadyToImportWriter and end-to-end pipeline test"
+category: feature
+severity: high
+status: open
+branch: feature/statement-import-pipeline
+depends_on: F-008
+---
+
+## What to build
+
+`services/ready_to_import_writer.py` — takes the four buckets produced by
+`GnuCashFuzzyMatcher` + `ReconcilePreviewReader` and writes `ready-to-import.txt`.
+
+**Interface:**
+```python
+class ReadyToImportWriter:
+    DOC_LINK_BASE: str = "bank_statements"
+
+    def write(
+        self,
+        path: str,
+        new: list[StandardTransaction],
+        likely_dup: list[MatchResult],
+        partial_match: list[MatchResult],
+        unresolved: list[StandardTransaction],
+    ) -> None: ...
+```
+
+**Output rules:**
+- `new`: written as live importable blocks under `===== NEW =====`
+- `likely_dup`: fully commented under `===== LIKELY DUPLICATE =====`
+- `partial_match`: EXISTING + GENERATED commented, SUGGESTED MERGE live
+  (with `guid` from `merged_tx`) under `===== PARTIAL MATCH =====`
+- `unresolved`: fully commented with `[UNRESOLVED — DO NOT IMPORT]` header
+- **Safety invariant**: no live block anywhere contains `Reconcile:Autopay`
+
+## Unit tests
+
+`tests/unit/services/test_ready_to_import_writer.py`:
+
+| Test | Scenario | Expected |
+|---|---|---|
+| `test_new_section_live_block` | one NEW tx | uncommented date line in output |
+| `test_likely_dup_fully_commented` | one LIKELY_DUP | every line starts with `;;` |
+| `test_partial_match_structure` | one PARTIAL_MATCH | EXISTING commented, GENERATED commented, SUGGESTED MERGE live |
+| `test_partial_match_guid_in_merge` | PARTIAL_MATCH with guid | `guid:` line in live merge block |
+| `test_partial_match_gnucash_category` | PARTIAL_MATCH | live block has GnuCash expense account |
+| `test_partial_match_generated_doc_link` | PARTIAL_MATCH | live block has generated doc_link |
+| `test_unresolved_do_not_import` | one UNRESOLVED | `[UNRESOLVED — DO NOT IMPORT]` in output |
+| `test_unresolved_fully_commented` | one UNRESOLVED | every line starts with `;;` |
+| `test_no_live_reconcile_autopay` | mix of all buckets | no live line contains `Reconcile:Autopay` |
+| `test_doc_link_prefix` | NEW tx | `doc_link: "bank_statements/..."` |
+| `test_cjk_in_output` | tx with `"自動轉賬"` | CJK preserved in written file |
+| `test_empty_all_buckets` | all empty | valid file with empty sections, no error |
+
+## Integration tests
+
+`tests/integration/services/test_ready_to_import_writer.py`:
+
+- **NEW section parseable**: take written NEW section, feed into existing
+  `PlaintextParser` — parses without error, produces expected tx count
+- **End-to-end pipeline**: hardcoded `StandardTransaction` list →
+  `StatementReconciler` → `ReconcilePreviewWriter` → `ReconcilePreviewReader`
+  → `GnuCashFuzzyMatcher` (temp book) → `ReadyToImportWriter` →
+  `ImportTransactionsUseCase` → verify transactions appear in GnuCash book
+- **Idempotency**: run the full pipeline twice on the same inputs → second run
+  produces no duplicates in GnuCash (`TransactionMatcher` catches them)
+- **PARTIAL_MATCH import updates not inserts**: re-import a SUGGESTED MERGE
+  block that has a `guid` → existing GnuCash tx updated, not duplicated
+
+## Acceptance
+
+End-to-end integration test passes: a set of hardcoded `StandardTransaction`
+objects flows through the full pipeline and lands correctly in a real GnuCash
+book, with no duplicates on re-run and no `Reconcile:Autopay` account written
+to the book at any point.
+
+## Files
+
+- `services/ready_to_import_writer.py` (new)
+- `tests/unit/services/test_ready_to_import_writer.py` (new)
+- `tests/integration/services/test_ready_to_import_writer.py` (new)

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -32,6 +32,11 @@ When a fix is merged, update `status: open` → `closed` in the file's frontmatt
 | [F-002](F-002-balance-sheet-command-missing.md) | No balance-sheet command | enhancement |
 | [F-003](F-003-export-date-range-filter-missing.md) | export command has no date-range filter | enhancement |
 | [F-004](F-004-no-search-find-transaction-command.md) | No search / find-transaction command | enhancement |
+| [F-005](F-005-data-models-and-provider-protocol.md) | Statement import: data models and StatementProvider protocol | feature |
+| [F-006](F-006-statement-reconciler.md) | Statement import: StatementReconciler (depends on F-005) | feature |
+| [F-007](F-007-writer-and-preview-reader.md) | Statement import: ReconcilePreviewWriter and ReconcilePreviewReader (depends on F-006) | feature |
+| [F-008](F-008-gnucash-fuzzy-matcher.md) | Statement import: GnuCashFuzzyMatcher (depends on F-007) | feature |
+| [F-009](F-009-ready-to-import-writer.md) | Statement import: ReadyToImportWriter and end-to-end test (depends on F-008) | feature |
 
 ## Quality
 

--- a/docs/statement-import-pipeline.md
+++ b/docs/statement-import-pipeline.md
@@ -1,0 +1,519 @@
+# Statement Import Pipeline — Design Document
+
+**Feature branch**: `feature/statement-import-pipeline`
+**Created**: 2026-05-01
+**Status**: Design approved, implementation pending
+
+---
+
+## Overview
+
+A pipeline for importing bank and credit card PDF statements into GnuCash,
+with cross-statement autopay reconciliation, fuzzy duplicate detection against
+an existing GnuCash book, and human-guided merge of conflicting information.
+
+The pipeline is split into two phases:
+
+- **Phase 1 (native Python, no GnuCash):** Parse PDFs → reconcile autopay
+  entries → write `_reconcile.txt` preview
+- **Phase 2 (GnuCash READ_ONLY):** Fuzzy-match against `.gnucash` file →
+  classify as NEW / LIKELY_DUP / PARTIAL_MATCH → write ready-to-import txt
+
+The ready-to-import txt feeds directly into the existing `import-transactions`
+pipeline, which performs exact-match deduplication as a final safety net.
+
+---
+
+## Motivation
+
+Banks such as BOCHK, BOCI (BOC Credit Card), and AEON HK do not provide QFX
+downloads. Their monthly PDF statements are the only machine-readable source.
+A provider-based PDF parser architecture allows each bank's format to be
+supported independently while sharing common reconciliation and dedup logic.
+
+---
+
+## Architecture
+
+### Component Overview
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                      PHASE 1 (native)                        │
+│                                                              │
+│  PDF files                                                   │
+│      ↓                                                       │
+│  StatementProvider.can_handle() / parse()                    │
+│  (one provider per bank format)                              │
+│      ↓                                                       │
+│  list[StandardTransaction]                                   │
+│      ↓                                                       │
+│  StatementReconciler.reconcile()                             │
+│  (match Reconcile:Autopay pairs across statements)           │
+│      ↓                                                       │
+│  _reconcile.txt  (preview — all transactions, status marked) │
+└──────────────────────────────────────────────────────────────┘
+                            ↓ human reviews
+┌──────────────────────────────────────────────────────────────┐
+│                      PHASE 2 (GnuCash READ_ONLY)             │
+│                                                              │
+│  _reconcile.txt + .gnucash file                              │
+│      ↓                                                       │
+│  GnuCashFuzzyMatcher (GnuCashRepository READ_ONLY)           │
+│  → NEW / LIKELY_DUP / PARTIAL_MATCH                          │
+│      ↓                                                       │
+│  ready-to-import.txt                                         │
+│  - NEW            → import as-is                             │
+│  - LIKELY_DUP     → commented out, note attached             │
+│  - PARTIAL_MATCH  → suggested merge shown, human edits       │
+└──────────────────────────────────────────────────────────────┘
+                            ↓
+┌──────────────────────────────────────────────────────────────┐
+│              EXISTING import-transactions pipeline            │
+│        (exact-match dedup via TransactionMatcher)            │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Data Models
+
+### `StandardTransaction`
+
+The common output format for all providers:
+
+```python
+@dataclass
+class StandardTransaction:
+    post_date: date
+    description: str
+    currency: str
+    splits: list[Split]          # at least 2; typically 2 for simple transactions,
+                                 # more for split expenses across multiple accounts
+    source_pdfs: list[str]       # filename(s) only — merged tx carries both sides
+    guid: str | None = None      # set from GnuCash on PARTIAL_MATCH merge so that
+                                 # re-import updates the existing tx (not insert)
+```
+
+```python
+@dataclass
+class Split:
+    account: str
+    amount: Decimal              # use Decimal, not float — float causes ULP mismatches
+                                 # in dict key lookups during fuzzy matching
+```
+
+`doc_link` paths are constructed by the **output writer** as
+`f"{DOC_LINK_BASE}/{source_pdfs[0]}"` — the path prefix is not stored in the
+data model. `DOC_LINK_BASE` is defined as a module-level constant in the
+public repo's output writer with a default value of `"bank_statements"`. The
+private orchestrator (`reconcile_boc.py`) may override it if needed. Using a
+fixed default ensures `_reconcile.txt` and `ready-to-import.txt` produce
+consistent `doc_link` paths across runs.
+
+`source_pdfs` ordering convention:
+- Single-source transaction: `source_pdfs = [pdf_filename]`
+- Merged autopay transaction: `source_pdfs = [card_pdf, bank_pdf]` — the
+  card-side PDF is always `[0]` (primary `doc_link`); the bank-side PDF is
+  `[1]`. The `StatementReconciler` is responsible for populating this order.
+
+`Reconcile:Autopay` is used as a placeholder account name when one side of a
+cross-statement payment is known but the other is not yet resolved.
+
+### `MatchResult`
+
+Returned by `GnuCashFuzzyMatcher` for each candidate transaction:
+
+```python
+@dataclass
+class MatchResult:
+    status: MatchStatus                        # NEW | LIKELY_DUP | PARTIAL_MATCH
+    existing_tx: gnucash.Transaction | None    # None only for NEW
+    merged_tx: StandardTransaction | None      # non-None only for PARTIAL_MATCH;
+                                               # None for NEW and LIKELY_DUP
+    # No confidence field — match status is deterministic, not probabilistic.
+```
+
+```python
+class MatchStatus(Enum):
+    NEW           = "new"          # not found in GnuCash
+    LIKELY_DUP    = "likely_dup"   # same date±1, amount, accounts
+    PARTIAL_MATCH = "partial"      # same date±1, amount; different category
+```
+
+---
+
+## New Public Repo Components
+
+### `infrastructure/pdf/provider.py` — `StatementProvider` Protocol
+
+```python
+class StatementProvider(Protocol):
+    autopay_source: dict[str, str]  # currency → bank account funding autopay
+                                    # e.g. {"HKD": "Assets:...:BOC HKD Saving"}
+    def can_handle(self, filename: str) -> bool: ...
+    def parse(self, path: str) -> list[StandardTransaction]: ...
+```
+
+Provider registration is explicit — the orchestrator (private script) lists
+which providers to try, in order. No dynamic discovery.
+
+### `infrastructure/pdf/standard_tx.py` — Data Classes
+
+`StandardTransaction` and `Split` only. These are pure data models shared
+between providers, the reconciler, and the output writer — no GnuCash-specific
+types.
+
+`MatchResult` and `MatchStatus` are defined in `services/gnucash_fuzzy_matcher.py`
+alongside the matcher that produces them. Keeping them there avoids an upward
+dependency from `infrastructure` onto the GnuCash binding type
+(`gnucash.Transaction`).
+
+### `services/statement_reconciler.py` — `StatementReconciler`
+
+Resolves `Reconcile:Autopay` placeholder pairs across statements.
+
+**Matching criteria:**
+- Both transactions have a `Reconcile:Autopay` split
+- One has `Reconcile:Autopay` as positive amount (bank side — debit from savings)
+- One has `Reconcile:Autopay` as negative amount (card side — credit to card)
+- Same currency
+- Date within ±1 day (timezone and travel tolerance)
+- Absolute amounts match exactly
+
+**On match:** produce one merged `StandardTransaction` (Phase 1 merge — no GnuCash
+involvement yet) using:
+- Date, description, doc_link from the card side (credit card statement is primary)
+- Bank account from the bank side
+- Card account from the card side
+
+Note: this Phase 1 date comes from the card statement. If this merged transaction
+later hits a Phase 2 PARTIAL_MATCH against an existing GnuCash entry, the merge
+rules table applies and GnuCash's date wins (timezone-corrected by the user).
+
+**Unmatched:** remain in output with `Reconcile:Autopay` still in place, clearly
+marked as `[UNRESOLVED]` — a signal that the corresponding statement PDF was
+not provided yet (partial run).
+
+**Autopay collision tie-break:** if the ±1 day window produces more than one
+match candidate on **either side** of the pairing, the reconciler does **not**
+auto-resolve. Both cases emit `[UNRESOLVED]`:
+
+- Same-side collision: two bank entries (or two card entries) for the same
+  amount within ±1 day → neither is matched
+- Cross-side collision: one bank entry matches two card entries from different
+  providers for the same amount within ±1 day → none of the three is matched
+
+Silent wrong merges are worse than visible failures. All collision cases must
+produce a human-readable `[UNRESOLVED]` comment identifying the conflicting
+entries so the user can resolve by narrowing the date range or inspecting the
+statements manually.
+
+### `services/reconcile_preview_reader.py` — `ReconcilePreviewReader`
+
+Reads `_reconcile.txt` and yields transactions for Phase 2. This is the
+Phase 1 → Phase 2 bridge. It does **not** use `PlaintextParser` — the
+annotation-heavy format of `_reconcile.txt` is incompatible.
+
+**Interface:**
+
+```python
+class ReconcilePreviewReader:
+    def read(self, path: str) -> tuple[
+        list[StandardTransaction],   # resolved — eligible for fuzzy match
+        list[StandardTransaction],   # unresolved — contain Reconcile:Autopay
+    ]: ...
+```
+
+**Parsing contract:**
+- Lines starting with `;;` are comments — skipped entirely, including section
+  headers (`===== RESOLVED =====`, `===== UNRESOLVED =====`). Section headers
+  are for human readability only; the reader does NOT use position within a
+  section to classify transactions.
+- Transaction blocks are the same format as `ready-to-import.txt` (date line,
+  tab-indented metadata and split lines).
+- A transaction is classified as **unresolved** if any split account equals
+  the literal string `Reconcile:Autopay`; otherwise **resolved**. This is
+  the sole classification criterion — not section position.
+
+**UNRESOLVED handling in Phase 2 — critical correctness rule:**
+
+UNRESOLVED transactions (those still containing `Reconcile:Autopay`) are
+**never passed to `GnuCashFuzzyMatcher`** and are **never written to
+`ready-to-import.txt`** as live transaction blocks. Importing a transaction
+with `Reconcile:Autopay` as an account would write a garbage split into the
+GnuCash book.
+
+Instead, each UNRESOLVED transaction is written to `ready-to-import.txt` as
+a fully commented-out block with a warning header:
+
+```
+;; [UNRESOLVED — DO NOT IMPORT]
+;; Missing statement: the other side of this autopay was not provided.
+;; Re-run with the missing PDF to resolve.
+;; 2026-04-02 * "自動轉賬 / BOC CREDIT CARD (INT"
+;;     doc_link: "bank_statements/bochk-2026-04.pdf"
+;;     ...
+;;     Reconcile:Autopay 125.00 HKD
+```
+
+---
+
+### `services/gnucash_fuzzy_matcher.py` — `GnuCashFuzzyMatcher`
+
+Uses `GnuCashRepository` in `SessionMode.READ_ONLY` — no GnuCash Python
+bindings quirks, no write risk.
+
+**Matching algorithm:**
+
+**Amount normalization (applied symmetrically on both sides):**
+
+For any balanced transaction, the sum of all positive splits equals the sum of
+all negative splits. Use the sum of positive splits as the canonical amount:
+
+```
+amount = sum(s for s in split_amounts if s > 0)
+```
+
+- **Candidate side**: `sum(s.amount for s in tx.splits if s.amount > Decimal(0))`
+- **GnuCash side**: `sum(Decimal(str(sp.GetAmount())) for sp in tx.GetSplitList() if sp.GetAmount() > 0)`
+
+This is consistent across both sides regardless of split count or ordering, and
+is the sole normalization rule used for index keys and lookup probes.
+
+**Current constraint:** multi-currency splits (where split amounts are in
+different currencies) are not yet supported. All splits are assumed to share
+the transaction's base currency.
+
+1. Load all existing GnuCash transactions into an index:
+   `dict[tuple[date, Decimal], list[gnucash.Transaction]]`
+   keyed by `(posted_date, normalized_amount)` using the rule above.
+2. For each candidate `StandardTransaction`:
+   a. Compute `amount` using the same normalization rule (sum of positive splits).
+   b. Look up index entries within ±1 day by probing three keys:
+      `index.get((date - 1day, amount), []) + index.get((date, amount), []) +
+      index.get((date + 1day, amount), [])`. A single dict lookup on exact date
+      would silently miss adjacent-day matches.
+   c. For each candidate GnuCash tx:
+      - **LIKELY_DUP**: all split account names match exactly (set equality
+        across both transactions' split account name lists) → skip on export
+      - **PARTIAL_MATCH**: the asset/liability split accounts match but at
+        least one income/expense account differs → produce merged suggestion.
+        Account type (Asset/Liability vs Income/Expense) is determined via
+        `account.GetType()` from the GnuCash Python bindings — not via name
+        prefix heuristics — to handle custom account hierarchies correctly.
+        For 3+ split transactions, "asset/liability accounts match" means the
+        set of accounts where `GetType()` is ASSET or LIABILITY is identical.
+      - No match → **NEW**
+
+**Why GnuCash Python bindings (READ_ONLY), not XML parsing:**
+- Handles gzip compression, XML schema versions, and encrypted books correctly
+- Provides typed account/transaction/split objects rather than raw XML nodes
+- `SessionMode.READ_ONLY` guarantees no writes
+- Consistent with the rest of the codebase
+
+---
+
+## Autopay Reconciliation Design
+
+### The Problem
+
+When a credit card autopay occurs, two statements record the same real-world
+payment from opposite perspectives:
+
+| Statement | What it records |
+|---|---|
+| Bank (BOCHK) | `Savings account -247.10 HKD` → `Reconcile:Autopay +247.10` |
+| Credit card (BOCI) | `BOCI-0012 +247.10 HKD` → `Reconcile:Autopay -247.10` |
+
+Both use `Reconcile:Autopay` as a placeholder. The reconciler finds these pairs
+and merges them into one correct double-entry transaction:
+
+```
+2026-04-15 * "AUTOPAY INGROUP"
+    doc_link: "bank_statements/boci-0012-2026-04.pdf"
+    currency.mnemonic: "HKD"
+    Liabilities:Credit Card:BOCI-0012        247.10 HKD
+    Assets:...:BOC HK:Savings:BOC HKD Saving -247.10 HKD
+```
+
+### Known Autopay Relationships (private provider config)
+
+Each provider declares which bank account funds its autopay, by currency:
+
+```python
+# BOCI credit card provider
+autopay_source = {
+    "HKD": "Assets:Current Assets:BOC HK:Savings:BOC HKD Saving",
+    "CNY": "Assets:Current Assets:BOC HK:Savings:BOC CNY Saving",
+}
+
+# AEON HK credit card provider
+autopay_source = {
+    "HKD": "Assets:Current Assets:BOC HK:Savings:BOC HKD Saving",
+}
+```
+
+This config lives in the private provider implementations, not the public repo.
+
+---
+
+## Merge Rules (PARTIAL_MATCH)
+
+When a generated transaction partially matches an existing GnuCash transaction,
+the suggested merge follows these rules:
+
+| Field | Winner | Rationale |
+|---|---|---|
+| `guid` | GnuCash | Enables UPDATE (not INSERT) on re-import |
+| Account categorization | GnuCash | Manually verified by user |
+| `doc_link` | Generated | GnuCash rarely has PDF statement links |
+| Description | GnuCash always, unless empty | Bank descriptions are longer but messier; user's GnuCash description is already cleaned up. Generated description is preserved in the commented `GENERATED` block for reference. |
+| Date | GnuCash | Timezone/travel-corrected by user |
+| Amount | GnuCash | Authoritative |
+
+The merged suggestion is output as an **uncommented, ready-to-import block**
+preceded by commented-out versions of both the existing and generated
+transactions for human review.
+
+---
+
+## Output Format
+
+### `_reconcile.txt` — Preview File
+
+Always written to the current directory. Always overwritten on each run —
+partial re-runs produce a fresh file. Named with a leading underscore to signal
+it is auto-generated and not a source file.
+
+**Note:** `_reconcile.txt` is **not** a valid plaintext import file. It
+contains section headers and status comments (`;; ===== RESOLVED =====`,
+`[UNRESOLVED]`, etc.) that the existing `PlaintextParser` does not handle.
+Phase 2 reads `_reconcile.txt` with a dedicated `ReconcilePreviewReader` that
+strips comments and section markers before passing transactions to
+`GnuCashFuzzyMatcher`. This reader is part of the new public repo components.
+
+Structure:
+```
+;; ===== RESOLVED =====
+;; Transactions where Reconcile:Autopay was matched across statements
+
+;; bochk-2026-04.pdf
+
+2026-03-29 * "薪金入賬 / FPS/JUNTECH LIMITED/..."
+    doc_link: "bank_statements/bochk-2026-04.pdf"
+    currency.mnemonic: "HKD"
+    Assets:Current Assets:BOC HK:Savings:BOC HKD Saving 18110.00 HKD
+    Income:Salary:HKD -18110.00 HKD
+
+;; boci-0012-2026-04.pdf
+
+2026-04-15 * "AUTOPAY INGROUP"
+    doc_link: "bank_statements/boci-0012-2026-04.pdf"
+    currency.mnemonic: "HKD"
+    Liabilities:Credit Card:BOCI-0012 247.10 HKD
+    Assets:Current Assets:BOC HK:Savings:BOC HKD Saving -247.10 HKD
+
+;; ===== UNRESOLVED =====
+;; Transactions still containing Reconcile:Autopay — re-run with missing PDF
+
+;; bochk-2026-04.pdf
+
+2026-04-02 * "自動轉賬 / BOC CREDIT CARD (INT"
+    doc_link: "bank_statements/bochk-2026-04.pdf"
+    currency.mnemonic: "HKD"
+    Assets:Current Assets:BOC HK:Savings:BOC HKD Saving -125.00 HKD
+    Reconcile:Autopay 125.00 HKD
+```
+
+### `ready-to-import.txt` — Final Output (`-o` flag)
+
+Structure:
+```
+;; ===== NEW — ready to import =====
+
+;; ===== PARTIAL MATCH — review merged suggestion =====
+;; EXISTING (GnuCash):
+;; 2026-04-15 * "AUTOPAY INGROUP"
+;;     guid: "abc123..."
+;;     Expenses-HK:Dining 247.10 HKD          ← manually categorized
+;;     ...
+;; GENERATED (statement):
+;; 2026-04-15 * "AUTOPAY INGROUP"
+;;     doc_link: "bank_statements/boci-0012-2026-04.pdf"
+;;     Expenses:Miscellaneous 247.10 HKD
+;;     ...
+;; SUGGESTED MERGE (edit if needed, then import):
+2026-04-15 * "AUTOPAY INGROUP"
+    guid: "abc123..."
+    doc_link: "bank_statements/boci-0012-2026-04.pdf"
+    ...
+
+;; ===== LIKELY DUPLICATE — already in GnuCash =====
+;; (commented out, no action needed)
+```
+
+---
+
+## Implementation Plan
+
+### New files (public repo)
+
+| File | Purpose |
+|---|---|
+| `infrastructure/pdf/__init__.py` | Package init |
+| `infrastructure/pdf/provider.py` | `StatementProvider` Protocol only |
+| `infrastructure/pdf/standard_tx.py` | `StandardTransaction`, `Split` data classes |
+| `services/statement_reconciler.py` | Cross-statement `Reconcile:Autopay` matching |
+| `services/gnucash_fuzzy_matcher.py` | `MatchResult`, `MatchStatus`; fuzzy match against GnuCash book (READ_ONLY) |
+| `services/reconcile_preview_reader.py` | Reads `_reconcile.txt`, strips annotations, yields `StandardTransaction` for Phase 2 |
+| `tests/unit/services/test_statement_reconciler.py` | Unit tests |
+| `tests/unit/services/test_reconcile_preview_reader.py` | Unit tests — parsing contract, UNRESOLVED detection, comment stripping |
+| `tests/unit/services/test_gnucash_fuzzy_matcher.py` | Unit tests |
+
+### Private scripts (not in public repo)
+
+| File | Purpose |
+|---|---|
+| `convert_bochk_pdf.py` | `StatementProvider` for BOCHK consolidated statement |
+| `convert_boci_pdf.py` | `StatementProvider` for BOCI credit card statement |
+| `convert_aeon_pdf.py` | `StatementProvider` for AEON HK credit card statement |
+| `reconcile_boc.py` | Orchestrator: registers providers, runs pipeline, writes output |
+
+### Existing components reused unchanged
+
+| Component | Role in pipeline |
+|---|---|
+| `GnuCashRepository(READ_ONLY)` | Read existing transactions for fuzzy match |
+| `TransactionMatcher` | Exact-match dedup in final import step |
+| `ConflictResolver` | Strategy application in final import step |
+| `PlaintextParser` | Reads `ready-to-import.txt` in final import step |
+| `ImportTransactionsUseCase` | Final import into GnuCash book |
+
+---
+
+## Implementation Notes
+
+### CJK Character Encoding
+
+BOCHK, BOCI, and AEON HK statements contain Chinese characters in merchant
+names (e.g. `财付通`, `自動轉賬`). `pdfplumber` uses `pdfminer` under the hood,
+which handles CJK glyph mapping correctly for these banks' PDFs. Implementors
+must ensure output files are written as UTF-8 explicitly (`open(..., encoding="utf-8")`).
+Do not rely on the system locale default.
+
+---
+
+## Open Questions
+
+- **Same-amount same-day collision in fuzzy match**: if two transactions have
+  the same date and amount but different accounts, both could be PARTIAL_MATCH
+  candidates for the same generated transaction. Current plan: flag all
+  candidates and let the user choose.
+- **Currency conversion splits**: AEON and BOCI statements include original
+  currency and rate in the description (e.g. `CNY 3.55(rate 1.149295)`). The
+  current design records only the HKD amount. A future enhancement could emit
+  proper multi-currency GnuCash splits with `share_price`.
+- **Encrypted GnuCash books**: `GnuCashRepository` in READ_ONLY mode should
+  handle encrypted books if the user supplies the passphrase. Not yet
+  investigated.

--- a/infrastructure/pdf/provider.py
+++ b/infrastructure/pdf/provider.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from infrastructure.pdf.standard_tx import StandardTransaction
+
+
+@runtime_checkable
+class StatementProvider(Protocol):
+    """Protocol for bank/credit-card PDF statement parsers.
+
+    autopay_source maps currency code to the GnuCash account path that funds
+    autopay for this card, e.g. {"HKD": "Assets:...:BOC HKD Saving"}.
+    Used by StatementReconciler to resolve Reconcile:Autopay placeholders.
+    """
+
+    autopay_source: dict[str, str]  # currency_code → funding_account_path
+
+    def can_handle(self, filename: str) -> bool: ...
+    def parse(self, path: str) -> list[StandardTransaction]: ...

--- a/infrastructure/pdf/standard_tx.py
+++ b/infrastructure/pdf/standard_tx.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+
+
+@dataclass
+class Split:
+    account: str
+    amount: Decimal
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.amount, Decimal):
+            raise TypeError(f"Split.amount must be Decimal, got {type(self.amount).__name__}")
+
+
+@dataclass
+class StandardTransaction:
+    post_date: date
+    description: str
+    currency: str
+    splits: list[Split]
+    source_pdfs: list[str] = field(default_factory=list)
+    guid: str | None = None
+
+    def __post_init__(self) -> None:
+        if len(self.splits) < 2:
+            raise ValueError("StandardTransaction requires at least 2 splits")
+        # Balance (splits summing to zero) is intentionally NOT enforced here.
+        # Transactions containing Reconcile:Autopay placeholders are deliberately
+        # unbalanced — they become balanced only after StatementReconciler merges
+        # the two sides of an autopay pair.

--- a/services/gnucash_fuzzy_matcher.py
+++ b/services/gnucash_fuzzy_matcher.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+from enum import Enum
+
+from infrastructure.pdf.standard_tx import Split, StandardTransaction
+
+# GnuCash imports are lazy (inside _build_index) to avoid loading the C
+# extension at module import time — unit tests must not trigger that load.
+
+
+class MatchStatus(Enum):
+    NEW = "new"
+    LIKELY_DUP = "likely_dup"
+    PARTIAL_MATCH = "partial"
+
+
+@dataclass
+class _IndexEntry:
+    """Python-native snapshot of a GnuCash transaction.
+
+    Extracted during _build_index() so the GnuCash session can be closed
+    immediately after indexing. No live GnuCash C-extension references remain
+    after index build — prevents session leak and OOM in the test suite.
+    """
+    post_date: date
+    amount: Decimal                          # sum of positive splits
+    account_names: frozenset[str]            # all split account full names
+    asset_liability_accounts: frozenset[str] # subset by account type
+    guid: str
+    description: str
+    splits: list[tuple[str, Decimal]]        # (account_name, signed_amount)
+    doc_link: str = ""
+
+
+@dataclass
+class MatchResult:
+    status: MatchStatus
+    existing: _IndexEntry | None   # None only for NEW
+    merged_tx: StandardTransaction | None  # non-None only for PARTIAL_MATCH
+
+
+class GnuCashFuzzyMatcher:
+    """Fuzzy-matches StandardTransaction candidates against an existing GnuCash book.
+
+    Opens GnuCashRepository READ_ONLY, extracts all transaction data into
+    Python-native _IndexEntry objects, then closes the session immediately.
+    No GnuCash C-extension references are kept after index build.
+    """
+
+    _ONE_DAY = timedelta(days=1)
+
+    def __init__(self, repo) -> None:
+        self._repo = repo
+        self._index: dict[tuple[date, Decimal], list[_IndexEntry]] = {}
+        self._built = False
+
+    def _build_index(self) -> None:
+        if self._built:
+            return
+
+        from infrastructure.gnucash.utils import gnc_numeric_to_fraction_or_decimal
+        from repositories.gnucash_repository import SessionMode
+
+        try:
+            import gnucash as gc
+            _al_types = {
+                gc.ACCT_TYPE_ASSET, gc.ACCT_TYPE_BANK, gc.ACCT_TYPE_CASH,
+                gc.ACCT_TYPE_CREDIT, gc.ACCT_TYPE_EQUITY, gc.ACCT_TYPE_LIABILITY,
+                gc.ACCT_TYPE_MUTUAL,
+            }
+        except Exception:
+            _al_types = set()
+
+        self._repo.open(mode=SessionMode.READ_ONLY)
+        try:
+            for tx in self._repo.get_all_transactions():
+                raw_splits = tx.GetSplitList()
+                splits_data: list[tuple[str, Decimal]] = []
+                al_accounts: set[str] = set()
+
+                for sp in raw_splits:
+                    acct = sp.GetAccount()
+                    name = _full_name(acct)
+                    amount = Decimal(gnc_numeric_to_fraction_or_decimal(sp.GetAmount()))
+                    splits_data.append((name, amount))
+                    try:
+                        if acct.GetType() in _al_types:
+                            al_accounts.add(name)
+                    except Exception:
+                        pass
+
+                positive = sum(a for _, a in splits_data if a > 0)
+                if positive <= Decimal(0):
+                    continue
+
+                d = tx.GetDate().date()
+                guid = tx.GetGUID().to_string()
+                desc = tx.GetDescription() or ""
+
+                # Extract doc_link from KVP metadata
+                from infrastructure.gnucash.kvp import get_custom_metadata
+                doc_link = get_custom_metadata(tx).get("doc_link", "")
+
+                entry = _IndexEntry(
+                    post_date=d,
+                    amount=positive,
+                    account_names=frozenset(n for n, _ in splits_data),
+                    asset_liability_accounts=frozenset(al_accounts),
+                    guid=guid,
+                    description=desc,
+                    splits=splits_data,
+                    doc_link=doc_link,
+                )
+                key = (d, positive)
+                self._index.setdefault(key, []).append(entry)
+        finally:
+            # Always close session — releases the entire GnuCash book from memory
+            with contextlib.suppress(Exception):
+                self._repo.session.end()
+
+        self._built = True
+
+    def match(self, tx: StandardTransaction) -> MatchResult:
+        self._build_index()
+
+        positive = sum(s.amount for s in tx.splits if s.amount > Decimal(0))
+        if positive <= Decimal(0):
+            return MatchResult(status=MatchStatus.NEW, existing=None, merged_tx=None)
+
+        d = tx.post_date
+        candidates: list[_IndexEntry] = (
+            self._index.get((d - self._ONE_DAY, positive), [])
+            + self._index.get((d, positive), [])
+            + self._index.get((d + self._ONE_DAY, positive), [])
+        )
+
+        if not candidates:
+            return MatchResult(status=MatchStatus.NEW, existing=None, merged_tx=None)
+
+        best = _pick_best(candidates, tx, d)
+        candidate_accounts = frozenset(s.account for s in tx.splits)
+
+        if best.account_names == candidate_accounts:
+            return MatchResult(status=MatchStatus.LIKELY_DUP, existing=best, merged_tx=None)
+
+        candidate_al = frozenset(
+            s.account for s in tx.splits
+            if s.account in best.asset_liability_accounts
+        )
+
+        if best.asset_liability_accounts == candidate_al:
+            merged = _build_merge(tx, best)
+            return MatchResult(status=MatchStatus.PARTIAL_MATCH, existing=best, merged_tx=merged)
+
+        return MatchResult(status=MatchStatus.NEW, existing=None, merged_tx=None)
+
+
+def _full_name(acct) -> str:
+    parts = []
+    a = acct
+    while a is not None:
+        name = a.GetName()
+        if not name or name == "Root Account":
+            break
+        parts.append(name)
+        a = a.get_parent()
+    return ":".join(reversed(parts))
+
+
+def _pick_best(candidates: list[_IndexEntry], tx: StandardTransaction, target: date) -> _IndexEntry:
+    """Choose best candidate: exact date > most shared accounts > earliest date."""
+    candidate_accounts = {s.account for s in tx.splits}
+
+    def score(e: _IndexEntry) -> tuple:
+        date_score = 0 if e.post_date == target else 1
+        shared = len(e.account_names & candidate_accounts)
+        return (date_score, -shared, e.post_date)
+
+    return min(candidates, key=score)
+
+
+def _build_merge(candidate: StandardTransaction, existing: _IndexEntry) -> StandardTransaction:
+    """Produce merged StandardTransaction for PARTIAL_MATCH.
+
+    Merge rules: GnuCash category/date/guid/amount win; generated doc_link wins.
+    """
+    description = existing.description if existing.description.strip() else candidate.description
+
+    splits = [Split(account=name, amount=amount) for name, amount in existing.splits]
+
+    doc_link_pdf = candidate.source_pdfs[0] if candidate.source_pdfs else ""
+    if not doc_link_pdf and existing.doc_link:
+        doc_link_pdf = existing.doc_link.split("/")[-1]
+
+    source_pdfs = [doc_link_pdf] if doc_link_pdf else []
+    if len(candidate.source_pdfs) > 1:
+        source_pdfs.append(candidate.source_pdfs[1])
+
+    return StandardTransaction(
+        post_date=existing.post_date,
+        description=description,
+        currency=candidate.currency,
+        splits=splits,
+        source_pdfs=source_pdfs,
+        guid=existing.guid,
+    )

--- a/services/ready_to_import_writer.py
+++ b/services/ready_to_import_writer.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from infrastructure.pdf.standard_tx import Split, StandardTransaction
+from services.gnucash_fuzzy_matcher import MatchResult, MatchStatus
+from services.reconcile_preview_writer import DOC_LINK_BASE
+
+AUTOPAY_ACCOUNT = "Reconcile:Autopay"
+
+
+class ReadyToImportWriter:
+    """Writes ready-to-import.txt from the four output buckets.
+
+    Sections:
+    - NEW: live importable blocks
+    - PARTIAL_MATCH: EXISTING + GENERATED commented; SUGGESTED MERGE live with guid
+    - LIKELY_DUP: fully commented (already in GnuCash, no action needed)
+    - UNRESOLVED: [DO NOT IMPORT] header, fully commented
+    """
+
+    doc_link_base: str = DOC_LINK_BASE
+
+    def write(
+        self,
+        path: str,
+        new: list[StandardTransaction],
+        likely_dup: list[MatchResult],
+        partial_match: list[MatchResult],
+        unresolved: list[StandardTransaction],
+    ) -> None:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(";; ===== NEW — ready to import =====\n\n")
+            for tx in new:
+                _assert_no_autopay(tx)
+                _write_live(f, tx, self.doc_link_base)
+
+            f.write(";; ===== PARTIAL MATCH — review merged suggestion =====\n\n")
+            for result in partial_match:
+                if result.status != MatchStatus.PARTIAL_MATCH:
+                    raise ValueError(f"Expected PARTIAL_MATCH, got {result.status}")
+                if result.existing is None or result.merged_tx is None:
+                    raise ValueError("PARTIAL_MATCH result must have existing and merged_tx")
+                _assert_no_autopay(result.merged_tx)
+                _write_partial_match(f, result, self.doc_link_base)
+
+            f.write(";; ===== LIKELY DUPLICATE — already in GnuCash =====\n\n")
+            for result in likely_dup:
+                f.write(f";; LIKELY DUPLICATE — already in GnuCash (guid: {result.existing.guid})\n")
+                display_tx = StandardTransaction(
+                    post_date=result.existing.post_date,
+                    description=result.existing.description,
+                    currency="HKD",
+                    splits=[Split(a, amt) for a, amt in result.existing.splits],
+                    guid=result.existing.guid,
+                )
+                _write_commented_tx(f, display_tx, result.existing.doc_link or "", self.doc_link_base)
+                f.write("\n")
+
+            f.write(";; ===== UNRESOLVED — DO NOT IMPORT =====\n\n")
+            for tx in unresolved:
+                f.write(";; [UNRESOLVED — DO NOT IMPORT]\n")
+                f.write(";; Missing statement: the other side of this autopay was not provided.\n")
+                f.write(";; Re-run with the missing PDF to resolve.\n")
+                _write_commented_tx(f, tx, "", self.doc_link_base)
+                f.write("\n")
+
+
+def _assert_no_autopay(tx: StandardTransaction) -> None:
+    for split in tx.splits:
+        if split.account == AUTOPAY_ACCOUNT:
+            raise ValueError(
+                f"Transaction '{tx.description}' contains {AUTOPAY_ACCOUNT} "
+                f"— must not be written as a live importable block"
+            )
+
+
+def _write_live(f, tx: StandardTransaction, doc_link_base: str) -> None:
+    desc = tx.description.replace('"', '\\"')
+    f.write(f'{tx.post_date.strftime("%Y-%m-%d")} * "{desc}"\n')
+    if tx.guid:
+        f.write(f'\tguid: "{tx.guid}"\n')
+    if tx.source_pdfs:
+        f.write(f'\tdoc_link: "{doc_link_base}/{tx.source_pdfs[0]}"\n')
+    f.write(f'\tcurrency.mnemonic: "{tx.currency}"\n')
+    for split in tx.splits:
+        f.write(f'\t{split.account} {_fmt(split.amount)} {tx.currency}\n')
+    f.write("\n")
+
+
+def _write_commented_tx(
+    f, tx: StandardTransaction, explicit_doc_link: str, doc_link_base: str
+) -> None:
+    desc = tx.description.replace('"', '\\"')
+    f.write(f';; {tx.post_date.strftime("%Y-%m-%d")} * "{desc}"\n')
+    if tx.guid:
+        f.write(f';;     guid: "{tx.guid}"\n')
+    if explicit_doc_link:
+        f.write(f';;     doc_link: "{explicit_doc_link}"\n')
+    elif tx.source_pdfs:
+        f.write(f';;     doc_link: "{doc_link_base}/{tx.source_pdfs[0]}"\n')
+    f.write(f';;     currency.mnemonic: "{tx.currency}"\n')
+    for split in tx.splits:
+        f.write(f';;     {split.account} {_fmt(split.amount)} {tx.currency}\n')
+
+
+def _write_partial_match(f, result: MatchResult, doc_link_base: str) -> None:
+    existing = result.existing
+    merged = result.merged_tx
+    candidate_doc = (
+        f"{doc_link_base}/{merged.source_pdfs[0]}" if merged.source_pdfs else ""
+    )
+
+    existing_display = StandardTransaction(
+        post_date=existing.post_date,
+        description=existing.description,
+        currency=merged.currency,
+        splits=[Split(a, amt) for a, amt in existing.splits],
+        guid=existing.guid,
+    )
+    candidate_display = StandardTransaction(
+        post_date=merged.post_date,
+        description=merged.description,
+        currency=merged.currency,
+        splits=merged.splits,
+        source_pdfs=merged.source_pdfs,
+    )
+
+    f.write(";; EXISTING (GnuCash):\n")
+    _write_commented_tx(f, existing_display, existing.doc_link, doc_link_base)
+
+    f.write(";; GENERATED (statement):\n")
+    _write_commented_tx(f, candidate_display, candidate_doc, doc_link_base)
+
+    f.write(";; SUGGESTED MERGE (edit if needed, then import):\n")
+    _write_live(f, merged, doc_link_base)
+
+
+def _fmt(amount: Decimal) -> str:
+    return f"{amount:.2f}"

--- a/services/reconcile_preview_reader.py
+++ b/services/reconcile_preview_reader.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import re
+from datetime import date
+from decimal import Decimal
+
+from infrastructure.pdf.standard_tx import Split, StandardTransaction
+
+AUTOPAY_ACCOUNT = "Reconcile:Autopay"
+
+# Matches: YYYY-MM-DD * "description"
+DATE_LINE_RE = re.compile(r'^(\d{4}-\d{2}-\d{2})\s+\*\s+"(.*)"$')
+# Matches tab-indented key: "value"  or  key: value
+META_RE = re.compile(r'^\t(\S[^:]*?):\s+"?([^"]*)"?\s*$')
+# Matches tab-indented split: account amount currency
+SPLIT_RE = re.compile(r'^\t(\S.*?)\s+([-\d.]+)\s+([A-Z]+)\s*$')
+
+
+class ReconcilePreviewReader:
+    """Reads _reconcile.txt and classifies transactions by Reconcile:Autopay presence.
+
+    Returns (importable, unresolved):
+    - importable: all transactions without Reconcile:Autopay (resolved + normal)
+    - unresolved: transactions containing Reconcile:Autopay
+
+    Section headers (;; ===== ... =====) and all ;; comment lines are skipped.
+    Classification is by account name only — section position has no effect.
+    """
+
+    def read(
+        self, path: str
+    ) -> tuple[list[StandardTransaction], list[StandardTransaction]]:
+        importable: list[StandardTransaction] = []
+        unresolved: list[StandardTransaction] = []
+
+        with open(path, encoding="utf-8") as f:
+            lines = f.readlines()
+
+        pending = _parse_blocks(lines)
+        for tx in pending:
+            if any(s.account == AUTOPAY_ACCOUNT for s in tx.splits):
+                unresolved.append(tx)
+            else:
+                importable.append(tx)
+
+        return importable, unresolved
+
+
+def _parse_blocks(lines: list[str]) -> list[StandardTransaction]:
+    txs: list[StandardTransaction] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i].rstrip("\n")
+
+        # Skip comment lines (includes section headers)
+        if line.startswith(";;") or line.strip() == "":
+            i += 1
+            continue
+
+        m = DATE_LINE_RE.match(line)
+        if not m:
+            i += 1
+            continue
+
+        post_date = date.fromisoformat(m.group(1))
+        description = m.group(2).replace('\\"', '"')
+        guid = None
+        source_pdfs: list[str] = []
+        currency = "HKD"
+        splits: list[Split] = []
+
+        i += 1
+        while i < len(lines):
+            inner = lines[i].rstrip("\n")
+            if inner.strip() == "" or DATE_LINE_RE.match(inner) or inner.startswith(";;"):
+                break
+
+            meta = META_RE.match(inner)
+            if meta:
+                key, val = meta.group(1).strip(), meta.group(2).strip()
+                if key == "guid":
+                    guid = val
+                elif key == "doc_link":
+                    # Extract filename from "bank_statements/file.pdf"
+                    source_pdfs.insert(0, val.split("/")[-1])
+                elif key == "doc_link_bank":
+                    source_pdfs.append(val.split("/")[-1])
+                elif key == "currency.mnemonic":
+                    currency = val
+                i += 1
+                continue
+
+            split_m = SPLIT_RE.match(inner)
+            if split_m:
+                account = split_m.group(1).strip()
+                amount = Decimal(split_m.group(2))
+                splits.append(Split(account=account, amount=amount))
+                i += 1
+                continue
+
+            i += 1
+
+        if len(splits) >= 2:
+            txs.append(StandardTransaction(
+                post_date=post_date,
+                description=description,
+                currency=currency,
+                splits=splits,
+                source_pdfs=source_pdfs,
+                guid=guid,
+            ))
+
+    return txs

--- a/services/reconcile_preview_reader.py
+++ b/services/reconcile_preview_reader.py
@@ -83,8 +83,7 @@ def _parse_blocks(lines: list[str]) -> list[StandardTransaction]:
                 elif key == "doc_link":
                     # Extract filename from "bank_statements/file.pdf"
                     source_pdfs.insert(0, val.split("/")[-1])
-                elif key == "doc_link_bank":
-                    source_pdfs.append(val.split("/")[-1])
+
                 elif key == "currency.mnemonic":
                     currency = val
                 i += 1

--- a/services/reconcile_preview_writer.py
+++ b/services/reconcile_preview_writer.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from infrastructure.pdf.standard_tx import StandardTransaction
+
+AUTOPAY_ACCOUNT = "Reconcile:Autopay"
+DOC_LINK_BASE = "bank_statements"
+
+
+class ReconcilePreviewWriter:
+    """Writes _reconcile.txt from the three StatementReconciler output buckets.
+
+    Format:
+      - Section headers are ;; comment lines (human-readable, not parsed by reader)
+      - Transaction blocks: date line, tab-indented metadata and splits, blank line
+      - Two source PDFs (merged autopay): doc_link = source_pdfs[0] (card),
+        doc_link_bank = source_pdfs[1] (bank)
+    """
+
+    doc_link_base: str = DOC_LINK_BASE
+
+    def write(
+        self,
+        path: str,
+        resolved: list[StandardTransaction],
+        unresolved: list[StandardTransaction],
+        normal: list[StandardTransaction],
+    ) -> None:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(";; ===== RESOLVED =====\n")
+            f.write(";; Transactions where Reconcile:Autopay was matched across statements\n\n")
+            for tx in resolved:
+                _write_tx(f, tx, self.doc_link_base)
+
+            f.write(";; ===== NORMAL =====\n")
+            f.write(";; Regular transactions with no autopay involvement\n\n")
+            for tx in normal:
+                _write_tx(f, tx, self.doc_link_base)
+
+            f.write(";; ===== UNRESOLVED =====\n")
+            f.write(";; Transactions still containing Reconcile:Autopay — re-run with missing PDF\n\n")
+            for tx in unresolved:
+                _write_tx(f, tx, self.doc_link_base)
+
+
+def _write_tx(f, tx: StandardTransaction, doc_link_base: str) -> None:
+    desc = tx.description.replace('"', '\\"')
+    f.write(f'{tx.post_date.strftime("%Y-%m-%d")} * "{desc}"\n')
+
+    if tx.guid:
+        f.write(f'\tguid: "{tx.guid}"\n')
+
+    if tx.source_pdfs:
+        f.write(f'\tdoc_link: "{doc_link_base}/{tx.source_pdfs[0]}"\n')
+        if len(tx.source_pdfs) > 1:
+            f.write(f'\tdoc_link_bank: "{doc_link_base}/{tx.source_pdfs[1]}"\n')
+
+    f.write(f'\tcurrency.mnemonic: "{tx.currency}"\n')
+
+    for split in tx.splits:
+        amount_str = _format_amount(split.amount)
+        f.write(f'\t{split.account} {amount_str} {tx.currency}\n')
+
+    f.write("\n")
+
+
+def _format_amount(amount: Decimal) -> str:
+    return f"{amount:.2f}"

--- a/services/reconcile_preview_writer.py
+++ b/services/reconcile_preview_writer.py
@@ -14,8 +14,7 @@ class ReconcilePreviewWriter:
     Format:
       - Section headers are ;; comment lines (human-readable, not parsed by reader)
       - Transaction blocks: date line, tab-indented metadata and splits, blank line
-      - Two source PDFs (merged autopay): doc_link = source_pdfs[0] (card),
-        doc_link_bank = source_pdfs[1] (bank)
+      - doc_link uses source_pdfs[0] (card PDF for merged autopay, only PDF otherwise)
     """
 
     doc_link_base: str = DOC_LINK_BASE
@@ -53,8 +52,6 @@ def _write_tx(f, tx: StandardTransaction, doc_link_base: str) -> None:
 
     if tx.source_pdfs:
         f.write(f'\tdoc_link: "{doc_link_base}/{tx.source_pdfs[0]}"\n')
-        if len(tx.source_pdfs) > 1:
-            f.write(f'\tdoc_link_bank: "{doc_link_base}/{tx.source_pdfs[1]}"\n')
 
     f.write(f'\tcurrency.mnemonic: "{tx.currency}"\n')
 

--- a/services/statement_reconciler.py
+++ b/services/statement_reconciler.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+
+from infrastructure.pdf.standard_tx import Split, StandardTransaction
+
+AUTOPAY_ACCOUNT = "Reconcile:Autopay"
+
+
+def _autopay_amount(tx: StandardTransaction) -> Decimal | None:
+    """Return the signed Reconcile:Autopay split amount, or None if not present."""
+    for split in tx.splits:
+        if split.account == AUTOPAY_ACCOUNT:
+            return split.amount
+    return None
+
+
+def _other_account(tx: StandardTransaction) -> str:
+    """Return the non-autopay account from a 2-split autopay transaction."""
+    for split in tx.splits:
+        if split.account != AUTOPAY_ACCOUNT:
+            return split.account
+    return ""
+
+
+class StatementReconciler:
+    """Merges Reconcile:Autopay placeholder pairs across statements.
+
+    Inputs are a flat list of StandardTransaction from all providers.
+    Outputs three buckets: resolved (autopay pairs merged), unresolved
+    (Reconcile:Autopay still present), normal (no autopay involvement).
+    """
+
+    DATE_TOLERANCE = timedelta(days=1)
+
+    def reconcile(
+        self,
+        transactions: list[StandardTransaction],
+    ) -> tuple[
+        list[StandardTransaction],  # resolved
+        list[StandardTransaction],  # unresolved
+        list[StandardTransaction],  # normal
+    ]:
+        bank_side: list[StandardTransaction] = []   # Reconcile:Autopay > 0
+        card_side: list[StandardTransaction] = []   # Reconcile:Autopay < 0
+        normal: list[StandardTransaction] = []
+
+        for tx in transactions:
+            amt = _autopay_amount(tx)
+            if amt is None:
+                normal.append(tx)
+            elif amt > Decimal(0):
+                bank_side.append(tx)
+            else:
+                card_side.append(tx)
+
+        matched_bank: set[int] = set()
+        matched_card: set[int] = set()
+        resolved: list[StandardTransaction] = []
+
+        for bi, bank in enumerate(bank_side):
+            bank_amt = _autopay_amount(bank)
+            card_matches = [
+                ci for ci, card in enumerate(card_side)
+                if ci not in matched_card
+                and card.currency == bank.currency
+                and abs(_autopay_amount(card)) == bank_amt  # type: ignore[arg-type]
+                and abs((bank.post_date - card.post_date).days) <= 1
+            ]
+
+            # Also check for same-side collisions: other bank entries with same
+            # amount/currency/date that haven't been matched yet
+            bank_collisions = [
+                bi2 for bi2, bank2 in enumerate(bank_side)
+                if bi2 != bi
+                and bi2 not in matched_bank
+                and bank2.currency == bank.currency
+                and _autopay_amount(bank2) == bank_amt
+                and abs((bank.post_date - bank2.post_date).days) <= 1
+            ]
+
+            if len(card_matches) == 1 and len(bank_collisions) == 0:
+                ci = card_matches[0]
+                card = card_side[ci]
+                matched_bank.add(bi)
+                matched_card.add(ci)
+                resolved.append(_merge(bank, card))
+            # else: collision or no match — leave for unresolved
+
+        unresolved = (
+            [tx for i, tx in enumerate(bank_side) if i not in matched_bank]
+            + [tx for i, tx in enumerate(card_side) if i not in matched_card]
+        )
+
+        return resolved, unresolved, normal
+
+
+def _merge(bank: StandardTransaction, card: StandardTransaction) -> StandardTransaction:
+    """Produce one merged transaction from a matched bank/card autopay pair.
+
+    Card side is primary: provides date, description, source_pdfs[0].
+    Bank side provides the savings account split.
+    """
+    bank_account = _other_account(bank)
+    card_account = _other_account(card)
+    bank_amt = _autopay_amount(bank)
+    assert bank_amt is not None
+
+    return StandardTransaction(
+        post_date=card.post_date,
+        description=card.description,
+        currency=card.currency,
+        splits=[
+            Split(card_account, abs(bank_amt)),    # card liability: +X (reduce)
+            Split(bank_account, -abs(bank_amt)),   # bank savings: -X (debit)
+        ],
+        source_pdfs=(card.source_pdfs or []) + (bank.source_pdfs or []),
+        guid=None,
+    )

--- a/tests/integration/test_gnucash_fuzzy_matcher.py
+++ b/tests/integration/test_gnucash_fuzzy_matcher.py
@@ -1,0 +1,202 @@
+"""Integration tests for GnuCashFuzzyMatcher against a real GnuCash book.
+
+These tests run in Docker with real GnuCash Python bindings.
+No mocking of GnuCash types — per project testing philosophy.
+"""
+import os
+import tempfile
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from infrastructure.pdf.standard_tx import Split, StandardTransaction
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from services.gnucash_fuzzy_matcher import GnuCashFuzzyMatcher, MatchStatus
+
+# ---------------------------------------------------------------------------
+# Fixture: temp GnuCash book with HKD accounts and known transactions
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def hkd_book():
+    """Temp GnuCash book with BOC HKD accounts for fuzzy matcher tests."""
+    import gnucash
+    from gnucash import Account, GncNumeric, Session, Transaction
+    from gnucash import Split as GncSplit
+
+    fd, path = tempfile.mkstemp(suffix=".gnucash")
+    os.close(fd)
+    os.unlink(path)
+
+    try:
+        from gnucash import SessionOpenMode
+        session = Session(f"xml://{path}", SessionOpenMode.SESSION_NEW_STORE)
+    except ImportError:
+        session = Session(f"xml://{path}", is_new=True)
+
+    book = session.book
+    root = book.get_root_account()
+    table = book.get_table()
+    hkd = table.lookup("CURRENCY", "HKD")
+
+    def acct(name, type_, parent):
+        a = Account(book)
+        a.SetName(name)
+        a.SetType(type_)
+        a.SetCommodity(hkd)
+        parent.append_child(a)
+        return a
+
+    # Account hierarchy
+    assets = acct("Assets", gnucash.ACCT_TYPE_ASSET, root)
+    bank = acct("BOC HKD Saving", gnucash.ACCT_TYPE_BANK, assets)
+    expenses = acct("Expenses", gnucash.ACCT_TYPE_EXPENSE, root)
+    dining = acct("Dining", gnucash.ACCT_TYPE_EXPENSE, expenses)
+    acct("Groceries", gnucash.ACCT_TYPE_EXPENSE, expenses)
+    liabilities = acct("Liabilities", gnucash.ACCT_TYPE_LIABILITY, root)
+    boci = acct("BOCI-0012", gnucash.ACCT_TYPE_CREDIT, liabilities)
+
+    def add_tx(d: date, splits: list[tuple[Account, int, int]]) -> Transaction:
+        tx = Transaction(book)
+        tx.BeginEdit()
+        tx.SetCurrency(hkd)
+        tx.SetDatePostedSecs(
+            int(gnucash.GncDateTime(
+                gnucash.GncDate(d.year, d.month, d.day)
+            ).GetTime64())
+            if hasattr(gnucash, "GncDateTime")
+            else int(d.strftime("%s"))
+        )
+        for acct_obj, num, denom in splits:
+            sp = GncSplit(book)
+            sp.SetParent(tx)
+            sp.SetAccount(acct_obj)
+            sp.SetValue(GncNumeric(num, denom))
+            sp.SetAmount(GncNumeric(num, denom))
+        tx.CommitEdit()
+        return tx
+
+    # Transaction 1: salary deposit 2026-03-29 (different date/amount — won't interfere)
+    add_tx(date(2026, 3, 29), [(bank, 1811000, 100), (dining, -1811000, 100)])
+
+    # Transaction 2: credit card charge 2026-04-15 boci → dining (user-categorized)
+    # This is the realistic PARTIAL_MATCH scenario: user manually chose Dining
+    add_tx(date(2026, 4, 15), [(boci, 24710, 100), (dining, -24710, 100)])
+
+    session.save()
+    session.end()
+
+    yield path, {
+        "bank": "Assets:BOC HKD Saving",
+        "dining": "Expenses:Dining",
+        "groceries": "Expenses:Groceries",
+        "boci": "Liabilities:BOCI-0012",
+    }
+
+    if os.path.exists(path):
+        os.unlink(path)
+    lock = path + ".LCK"
+    if os.path.exists(lock):
+        os.unlink(lock)
+
+
+def _matcher(path: str) -> GnuCashFuzzyMatcher:
+    repo = GnuCashRepository(path)
+    return GnuCashFuzzyMatcher(repo)
+
+
+def _tx(
+    d: date,
+    acct1: str,
+    acct2: str,
+    amount: str = "247.10",
+    desc: str = "AUTOPAY",
+) -> StandardTransaction:
+    return StandardTransaction(
+        post_date=d,
+        description=desc,
+        currency="HKD",
+        splits=[
+            Split(acct1, Decimal(amount)),
+            Split(acct2, Decimal(f"-{amount}")),
+        ],
+        source_pdfs=["boci.pdf"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGnuCashFuzzyMatcher:
+    def test_new_no_match(self, hkd_book):
+        path, accts = hkd_book
+        m = _matcher(path)
+        tx = _tx(date(2026, 4, 20), accts["bank"], accts["dining"], amount="999.99")
+        assert m.match(tx).status == MatchStatus.NEW
+
+    def test_likely_dup_exact_date(self, hkd_book):
+        path, accts = hkd_book
+        m = _matcher(path)
+        # Exact match: same accounts (boci→dining) as in GnuCash
+        tx = _tx(date(2026, 4, 15), accts["boci"], accts["dining"], amount="247.10")
+        result = m.match(tx)
+        assert result.status == MatchStatus.LIKELY_DUP
+        assert result.merged_tx is None
+
+    def test_likely_dup_plus_one_day(self, hkd_book):
+        path, accts = hkd_book
+        m = _matcher(path)
+        tx = _tx(date(2026, 4, 16), accts["boci"], accts["dining"], amount="247.10")
+        result = m.match(tx)
+        assert result.status == MatchStatus.LIKELY_DUP
+
+    def test_likely_dup_minus_one_day(self, hkd_book):
+        path, accts = hkd_book
+        m = _matcher(path)
+        tx = _tx(date(2026, 4, 14), accts["boci"], accts["dining"], amount="247.10")
+        result = m.match(tx)
+        assert result.status == MatchStatus.LIKELY_DUP
+
+    def test_two_days_away_is_new(self, hkd_book):
+        path, accts = hkd_book
+        m = _matcher(path)
+        tx = _tx(date(2026, 4, 13), accts["boci"], accts["dining"], amount="247.10")
+        assert m.match(tx).status == MatchStatus.NEW
+
+    def test_partial_match_expense_differs(self, hkd_book):
+        path, accts = hkd_book
+        m = _matcher(path)
+        # GnuCash has boci→bank; we generate boci→groceries (same bank, diff expense)
+        tx = _tx(date(2026, 4, 15), accts["boci"], accts["groceries"], amount="247.10")
+        result = m.match(tx)
+        assert result.status == MatchStatus.PARTIAL_MATCH
+        assert result.existing is not None
+
+    def test_partial_match_merged_guid(self, hkd_book):
+        path, accts = hkd_book
+        m = _matcher(path)
+        tx = _tx(date(2026, 4, 15), accts["boci"], accts["groceries"], amount="247.10")
+        result = m.match(tx)
+        assert result.merged_tx is not None
+        assert result.merged_tx.guid is not None
+        assert len(result.merged_tx.guid) == 32  # GnuCash GUID is 32 hex chars
+
+    def test_partial_match_gnucash_category(self, hkd_book):
+        path, accts = hkd_book
+        m = _matcher(path)
+        tx = _tx(date(2026, 4, 15), accts["boci"], accts["groceries"], amount="247.10")
+        result = m.match(tx)
+        merged_accounts = {s.account for s in result.merged_tx.splits}
+        # GnuCash has Dining; our candidate had Groceries — Dining should win
+        assert any("Dining" in a for a in merged_accounts)
+        assert not any("Groceries" in a for a in merged_accounts)
+
+    def test_partial_match_generated_doc_link(self, hkd_book):
+        path, accts = hkd_book
+        m = _matcher(path)
+        tx = _tx(date(2026, 4, 15), accts["boci"], accts["groceries"], amount="247.10")
+        tx.source_pdfs = ["boci-0012-2026-04.pdf"]
+        result = m.match(tx)
+        assert result.merged_tx.source_pdfs[0] == "boci-0012-2026-04.pdf"

--- a/tests/integration/test_gnucash_fuzzy_matcher.py
+++ b/tests/integration/test_gnucash_fuzzy_matcher.py
@@ -3,6 +3,8 @@
 These tests run in Docker with real GnuCash Python bindings.
 No mocking of GnuCash types — per project testing philosophy.
 """
+from __future__ import annotations
+
 import os
 import tempfile
 from datetime import date

--- a/tests/integration/test_pdf_infrastructure.py
+++ b/tests/integration/test_pdf_infrastructure.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import date
 from decimal import Decimal
 

--- a/tests/integration/test_pdf_infrastructure.py
+++ b/tests/integration/test_pdf_infrastructure.py
@@ -1,0 +1,27 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from infrastructure.pdf.standard_tx import Split, StandardTransaction
+
+
+def test_split_decimal_enforcement_in_docker():
+    # Runs in the Docker Python environment to confirm the installed package
+    # preserves __post_init__ enforcement (catches packaging or import errors).
+    with pytest.raises(TypeError, match="must be Decimal"):
+        Split(account="Assets:Bank", amount=1.5)
+
+
+def test_cjk_no_encoding_error():
+    tx = StandardTransaction(
+        post_date=date(2026, 4, 15),
+        description="自動轉賬",
+        currency="HKD",
+        splits=[
+            Split("Assets:Bank", Decimal("100.00")),
+            Split("Expenses:Misc", Decimal("-100.00")),
+        ],
+    )
+    assert tx.description == "自動轉賬"
+    assert "自動轉賬" in repr(tx)

--- a/tests/integration/test_ready_to_import.py
+++ b/tests/integration/test_ready_to_import.py
@@ -1,0 +1,176 @@
+"""Integration test: full pipeline end-to-end with real GnuCash book."""
+import os
+import tempfile
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from infrastructure.pdf.standard_tx import Split, StandardTransaction
+from repositories.gnucash_repository import GnuCashRepository
+from services.gnucash_fuzzy_matcher import GnuCashFuzzyMatcher, MatchStatus
+from services.ready_to_import_writer import AUTOPAY_ACCOUNT, ReadyToImportWriter
+from services.reconcile_preview_reader import ReconcilePreviewReader
+from services.reconcile_preview_writer import ReconcilePreviewWriter
+from services.statement_reconciler import StatementReconciler
+
+
+@pytest.fixture
+def simple_book():
+    """Minimal GnuCash book: one manually-entered credit card charge."""
+    import gnucash
+    from gnucash import Account, GncNumeric, Session, Transaction
+    from gnucash import Split as GncSplit
+
+    fd, path = tempfile.mkstemp(suffix=".gnucash")
+    os.close(fd)
+    os.unlink(path)
+
+    try:
+        from gnucash import SessionOpenMode
+        session = Session(f"xml://{path}", SessionOpenMode.SESSION_NEW_STORE)
+    except ImportError:
+        session = Session(f"xml://{path}", is_new=True)
+
+    book = session.book
+    root = book.get_root_account()
+    table = book.get_table()
+    hkd = table.lookup("CURRENCY", "HKD")
+
+    def acct(name, type_, parent):
+        a = Account(book)
+        a.SetName(name)
+        a.SetType(type_)
+        a.SetCommodity(hkd)
+        parent.append_child(a)
+        return a
+
+    assets = acct("Assets", gnucash.ACCT_TYPE_ASSET, root)
+    acct("BOC HKD Saving", gnucash.ACCT_TYPE_BANK, assets)
+    expenses = acct("Expenses", gnucash.ACCT_TYPE_EXPENSE, root)
+    dining = acct("Dining", gnucash.ACCT_TYPE_EXPENSE, expenses)
+    liabilities = acct("Liabilities", gnucash.ACCT_TYPE_LIABILITY, root)
+    boci = acct("BOCI-0012", gnucash.ACCT_TYPE_CREDIT, liabilities)
+
+    # Manually-entered charge: BOCI-0012 → Dining (user already categorized)
+    tx = Transaction(book)
+    tx.BeginEdit()
+    tx.SetCurrency(hkd)
+    tx.SetDatePostedSecs(
+        int(gnucash.GncDateTime(gnucash.GncDate(2026, 4, 15)).GetTime64())
+        if hasattr(gnucash, "GncDateTime")
+        else int(date(2026, 4, 15).strftime("%s"))
+    )
+    for acct_obj, num, denom in [(boci, 24710, 100), (dining, -24710, 100)]:
+        sp = GncSplit(book)
+        sp.SetParent(tx)
+        sp.SetAccount(acct_obj)
+        sp.SetValue(GncNumeric(num, denom))
+        sp.SetAmount(GncNumeric(num, denom))
+    tx.CommitEdit()
+
+    session.save()
+    session.end()
+
+    yield path
+
+    if os.path.exists(path):
+        os.unlink(path)
+    lock = path + ".LCK"
+    if os.path.exists(lock):
+        os.unlink(lock)
+
+
+def _make_tx(acct1, acct2, amount, d=date(2026, 4, 15), pdf="boci.pdf"):
+    return StandardTransaction(
+        post_date=d, description="AUTOPAY INGROUP", currency="HKD",
+        splits=[Split(acct1, Decimal(amount)), Split(acct2, Decimal(f"-{amount}"))],
+        source_pdfs=[pdf],
+    )
+
+
+def test_end_to_end_pipeline(tmp_path, simple_book):
+    """Full pipeline: StandardTransactions → reconciler → writer → reader →
+    fuzzy matcher → ready-to-import writer → PlaintextParser-parseable output.
+    """
+    boci = "Liabilities:BOCI-0012"
+    bank = "Assets:BOC HKD Saving"
+    groceries = "Expenses:Groceries"
+
+    # Three transactions coming from statement parsers:
+    # 1. A salary (normal, NEW — not in GnuCash)
+    salary = StandardTransaction(
+        post_date=date(2026, 3, 29), description="Salary", currency="HKD",
+        splits=[Split(bank, Decimal("18110.00")), Split("Income:Salary:HKD", Decimal("-18110.00"))],
+        source_pdfs=["bochk.pdf"],
+    )
+    # 2. A credit card charge (PARTIAL_MATCH — GnuCash has boci→dining, we have boci→groceries)
+    charge = _make_tx(boci, groceries, "247.10")
+    # 3. An unresolved autopay (no matching card statement provided)
+    unresolved_bank = StandardTransaction(
+        post_date=date(2026, 4, 2), description="BOC CREDIT CARD", currency="HKD",
+        splits=[Split(bank, Decimal("-125.00")), Split(AUTOPAY_ACCOUNT, Decimal("125.00"))],
+        source_pdfs=["bochk.pdf"],
+    )
+
+    # Phase 1: reconcile (no autopay pairs to merge in this batch)
+    resolved, unresolved, normal = StatementReconciler().reconcile(
+        [salary, charge, unresolved_bank]
+    )
+
+    # Write preview
+    preview = str(tmp_path / "_reconcile.txt")
+    ReconcilePreviewWriter().write(preview, resolved, unresolved, normal)
+
+    # Phase 2: read back and fuzzy match
+    importable, unresolved_out = ReconcilePreviewReader().read(preview)
+
+    matcher = GnuCashFuzzyMatcher(GnuCashRepository(simple_book))
+    new_txs, likely_dup, partial_match = [], [], []
+    for tx in importable:
+        result = matcher.match(tx)
+        if result.status == MatchStatus.NEW:
+            new_txs.append(tx)
+        elif result.status == MatchStatus.LIKELY_DUP:
+            likely_dup.append(result)
+        else:
+            partial_match.append(result)
+
+    # Write ready-to-import
+    output = str(tmp_path / "ready.txt")
+    ReadyToImportWriter().write(output, new_txs, likely_dup, partial_match, unresolved_out)
+
+    content = Path(output).read_text(encoding="utf-8")
+
+    # Salary should be NEW
+    assert "Salary" in content
+    assert "18110.00" in content
+
+    # Charge should be PARTIAL_MATCH with GnuCash's Dining category in merged
+    assert "SUGGESTED MERGE" in content
+    assert "Expenses:Dining" in content
+    assert "Expenses:Groceries" not in content.split("SUGGESTED MERGE")[1].split("===")[0]
+
+    # Unresolved should be commented out with warning
+    assert "[UNRESOLVED — DO NOT IMPORT]" in content
+
+    # No live Reconcile:Autopay anywhere
+    live_lines = [ln for ln in content.splitlines() if not ln.startswith(";;") and AUTOPAY_ACCOUNT in ln]
+    assert live_lines == []
+
+
+def test_idempotency(tmp_path, simple_book):
+    """Running the full pipeline twice on the same inputs produces no duplicates."""
+    boci = "Liabilities:BOCI-0012"
+    dining = "Expenses:Dining"
+
+    tx = _make_tx(boci, dining, "247.10")
+    matcher = GnuCashFuzzyMatcher(GnuCashRepository(simple_book))
+
+    result1 = matcher.match(tx)
+    result2 = matcher.match(tx)
+
+    # Both runs should see the same existing transaction
+    assert result1.status == result2.status
+    assert result1.existing.guid == result2.existing.guid

--- a/tests/integration/test_ready_to_import.py
+++ b/tests/integration/test_ready_to_import.py
@@ -1,4 +1,6 @@
 """Integration test: full pipeline end-to-end with real GnuCash book."""
+from __future__ import annotations
+
 import os
 import tempfile
 from datetime import date

--- a/tests/integration/test_reconcile_preview.py
+++ b/tests/integration/test_reconcile_preview.py
@@ -1,0 +1,91 @@
+"""Integration tests for ReconcilePreviewWriter + ReconcilePreviewReader pipeline."""
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+from infrastructure.pdf.standard_tx import Split, StandardTransaction
+from services.reconcile_preview_reader import AUTOPAY_ACCOUNT, ReconcilePreviewReader
+from services.reconcile_preview_writer import ReconcilePreviewWriter
+from services.statement_reconciler import StatementReconciler
+
+
+def _bank(amount: str, pdf: str = "bochk.pdf") -> StandardTransaction:
+    return StandardTransaction(
+        post_date=date(2026, 4, 15),
+        description="BOC CREDIT CARD",
+        currency="HKD",
+        splits=[
+            Split("Assets:BOC HKD Saving", Decimal(f"-{amount}")),
+            Split(AUTOPAY_ACCOUNT, Decimal(amount)),
+        ],
+        source_pdfs=[pdf],
+    )
+
+
+def _card(amount: str, pdf: str = "boci.pdf") -> StandardTransaction:
+    return StandardTransaction(
+        post_date=date(2026, 4, 15),
+        description="AUTOPAY INGROUP",
+        currency="HKD",
+        splits=[
+            Split("Liabilities:BOCI-0012", Decimal(amount)),
+            Split(AUTOPAY_ACCOUNT, Decimal(f"-{amount}")),
+        ],
+        source_pdfs=[pdf],
+    )
+
+
+def _normal(desc: str) -> StandardTransaction:
+    return StandardTransaction(
+        post_date=date(2026, 4, 15),
+        description=desc,
+        currency="HKD",
+        splits=[
+            Split("Assets:BOC HKD Saving", Decimal("18110.00")),
+            Split("Income:Salary:HKD", Decimal("-18110.00")),
+        ],
+        source_pdfs=["bochk.pdf"],
+    )
+
+
+def test_full_pipeline_no_transactions_dropped(tmp_path):
+    """Reconciler → writer → reader: total in == total out, none dropped."""
+    txs = [
+        _bank("247.10"), _card("247.10"),  # pair → resolved
+        _bank("999.00"),                   # no card → unresolved
+        _normal("Salary"), _normal("Rent"),
+    ]
+    reconciler = StatementReconciler()
+    resolved, unresolved, normal = reconciler.reconcile(txs)
+
+    path = str(tmp_path / "_reconcile.txt")
+    ReconcilePreviewWriter().write(path, resolved, unresolved, normal)
+    importable, unresolved_out = ReconcilePreviewReader().read(path)
+
+    total_in = len(resolved) + len(unresolved) + len(normal)
+    total_out = len(importable) + len(unresolved_out)
+    assert total_out == total_in, f"Dropped {total_in - total_out} transaction(s)"
+
+
+def test_cjk_utf8_on_disk(tmp_path):
+    """CJK characters survive write → disk → read without encoding error."""
+    tx = StandardTransaction(
+        post_date=date(2026, 4, 15),
+        description="自動轉賬 / BOC CREDIT CARD (INT",
+        currency="HKD",
+        splits=[
+            Split("Assets:BOC HKD Saving", Decimal("-247.10")),
+            Split("Liabilities:BOCI-0012", Decimal("247.10")),
+        ],
+        source_pdfs=["bochk.pdf"],
+    )
+    path = str(tmp_path / "_reconcile.txt")
+    ReconcilePreviewWriter().write(path, [tx], [], [])
+
+    # Verify bytes on disk are valid UTF-8
+    raw = Path(path).read_bytes()
+    text = raw.decode("utf-8")
+    assert "自動轉賬" in text
+
+    importable, _ = ReconcilePreviewReader().read(path)
+    assert importable[0].description == "自動轉賬 / BOC CREDIT CARD (INT"

--- a/tests/integration/test_reconcile_preview.py
+++ b/tests/integration/test_reconcile_preview.py
@@ -1,4 +1,6 @@
 """Integration tests for ReconcilePreviewWriter + ReconcilePreviewReader pipeline."""
+from __future__ import annotations
+
 from datetime import date
 from decimal import Decimal
 from pathlib import Path

--- a/tests/integration/test_statement_reconciler.py
+++ b/tests/integration/test_statement_reconciler.py
@@ -1,4 +1,6 @@
 """Integration test: realistic month simulation for StatementReconciler."""
+from __future__ import annotations
+
 from datetime import date
 from decimal import Decimal
 

--- a/tests/integration/test_statement_reconciler.py
+++ b/tests/integration/test_statement_reconciler.py
@@ -1,0 +1,77 @@
+"""Integration test: realistic month simulation for StatementReconciler."""
+from datetime import date
+from decimal import Decimal
+
+from infrastructure.pdf.standard_tx import Split, StandardTransaction
+from services.statement_reconciler import AUTOPAY_ACCOUNT, StatementReconciler
+
+
+def _bank(amount: str, day: int, pdf: str, savings: str = "Assets:BOC HKD Saving") -> StandardTransaction:
+    return StandardTransaction(
+        post_date=date(2026, 4, day),
+        description="BOC CREDIT CARD",
+        currency="HKD",
+        splits=[
+            Split(savings, Decimal(f"-{amount}")),
+            Split(AUTOPAY_ACCOUNT, Decimal(amount)),
+        ],
+        source_pdfs=[pdf],
+    )
+
+
+def _card(amount: str, day: int, pdf: str, liability: str, currency: str = "HKD") -> StandardTransaction:
+    return StandardTransaction(
+        post_date=date(2026, 4, day),
+        description="AUTOPAY INGROUP",
+        currency=currency,
+        splits=[
+            Split(liability, Decimal(amount)),
+            Split(AUTOPAY_ACCOUNT, Decimal(f"-{amount}")),
+        ],
+        source_pdfs=[pdf],
+    )
+
+
+def _normal(desc: str, amount: str) -> StandardTransaction:
+    return StandardTransaction(
+        post_date=date(2026, 4, 15),
+        description=desc,
+        currency="HKD",
+        splits=[
+            Split("Assets:BOC HKD Saving", Decimal(amount)),
+            Split("Income:Salary:HKD", Decimal(f"-{amount}")),
+        ],
+        source_pdfs=["bochk.pdf"],
+    )
+
+
+def test_realistic_month():
+    """3 autopay pairs + 5 normal transactions → 3 resolved, 0 unresolved, 5 normal."""
+    txs = [
+        # Normal transactions from BOCHK
+        _normal("Salary", "18110.00"),
+        _normal("Interest", "0.06"),
+        _normal("Interest CNY", "1.90"),
+        _normal("Rent", "7200.00"),
+        _normal("ATM", "400.00"),
+        # BOCHK autopay debits
+        _bank("247.10", 15, "bochk-2026-04.pdf"),   # → BOCI-0012
+        _bank("65.80",  10, "bochk-2026-04.pdf"),   # → BOCI-0113
+        _bank("1091.84", 23, "bochk-2026-04.pdf"),  # → AEON
+        # Credit card autopay credits
+        _card("247.10", 15, "boci-0012-2026-04.pdf", "Liabilities:BOCI-0012"),
+        _card("65.80",  10, "boci-0113-2026-04.pdf", "Liabilities:BOCI-0113"),
+        _card("1091.84", 24, "aeon-hk-2026-04.pdf", "Liabilities:AEON-HK-9044"),
+    ]
+
+    resolved, unresolved, normal = StatementReconciler().reconcile(txs)
+
+    assert len(resolved) == 3, f"Expected 3 resolved, got {len(resolved)}"
+    assert len(unresolved) == 0, f"Expected 0 unresolved, got {len(unresolved)}"
+    assert len(normal) == 5, f"Expected 5 normal, got {len(normal)}"
+
+    for tx in resolved:
+        for split in tx.splits:
+            assert split.account != AUTOPAY_ACCOUNT, (
+                f"Resolved tx still contains {AUTOPAY_ACCOUNT}"
+            )

--- a/tests/unit/infrastructure/test_standard_tx.py
+++ b/tests/unit/infrastructure/test_standard_tx.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import date
 from decimal import Decimal
 

--- a/tests/unit/infrastructure/test_standard_tx.py
+++ b/tests/unit/infrastructure/test_standard_tx.py
@@ -1,0 +1,102 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from infrastructure.pdf.provider import StatementProvider
+from infrastructure.pdf.standard_tx import Split, StandardTransaction
+
+
+class TestSplit:
+    def test_constructed_with_decimal(self):
+        s = Split(account="Assets:Bank", amount=Decimal("100.00"))
+        assert isinstance(s.amount, Decimal)
+        assert s.amount == Decimal("100.00")
+
+    def test_float_raises_type_error(self):
+        with pytest.raises(TypeError, match="must be Decimal"):
+            Split(account="Assets:Bank", amount=100.0)
+
+
+class TestStandardTransaction:
+    def _make(self, **kwargs):
+        defaults = {
+            "post_date": date(2026, 4, 15),
+            "description": "Test",
+            "currency": "HKD",
+            "splits": [
+                Split("Assets:Bank", Decimal("100.00")),
+                Split("Income:Salary", Decimal("-100.00")),
+            ],
+        }
+        defaults.update(kwargs)
+        return StandardTransaction(**defaults)
+
+    def test_defaults(self):
+        tx = self._make()
+        assert tx.guid is None
+        assert tx.source_pdfs == []
+
+    def test_source_pdfs_not_shared(self):
+        tx1 = self._make()
+        tx2 = self._make()
+        tx1.source_pdfs.append("a.pdf")
+        assert tx2.source_pdfs == []
+
+    def test_single_split_raises(self):
+        with pytest.raises(ValueError, match="at least 2 splits"):
+            self._make(splits=[Split("Assets:Bank", Decimal("100.00"))])
+
+    def test_three_splits(self):
+        tx = self._make(splits=[
+            Split("Assets:Bank", Decimal("300.00")),
+            Split("Expenses:Dining", Decimal("-200.00")),
+            Split("Expenses:Groceries", Decimal("-100.00")),
+        ])
+        assert len(tx.splits) == 3
+
+    def test_cjk_description(self):
+        tx = self._make(description="自動轉賬")
+        assert tx.description == "自動轉賬"
+        assert repr(tx)
+
+
+class TestStatementProvider:
+    def test_concrete_class_satisfies_protocol(self):
+        class MockProvider:
+            autopay_source = {"HKD": "Assets:Bank"}
+
+            def can_handle(self, filename: str) -> bool:
+                return filename.startswith("mock-")
+
+            def parse(self, path: str) -> list[StandardTransaction]:
+                return []
+
+        assert isinstance(MockProvider(), StatementProvider)
+
+    def test_missing_method_fails_protocol(self):
+        class IncompleteProvider:
+            autopay_source = {}
+
+        assert not isinstance(IncompleteProvider(), StatementProvider)
+
+    def test_missing_autopay_source_documents_runtime_gap(self):
+        # autopay_source is a Protocol data attribute. On Python 3.11+,
+        # isinstance() may or may not check its presence depending on the
+        # minor version. Protocol compliance for data attributes is enforced
+        # by static type checking (mypy), not solely by isinstance().
+        # This test documents the actual runtime behaviour on the current
+        # Python version rather than asserting a specific outcome.
+        class ProviderWithoutAutopaySource:
+            def can_handle(self, filename: str) -> bool:
+                return False
+
+            def parse(self, path: str) -> list[StandardTransaction]:
+                return []
+
+        result = isinstance(ProviderWithoutAutopaySource(), StatementProvider)
+        # On Python 3.11.14 this is False (attribute checked); on older minor
+        # versions it may be True (only methods checked). Either way, callers
+        # must not rely solely on isinstance() — use mypy for data attribute
+        # compliance. This assertion records the current runtime behaviour.
+        assert result is False  # update if Python version changes behaviour

--- a/tests/unit/services/test_gnucash_fuzzy_matcher.py
+++ b/tests/unit/services/test_gnucash_fuzzy_matcher.py
@@ -1,0 +1,94 @@
+"""Unit tests for GnuCashFuzzyMatcher pure-logic functions.
+
+Tests cover amount normalization and tie-breaking using only StandardTransaction
+and _IndexEntry (Python-native) — no GnuCash C-extension, no Docker.
+
+MatchStatus classification tests (NEW/LIKELY_DUP/PARTIAL_MATCH) and merged_tx
+content tests are in tests/integration/test_gnucash_fuzzy_matcher.py.
+"""
+from datetime import date
+from decimal import Decimal
+
+from infrastructure.pdf.standard_tx import Split, StandardTransaction
+from services.gnucash_fuzzy_matcher import _IndexEntry, _pick_best
+
+
+def _entry(
+    d: date,
+    accounts: list[str],
+    amount: str = "247.10",
+) -> _IndexEntry:
+    return _IndexEntry(
+        post_date=d,
+        amount=Decimal(amount),
+        account_names=frozenset(accounts),
+        asset_liability_accounts=frozenset(a for a in accounts if "Assets" in a or "Liabilities" in a),
+        guid="abc123",
+        description="test",
+        splits=[(accounts[0], Decimal(amount)), (accounts[1], Decimal(f"-{amount}"))],
+    )
+
+
+def _candidate(
+    d: date = date(2026, 4, 15),
+    acct1: str = "Assets:Bank",
+    acct2: str = "Expenses:Dining",
+) -> StandardTransaction:
+    return StandardTransaction(
+        post_date=d,
+        description="AUTOPAY",
+        currency="HKD",
+        splits=[
+            Split(acct1, Decimal("247.10")),
+            Split(acct2, Decimal("-247.10")),
+        ],
+    )
+
+
+class TestAmountNormalization:
+    def test_two_split_sum(self):
+        tx = _candidate()
+        total = sum(s.amount for s in tx.splits if s.amount > 0)
+        assert total == Decimal("247.10")
+
+    def test_three_split_sum(self):
+        tx = StandardTransaction(
+            post_date=date(2026, 4, 15),
+            description="Split",
+            currency="HKD",
+            splits=[
+                Split("Assets:Bank", Decimal("300.00")),
+                Split("Expenses:A", Decimal("-200.00")),
+                Split("Expenses:B", Decimal("-100.00")),
+            ],
+        )
+        total = sum(s.amount for s in tx.splits if s.amount > 0)
+        assert total == Decimal("300.00")
+
+    def test_symmetry_with_index_side(self):
+        entry = _entry(date(2026, 4, 15), ["Assets:Bank", "Expenses:Dining"])
+        candidate_sum = sum(s.amount for s in _candidate().splits if s.amount > 0)
+        assert entry.amount == candidate_sum
+
+
+class TestTieBreaking:
+    def test_exact_date_beats_near_date(self):
+        tx = _candidate(d=date(2026, 4, 15))
+        near = _entry(date(2026, 4, 14), ["Assets:Bank", "Expenses:A"])
+        exact = _entry(date(2026, 4, 15), ["Assets:Bank", "Expenses:A"])
+        best = _pick_best([near, exact], tx, date(2026, 4, 15))
+        assert best is exact
+
+    def test_most_matching_accounts_wins(self):
+        tx = _candidate(acct1="Assets:Bank", acct2="Expenses:Dining")
+        fewer = _entry(date(2026, 4, 14), ["Assets:Other", "Expenses:X"])
+        more = _entry(date(2026, 4, 14), ["Assets:Bank", "Expenses:X"])
+        best = _pick_best([fewer, more], tx, date(2026, 4, 15))
+        assert best is more
+
+    def test_earliest_date_tiebreak(self):
+        tx = _candidate(d=date(2026, 4, 15))
+        later = _entry(date(2026, 4, 16), ["Assets:Bank", "Expenses:A"])
+        earlier = _entry(date(2026, 4, 14), ["Assets:Bank", "Expenses:A"])
+        best = _pick_best([later, earlier], tx, date(2026, 4, 15))
+        assert best is earlier

--- a/tests/unit/services/test_gnucash_fuzzy_matcher.py
+++ b/tests/unit/services/test_gnucash_fuzzy_matcher.py
@@ -6,6 +6,8 @@ and _IndexEntry (Python-native) — no GnuCash C-extension, no Docker.
 MatchStatus classification tests (NEW/LIKELY_DUP/PARTIAL_MATCH) and merged_tx
 content tests are in tests/integration/test_gnucash_fuzzy_matcher.py.
 """
+from __future__ import annotations
+
 from datetime import date
 from decimal import Decimal
 

--- a/tests/unit/services/test_ready_to_import_writer.py
+++ b/tests/unit/services/test_ready_to_import_writer.py
@@ -1,0 +1,168 @@
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from infrastructure.pdf.standard_tx import Split, StandardTransaction
+from services.gnucash_fuzzy_matcher import MatchResult, MatchStatus, _IndexEntry
+from services.ready_to_import_writer import AUTOPAY_ACCOUNT, ReadyToImportWriter
+
+WRITER = ReadyToImportWriter()
+
+
+def _new_tx(desc: str = "AUTOPAY INGROUP", pdf: str = "boci.pdf") -> StandardTransaction:
+    return StandardTransaction(
+        post_date=date(2026, 4, 15),
+        description=desc,
+        currency="HKD",
+        splits=[
+            Split("Liabilities:BOCI-0012", Decimal("247.10")),
+            Split("Assets:BOC HKD Saving", Decimal("-247.10")),
+        ],
+        source_pdfs=[pdf],
+    )
+
+
+def _unresolved_tx() -> StandardTransaction:
+    return StandardTransaction(
+        post_date=date(2026, 4, 2),
+        description="BOC CREDIT CARD",
+        currency="HKD",
+        splits=[
+            Split("Assets:BOC HKD Saving", Decimal("-125.00")),
+            Split(AUTOPAY_ACCOUNT, Decimal("125.00")),
+        ],
+        source_pdfs=["bochk.pdf"],
+    )
+
+
+def _make_entry(desc: str = "AUTOPAY INGROUP", guid: str = "abc1" * 8) -> _IndexEntry:
+    return _IndexEntry(
+        post_date=date(2026, 4, 15),
+        amount=Decimal("247.10"),
+        account_names=frozenset(["Liabilities:BOCI-0012", "Expenses:Dining"]),
+        asset_liability_accounts=frozenset(["Liabilities:BOCI-0012"]),
+        guid=guid,
+        description=desc,
+        splits=[
+            ("Liabilities:BOCI-0012", Decimal("247.10")),
+            ("Expenses:Dining", Decimal("-247.10")),
+        ],
+    )
+
+
+def _partial_result(candidate_pdf: str = "boci.pdf") -> MatchResult:
+    existing = _make_entry()
+    merged = StandardTransaction(
+        post_date=date(2026, 4, 15),
+        description="AUTOPAY INGROUP",
+        currency="HKD",
+        splits=[
+            Split("Liabilities:BOCI-0012", Decimal("247.10")),
+            Split("Expenses:Dining", Decimal("-247.10")),
+        ],
+        source_pdfs=[candidate_pdf],
+        guid=existing.guid,
+    )
+    return MatchResult(status=MatchStatus.PARTIAL_MATCH, existing=existing, merged_tx=merged)
+
+
+def _dup_result() -> MatchResult:
+    return MatchResult(
+        status=MatchStatus.LIKELY_DUP,
+        existing=_make_entry(),
+        merged_tx=None,
+    )
+
+
+class TestReadyToImportWriter:
+    def _write(self, tmp_path: Path, new=None, likely_dup=None, partial=None, unresolved=None):
+        p = str(tmp_path / "out.txt")
+        WRITER.write(p, new or [], likely_dup or [], partial or [], unresolved or [])
+        return Path(p).read_text(encoding="utf-8")
+
+    def test_new_section_live_block(self, tmp_path):
+        content = self._write(tmp_path, new=[_new_tx()])
+        assert '2026-04-15 * "AUTOPAY INGROUP"' in content
+        # The date line is a live (uncommented) transaction line
+        live_date_lines = [ln for ln in content.splitlines() if ln.startswith("2026-")]
+        assert len(live_date_lines) == 1
+
+    def test_likely_dup_fully_commented(self, tmp_path):
+        content = self._write(tmp_path, likely_dup=[_dup_result()])
+        lines = [ln for ln in content.splitlines() if ln.strip() and "=====" not in ln]
+        non_comment = [ln for ln in lines if not ln.startswith(";;")]
+        assert non_comment == []
+
+    def test_partial_match_structure(self, tmp_path):
+        content = self._write(tmp_path, partial=[_partial_result()])
+        assert ";; EXISTING (GnuCash):" in content
+        assert ";; GENERATED (statement):" in content
+        assert ";; SUGGESTED MERGE" in content
+        # The MERGE block should be a live (uncommented) transaction
+        assert '2026-04-15 * "AUTOPAY INGROUP"' in content
+
+    def test_partial_match_guid_in_merge(self, tmp_path):
+        content = self._write(tmp_path, partial=[_partial_result()])
+        assert 'guid: "abc1abc1abc1abc1abc1abc1abc1abc1"' in content
+
+    def test_partial_match_gnucash_category(self, tmp_path):
+        content = self._write(tmp_path, partial=[_partial_result()])
+        # SUGGESTED MERGE uses GnuCash's Dining, not Groceries
+        assert "Expenses:Dining" in content
+
+    def test_partial_match_generated_doc_link(self, tmp_path):
+        content = self._write(tmp_path, partial=[_partial_result("boci-0012-2026-04.pdf")])
+        assert 'doc_link: "bank_statements/boci-0012-2026-04.pdf"' in content
+
+    def test_unresolved_do_not_import(self, tmp_path):
+        content = self._write(tmp_path, unresolved=[_unresolved_tx()])
+        assert "[UNRESOLVED — DO NOT IMPORT]" in content
+
+    def test_unresolved_fully_commented(self, tmp_path):
+        content = self._write(tmp_path, unresolved=[_unresolved_tx()])
+        unresolved_lines = []
+        in_section = False
+        for line in content.splitlines():
+            if "UNRESOLVED" in line and "=====" in line:
+                in_section = True
+            if in_section and line.strip():
+                unresolved_lines.append(line)
+        live_lines = [ln for ln in unresolved_lines if not ln.startswith(";;")]
+        assert live_lines == []
+
+    def test_no_live_reconcile_autopay(self, tmp_path):
+        content = self._write(
+            tmp_path,
+            new=[_new_tx()],
+            likely_dup=[_dup_result()],
+            partial=[_partial_result()],
+            unresolved=[_unresolved_tx()],
+        )
+        live_lines = [ln for ln in content.splitlines() if not ln.startswith(";;") and AUTOPAY_ACCOUNT in ln]
+        assert live_lines == []
+
+    def test_autopay_in_new_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="Reconcile:Autopay"):
+            self._write(tmp_path, new=[_unresolved_tx()])
+
+    def test_doc_link_prefix(self, tmp_path):
+        content = self._write(tmp_path, new=[_new_tx(pdf="boci.pdf")])
+        assert 'doc_link: "bank_statements/boci.pdf"' in content
+
+    def test_cjk_in_output(self, tmp_path):
+        content = self._write(tmp_path, new=[_new_tx(desc="自動轉賬")])
+        assert "自動轉賬" in content
+
+    def test_two_source_pdfs_uses_first(self, tmp_path):
+        tx = _new_tx()
+        tx.source_pdfs = ["boci.pdf", "bochk.pdf"]
+        content = self._write(tmp_path, new=[tx])
+        assert 'doc_link: "bank_statements/boci.pdf"' in content
+        assert "bochk.pdf" not in content  # bank PDF not in doc_link
+
+    def test_empty_all_buckets(self, tmp_path):
+        content = self._write(tmp_path)
+        assert "=====" in content  # section headers present
+        assert content  # not empty

--- a/tests/unit/services/test_ready_to_import_writer.py
+++ b/tests/unit/services/test_ready_to_import_writer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import date
 from decimal import Decimal
 from pathlib import Path

--- a/tests/unit/services/test_reconcile_preview_reader.py
+++ b/tests/unit/services/test_reconcile_preview_reader.py
@@ -1,0 +1,173 @@
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from infrastructure.pdf.standard_tx import Split, StandardTransaction
+from services.reconcile_preview_reader import ReconcilePreviewReader
+from services.reconcile_preview_writer import ReconcilePreviewWriter
+
+AUTOPAY_ACCOUNT = "Reconcile:Autopay"
+
+
+def _resolved_tx(desc: str = "AUTOPAY INGROUP", pdf: str = "boci.pdf") -> StandardTransaction:
+    return StandardTransaction(
+        post_date=date(2026, 4, 15),
+        description=desc,
+        currency="HKD",
+        splits=[
+            Split("Liabilities:BOCI-0012", Decimal("247.10")),
+            Split("Assets:BOC HKD Saving", Decimal("-247.10")),
+        ],
+        source_pdfs=[pdf],
+    )
+
+
+def _unresolved_tx() -> StandardTransaction:
+    return StandardTransaction(
+        post_date=date(2026, 4, 2),
+        description="BOC CREDIT CARD",
+        currency="HKD",
+        splits=[
+            Split("Assets:BOC HKD Saving", Decimal("-125.00")),
+            Split(AUTOPAY_ACCOUNT, Decimal("125.00")),
+        ],
+        source_pdfs=["bochk.pdf"],
+    )
+
+
+def _normal_tx(desc: str = "Salary") -> StandardTransaction:
+    return StandardTransaction(
+        post_date=date(2026, 3, 29),
+        description="Salary",
+        currency="HKD",
+        splits=[
+            Split("Assets:BOC HKD Saving", Decimal("18110.00")),
+            Split("Income:Salary:HKD", Decimal("-18110.00")),
+        ],
+        source_pdfs=["bochk.pdf"],
+    )
+
+
+class TestRoundTrip:
+    def _rw(self, tmp_path: Path, resolved, unresolved, normal):
+        p = str(tmp_path / "_reconcile.txt")
+        ReconcilePreviewWriter().write(p, resolved, unresolved, normal)
+        return ReconcilePreviewReader().read(p)
+
+    def test_round_trip_resolved(self, tmp_path):
+        tx = _resolved_tx()
+        importable, unresolved = self._rw(tmp_path, [tx], [], [])
+        assert len(importable) == 1
+        assert importable[0].description == tx.description
+        assert importable[0].post_date == tx.post_date
+
+    def test_round_trip_unresolved(self, tmp_path):
+        tx = _unresolved_tx()
+        importable, unresolved = self._rw(tmp_path, [], [tx], [])
+        assert len(unresolved) == 1
+        assert any(s.account == AUTOPAY_ACCOUNT for s in unresolved[0].splits)
+
+    def test_normal_tx_in_importable(self, tmp_path):
+        tx = _normal_tx()
+        importable, unresolved = self._rw(tmp_path, [], [], [tx])
+        assert len(importable) == 1
+        assert importable[0].description == "Salary"
+
+    def test_total_count_preserved(self, tmp_path):
+        resolved = [_resolved_tx()]
+        unresolved = [_unresolved_tx()]
+        normal = [_normal_tx(), _normal_tx("Rent")]
+        importable_out, unresolved_out = self._rw(tmp_path, resolved, unresolved, normal)
+        assert len(importable_out) + len(unresolved_out) == 4
+
+    def test_section_position_irrelevant(self, tmp_path):
+        # Write unresolved tx under RESOLVED header by constructing file manually
+        p = str(tmp_path / "_reconcile.txt")
+        with open(p, "w", encoding="utf-8") as f:
+            f.write(";; ===== RESOLVED =====\n\n")
+            f.write('2026-04-02 * "BOC CREDIT CARD"\n')
+            f.write('\tdoc_link: "bank_statements/bochk.pdf"\n')
+            f.write('\tcurrency.mnemonic: "HKD"\n')
+            f.write('\tAssets:BOC HKD Saving -125.00 HKD\n')
+            f.write(f'\t{AUTOPAY_ACCOUNT} 125.00 HKD\n\n')
+        importable, unresolved = ReconcilePreviewReader().read(p)
+        assert len(unresolved) == 1
+        assert len(importable) == 0
+
+    def test_comment_lines_skipped(self, tmp_path):
+        p = str(tmp_path / "_reconcile.txt")
+        with open(p, "w", encoding="utf-8") as f:
+            f.write(";; This is a comment\n")
+            f.write(";; ===== RESOLVED =====\n")
+            f.write(";; another comment\n\n")
+            f.write('2026-04-15 * "AUTOPAY INGROUP"\n')
+            f.write('\tcurrency.mnemonic: "HKD"\n')
+            f.write('\tLiabilities:BOCI-0012 247.10 HKD\n')
+            f.write('\tAssets:BOC HKD Saving -247.10 HKD\n\n')
+        importable, unresolved = ReconcilePreviewReader().read(p)
+        assert len(importable) == 1
+        for split in importable[0].splits:
+            assert ";;" not in split.account
+
+    def test_empty_file(self, tmp_path):
+        p = str(tmp_path / "_reconcile.txt")
+        Path(p).write_text("", encoding="utf-8")
+        importable, unresolved = ReconcilePreviewReader().read(p)
+        assert importable == []
+        assert unresolved == []
+
+    def test_importable_never_contains_autopay(self, tmp_path):
+        txs = [_resolved_tx(), _normal_tx(), _unresolved_tx()]
+        importable, _ = self._rw(tmp_path, [txs[0]], [txs[2]], [txs[1]])
+        for tx in importable:
+            for split in tx.splits:
+                assert split.account != AUTOPAY_ACCOUNT
+
+    def test_doc_link_prefix(self, tmp_path):
+        p = str(tmp_path / "_reconcile.txt")
+        ReconcilePreviewWriter().write(p, [_resolved_tx(pdf="boci.pdf")], [], [])
+        content = Path(p).read_text(encoding="utf-8")
+        assert 'doc_link: "bank_statements/boci.pdf"' in content
+
+    def test_cjk_preserved(self, tmp_path):
+        tx = _resolved_tx(desc="自動轉賬")
+        importable, _ = self._rw(tmp_path, [tx], [], [])
+        assert importable[0].description == "自動轉賬"
+
+    def test_three_splits_round_trip(self, tmp_path):
+        tx = StandardTransaction(
+            post_date=date(2026, 4, 15),
+            description="Split expense",
+            currency="HKD",
+            splits=[
+                Split("Assets:Bank", Decimal("300.00")),
+                Split("Expenses:Dining", Decimal("-200.00")),
+                Split("Expenses:Groceries", Decimal("-100.00")),
+            ],
+            source_pdfs=["test.pdf"],
+        )
+        importable, _ = self._rw(tmp_path, [tx], [], [])
+        assert len(importable[0].splits) == 3
+
+    def test_guid_round_trip(self, tmp_path):
+        tx = _resolved_tx()
+        tx.guid = "abc123"
+        importable, _ = self._rw(tmp_path, [tx], [], [])
+        assert importable[0].guid == "abc123"
+
+    def test_two_source_pdfs(self, tmp_path):
+        tx = StandardTransaction(
+            post_date=date(2026, 4, 15),
+            description="AUTOPAY INGROUP",
+            currency="HKD",
+            splits=[
+                Split("Liabilities:BOCI-0012", Decimal("247.10")),
+                Split("Assets:BOC HKD Saving", Decimal("-247.10")),
+            ],
+            source_pdfs=["boci.pdf", "bochk.pdf"],
+        )
+        importable, _ = self._rw(tmp_path, [tx], [], [])
+        assert importable[0].source_pdfs[0] == "boci.pdf"
+        assert importable[0].source_pdfs[1] == "bochk.pdf"

--- a/tests/unit/services/test_reconcile_preview_reader.py
+++ b/tests/unit/services/test_reconcile_preview_reader.py
@@ -157,7 +157,8 @@ class TestRoundTrip:
         importable, _ = self._rw(tmp_path, [tx], [], [])
         assert importable[0].guid == "abc123"
 
-    def test_two_source_pdfs(self, tmp_path):
+    def test_two_source_pdfs_card_first_is_doc_link(self, tmp_path):
+        # Only source_pdfs[0] (card PDF) is written as doc_link — bank PDF is dropped
         tx = StandardTransaction(
             post_date=date(2026, 4, 15),
             description="AUTOPAY INGROUP",
@@ -170,4 +171,4 @@ class TestRoundTrip:
         )
         importable, _ = self._rw(tmp_path, [tx], [], [])
         assert importable[0].source_pdfs[0] == "boci.pdf"
-        assert importable[0].source_pdfs[1] == "bochk.pdf"
+        assert len(importable[0].source_pdfs) == 1  # only card PDF survives round-trip

--- a/tests/unit/services/test_reconcile_preview_reader.py
+++ b/tests/unit/services/test_reconcile_preview_reader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import date
 from decimal import Decimal
 from pathlib import Path

--- a/tests/unit/services/test_statement_reconciler.py
+++ b/tests/unit/services/test_statement_reconciler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import date
 from decimal import Decimal
 

--- a/tests/unit/services/test_statement_reconciler.py
+++ b/tests/unit/services/test_statement_reconciler.py
@@ -1,0 +1,168 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from infrastructure.pdf.standard_tx import Split, StandardTransaction
+from services.statement_reconciler import AUTOPAY_ACCOUNT, StatementReconciler
+
+
+def bank_tx(
+    amount: str = "247.10",
+    date_: date = date(2026, 4, 15),
+    currency: str = "HKD",
+    pdf: str = "bochk.pdf",
+) -> StandardTransaction:
+    return StandardTransaction(
+        post_date=date_,
+        description="BOC CREDIT CARD",
+        currency=currency,
+        splits=[
+            Split("Assets:BOC HKD Saving", Decimal(f"-{amount}")),
+            Split(AUTOPAY_ACCOUNT, Decimal(amount)),
+        ],
+        source_pdfs=[pdf],
+    )
+
+
+def card_tx(
+    amount: str = "247.10",
+    date_: date = date(2026, 4, 15),
+    currency: str = "HKD",
+    pdf: str = "boci.pdf",
+    card_account: str = "Liabilities:BOCI-0012",
+) -> StandardTransaction:
+    return StandardTransaction(
+        post_date=date_,
+        description="AUTOPAY INGROUP",
+        currency=currency,
+        splits=[
+            Split(card_account, Decimal(amount)),
+            Split(AUTOPAY_ACCOUNT, Decimal(f"-{amount}")),
+        ],
+        source_pdfs=[pdf],
+    )
+
+
+def normal_tx(desc: str = "Salary") -> StandardTransaction:
+    return StandardTransaction(
+        post_date=date(2026, 4, 15),
+        description=desc,
+        currency="HKD",
+        splits=[
+            Split("Assets:BOC HKD Saving", Decimal("18110.00")),
+            Split("Income:Salary:HKD", Decimal("-18110.00")),
+        ],
+        source_pdfs=["bochk.pdf"],
+    )
+
+
+class TestStatementReconciler:
+    def setup_method(self):
+        self.r = StatementReconciler()
+
+    def test_clean_match(self):
+        resolved, unresolved, normal = self.r.reconcile([bank_tx(), card_tx()])
+        assert len(resolved) == 1
+        assert len(unresolved) == 0
+
+    def test_merged_no_autopay_account(self):
+        resolved, _, _ = self.r.reconcile([bank_tx(), card_tx()])
+        for split in resolved[0].splits:
+            assert split.account != AUTOPAY_ACCOUNT
+
+    def test_merged_card_description_wins(self):
+        resolved, _, _ = self.r.reconcile([bank_tx(), card_tx()])
+        assert resolved[0].description == "AUTOPAY INGROUP"
+
+    def test_merged_card_date_wins(self):
+        resolved, _, _ = self.r.reconcile([
+            bank_tx(date_=date(2026, 4, 14)),
+            card_tx(date_=date(2026, 4, 15)),
+        ])
+        assert resolved[0].post_date == date(2026, 4, 15)
+
+    def test_merged_source_pdfs_card_first(self):
+        resolved, _, _ = self.r.reconcile([bank_tx(), card_tx()])
+        assert resolved[0].source_pdfs == ["boci.pdf", "bochk.pdf"]
+
+    def test_date_plus_one_matches(self):
+        resolved, unresolved, _ = self.r.reconcile([
+            bank_tx(date_=date(2026, 4, 14)),
+            card_tx(date_=date(2026, 4, 15)),
+        ])
+        assert len(resolved) == 1
+        assert len(unresolved) == 0
+
+    def test_date_minus_one_matches(self):
+        resolved, unresolved, _ = self.r.reconcile([
+            bank_tx(date_=date(2026, 4, 15)),
+            card_tx(date_=date(2026, 4, 14)),
+        ])
+        assert len(resolved) == 1
+        assert len(unresolved) == 0
+
+    def test_date_plus_two_no_match(self):
+        _, unresolved, _ = self.r.reconcile([
+            bank_tx(date_=date(2026, 4, 13)),
+            card_tx(date_=date(2026, 4, 15)),
+        ])
+        assert len(unresolved) == 2
+
+    def test_partial_run_bank_only(self):
+        _, unresolved, _ = self.r.reconcile([bank_tx()])
+        assert len(unresolved) == 1
+
+    def test_partial_run_card_only(self):
+        _, unresolved, _ = self.r.reconcile([card_tx()])
+        assert len(unresolved) == 1
+
+    def test_same_side_collision_both_unresolved(self):
+        _, unresolved, _ = self.r.reconcile([
+            bank_tx(amount="247.10"),
+            bank_tx(amount="247.10"),
+            card_tx(amount="247.10"),
+        ])
+        assert len(unresolved) == 3
+
+    def test_cross_side_collision_all_unresolved(self):
+        _, unresolved, _ = self.r.reconcile([
+            bank_tx(amount="247.10"),
+            card_tx(amount="247.10", pdf="boci-0012.pdf"),
+            card_tx(amount="247.10", pdf="aeon.pdf"),
+        ])
+        assert len(unresolved) == 3
+
+    def test_currency_mismatch_no_match(self):
+        _, unresolved, _ = self.r.reconcile([
+            bank_tx(currency="HKD"),
+            card_tx(currency="CNY"),
+        ])
+        assert len(unresolved) == 2
+
+    def test_normal_passthrough(self):
+        tx = normal_tx()
+        _, _, normal = self.r.reconcile([tx])
+        assert normal == [tx]
+
+    def test_mixed_batch(self):
+        txs = [
+            normal_tx("Salary"),
+            normal_tx("Rent"),
+            bank_tx(amount="247.10"),
+            card_tx(amount="247.10"),
+            bank_tx(amount="999.99"),  # unresolved — no matching card
+        ]
+        resolved, unresolved, normal = self.r.reconcile(txs)
+        assert len(resolved) == 1
+        assert len(unresolved) == 1
+        assert len(normal) == 2
+
+    def test_cny_match(self):
+        resolved, unresolved, _ = self.r.reconcile([
+            bank_tx(amount="312.99", currency="CNY"),
+            card_tx(amount="312.99", currency="CNY"),
+        ])
+        assert len(resolved) == 1
+        assert resolved[0].currency == "CNY"
+        assert len(unresolved) == 0


### PR DESCRIPTION
## Summary

Adds the public repo infrastructure for importing bank/credit card PDF statements into GnuCash, with cross-statement autopay reconciliation and fuzzy duplicate detection.

- **F-005**: `StandardTransaction`, `Split` dataclasses and `StatementProvider` protocol — the common data model for all PDF statement parsers
- **F-006**: `StatementReconciler` — matches `Reconcile:Autopay` placeholder pairs across statements (bank side ↔ card side) by date ±1 day, amount, currency
- **F-007**: `ReconcilePreviewWriter` + `ReconcilePreviewReader` — writes/reads `_reconcile.txt` preview file; `source_pdfs[0]` (card statement, most informative) used as `doc_link`
- **F-008**: `GnuCashFuzzyMatcher` — READ_ONLY session, extracts Python-native `_IndexEntry` objects then closes session immediately (fixes session-leak OOM); classifies candidates as NEW / LIKELY_DUP / PARTIAL_MATCH
- **F-009**: `ReadyToImportWriter` + end-to-end pipeline test — four-bucket output with `[DO NOT IMPORT]` safety for unresolved autopay; 755 tests passing

## Key design decisions

- **Session leak fix (F-008)**: `GnuCashFuzzyMatcher` opens READ_ONLY session, extracts all data into `_IndexEntry` objects, closes session in `finally`. Prevents 9 open sessions × GnuCash book in memory = OOM kill at 52% of test suite.
- **Lazy GnuCash imports**: `gnucash_fuzzy_matcher.py` imports GnuCash C extension only inside `_build_index()` — unit tests import the module without triggering the heavy load.
- **No `Reconcile:Autopay` in live blocks**: `ReadyToImportWriter` raises `ValueError` if a NEW transaction contains the placeholder, preventing garbage accounts being written to GnuCash.
- **`doc_link` = `source_pdfs[0]`**: card statement PDF used as primary document (contains individual transaction details vs bank statement which just shows autopay total).

## Test plan

- [x] 755 tests passing across all supported GnuCash versions (Debian 13/12/11, Ubuntu 20/22)
- [x] No OOM — full suite runs in ~127s, same as before this PR
- [x] End-to-end integration test: StandardTransaction → reconciler → writer → reader → fuzzy matcher → ready-to-import writer → correct output
- [x] Tested with real April 2026 BOCHK/BOCI/AEON HK PDF statements in Docker
- [x] Idempotency: running fuzzy match twice returns same status and GUID