### PR TITLE
feat(F-010): extend KVP custom metadata to business objects and accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,14 +219,18 @@ Formula `value` = `share_price` * Split_Amount, e.g., 3.68 = 368/2170 * 21.70
 
 ### Custom Metadata
 
-GnuCash supports arbitrary key-value pairs (KVP slots) on any transaction or split.
-gnucash-plaintext exposes this as **custom metadata**: any tag in a transaction or
-split block that is not a reserved field (see tables below) is automatically stored
-in the GnuCash KVP layer and round-trips through export/import without loss.
+GnuCash supports arbitrary key-value pairs (KVP slots) on all its object types.
+gnucash-plaintext exposes this as **custom metadata**: any field in a block that is
+not a reserved field (see tables below) is automatically stored in the GnuCash KVP
+layer and round-trips through export/import without loss.
 
-This makes the format directly comparable to beancount's open-ended metadata model.
+This applies to **every object type** — transactions, splits, accounts, customers,
+vendors, invoices, and bills — making the format directly comparable to beancount's
+open-ended metadata model.
 
-#### Reserved transaction fields (stored via dedicated GnuCash setters)
+#### Reserved fields per object type
+
+**Transaction** — reserved fields use dedicated GnuCash setters:
 
 | Field | GnuCash field |
 |-------|--------------|
@@ -236,7 +240,7 @@ This makes the format directly comparable to beancount's open-ended metadata mod
 | `doc_link` | Document link / association |
 | `notes` | Transaction notes |
 
-#### Reserved split fields (stored via dedicated GnuCash setters)
+**Split** — reserved fields use dedicated GnuCash setters:
 
 | Field | GnuCash field |
 |-------|--------------|
@@ -246,6 +250,60 @@ This makes the format directly comparable to beancount's open-ended metadata mod
 | `memo` | Split memo |
 | `account.commodity.mnemonic` | Account commodity mnemonic |
 | `account.commodity.namespace` | Account commodity namespace |
+
+**Account** (`open` directive) — reserved fields:
+
+| Field | GnuCash field |
+|-------|--------------|
+| `guid` | Account GUID |
+| `type` | Account type |
+| `placeholder` | Placeholder flag |
+| `code` | Account code |
+| `description` | Account description |
+| `color` | Account color |
+| `notes` | Account notes |
+| `tax_related` | Tax-related flag |
+| `commodity.namespace` | Commodity namespace |
+| `commodity.mnemonic` | Commodity mnemonic |
+| `commodity_scu` | Commodity smallest currency unit |
+
+**Customer** — reserved fields:
+
+| Field | GnuCash field |
+|-------|--------------|
+| `name` | Customer name |
+| `currency` | Customer currency |
+| `addr1`–`addr4` | Billing address lines |
+| `email` | Contact email |
+
+**Vendor** — reserved fields:
+
+| Field | GnuCash field |
+|-------|--------------|
+| `name` | Vendor name |
+| `currency` | Vendor currency |
+
+**Invoice** — reserved fields:
+
+| Field | GnuCash field |
+|-------|--------------|
+| `customer_id` | Customer reference |
+| `currency` | Invoice currency |
+| `date_opened` | Invoice open date |
+| `billing_id` | Billing ID |
+| `notes` | Invoice notes |
+| `posted` | Posted block / sentinel |
+| `payment` | Payment block / sentinel |
+
+**Bill** — reserved fields:
+
+| Field | GnuCash field |
+|-------|--------------|
+| `vendor_id` | Vendor reference |
+| `currency` | Bill currency |
+| `date_opened` | Bill open date |
+| `posted` | Posted block / sentinel |
+| `payment` | Payment block / sentinel |
 
 #### Any other key → KVP slot
 
@@ -257,8 +315,10 @@ object are stored together in a single JSON object.
 - Colons (`:`) are **not allowed** in custom metadata key names. The plaintext
   format uses `key: value` syntax, so a colon inside a key name would create
   parsing ambiguity. An error is raised at import time if a colon is found.
-- Use **dots** for hierarchical keys (e.g. `tax.category`, `receipt.id`).
+- Use **dots** for hierarchical keys (e.g. `tax.category`, `jw.country`).
   Dots are already used by convention in the reserved fields above.
+
+**Transaction / split example:**
 
 ```
 2024-06-15 * "Dinner with client"
@@ -272,13 +332,36 @@ object are stored together in a single JSON object.
 	Assets:Bank:Checking -85.00 CAD
 ```
 
-In the example above:
-- `guid`, `notes` → stored via dedicated GnuCash API (reserved fields)
+- `guid`, `notes` → reserved fields, stored via dedicated GnuCash API
 - `tax_category`, `receipt_id` → stored in the transaction's KVP slot
 - `vendor`, `approved_by` → stored in the Dining split's KVP slot
 
-When you export this transaction back to plaintext, all four custom keys will
-appear in the output exactly as written.
+**Customer / account example:**
+
+```
+customer "CUST-001"
+  name: "Acme Logistics"
+  currency: CAD
+  addr1: "2000 McGill College Ave"
+  addr3: "Montreal"
+  addr4: "QC"
+  jw.country: "CA"
+  jw.postal_code: "H3A 3H3"
+
+2024-01-01 open Assets:Bank:Checking
+	type: "BANK"
+	commodity.namespace: CURRENCY
+	commodity.mnemonic: CAD
+	erp.cost_centre: "DEPT-42"
+```
+
+- `name`, `currency`, `addr1`–`addr4` → reserved customer fields
+- `jw.country`, `jw.postal_code` → stored in the customer's KVP slot
+- `type`, `commodity.*` → reserved account fields
+- `erp.cost_centre` → stored in the account's KVP slot
+
+All custom keys are emitted after the standard fields on export, preserving the
+round-trip exactly.
 
 #### Update merges custom metadata
 
@@ -307,7 +390,7 @@ After the second import the transaction carries all three keys: `receipt_id`,
 
 #### Cross-version compatibility
 
-KVP metadata works on all supported GnuCash versions:
+KVP metadata works on all supported GnuCash versions for all object types:
 
 | GnuCash version | OS | API used |
 |---|---|---|

--- a/docs/issues/F-010-kvp-metadata-all-object-types.md
+++ b/docs/issues/F-010-kvp-metadata-all-object-types.md
@@ -1,0 +1,278 @@
+# F-010: KVP Custom Metadata for All GnuCash Object Types
+
+## Status
+
+Open
+
+## Summary
+
+Extend the `plaintext_metadata` KVP slot mechanism — already implemented for
+`Transaction` and `Split` — to every other GnuCash object type that gnucash-plaintext
+imports and exports:
+
+| Object type | Import | Export |
+|---|---|---|
+| `Transaction` | ✅ done | ✅ done |
+| `Split` | ✅ done | ✅ done |
+| `customer` | ❌ unknown keys silently dropped | ❌ not emitted |
+| `vendor` | ❌ unknown keys silently dropped | ❌ not emitted |
+| `invoice` | ❌ unknown keys silently dropped | ❌ not emitted |
+| `bill` | ❌ unknown keys silently dropped | ❌ not emitted |
+| `open` (account) | ❌ unknown keys silently dropped | ❌ not emitted |
+
+TaxTable is a structured object with no natural free-form metadata slot in the
+GnuCash data model; it is out of scope for this issue.
+
+---
+
+## Motivation
+
+June Works uses gnucash-plaintext to manage GnuCash customer objects as the
+source of truth for client data.  They need to store structured metadata beyond
+the 4-line billing address (`jw.country`, `jw.postal_code`) without breaking
+compatibility with the standard GnuCash address fields.
+
+More broadly, any gnucash-plaintext user who extends their workflow with
+namespace-prefixed keys (e.g. `crm.salesforce_id`, `erp.cost_centre`) on
+**any** object type currently loses that data silently on import and never
+sees it on export.  This is a correctness gap: gnucash-plaintext claims to
+be a round-trip format, but custom keys on non-transaction objects are not
+part of the round-trip.
+
+---
+
+## Current Behaviour
+
+### Import side (`services/gnucash_importer.py`)
+
+`import_customer`, `import_vendor`, `import_invoice`, `import_bill`, and
+`create_account` each process a fixed set of known keys from
+`directive.metadata`. Any key not in the known set is silently discarded:
+
+```python
+# import_customer — known keys only; jw.country silently dropped
+customer.SetName(directive.metadata['name'])
+addr.SetAddr1(directive.metadata.get('addr1', ''))
+customer.CommitEdit()
+# ← jw.country, jw.postal_code etc. are gone here
+```
+
+### Export side
+
+`_export_customers`, `_export_vendors`, `_export_invoices`, `_export_bills`
+(in `use_cases/export_business_objects.py`) and `_format_account`
+(in `use_cases/export_transactions.py`) emit only their fixed field sets.
+No code reads the `plaintext_metadata` KVP slot on these objects.
+
+---
+
+## Desired Behaviour
+
+Any key on a directive block that is **not** in the object's known set should
+be stored in the GnuCash object's `plaintext_metadata` KVP slot (same JSON
+format as transactions) and re-emitted on export after the standard fields.
+
+### Example — customer
+
+```
+customer "CUST-001"
+  name: "Acme Logistics"
+  currency: CAD
+  addr1: "2000 McGill College Ave"
+  addr3: "Montreal"
+  addr4: "QC"
+  jw.country: "CA"
+  jw.postal_code: "H3A 3H3"
+```
+
+After import, `jw.country` and `jw.postal_code` are stored in the customer's
+`plaintext_metadata` KVP slot.  On export they are emitted after the standard
+fields, producing the same text above.
+
+### Example — account
+
+```
+2024-01-01 open Assets:Bank:Checking
+	guid: "abc123"
+	type: "BANK"
+	commodity.namespace: CURRENCY
+	commodity.mnemonic: CAD
+	erp.cost_centre: "DEPT-42"
+```
+
+`erp.cost_centre` survives the import → export round-trip via the account's
+`plaintext_metadata` KVP slot.
+
+---
+
+## Implementation Plan
+
+### 1. Known-key sets (add to `infrastructure/gnucash/kvp.py`)
+
+```python
+KNOWN_CUSTOMER_METADATA_KEYS = frozenset({
+    'name', 'currency', 'addr1', 'addr2', 'addr3', 'addr4', 'email',
+})
+
+KNOWN_VENDOR_METADATA_KEYS = frozenset({
+    'name', 'currency',
+})
+
+KNOWN_INVOICE_METADATA_KEYS = frozenset({
+    'customer_id', 'currency', 'date_opened', 'billing_id', 'notes',
+    'posted', 'payment',
+})
+
+KNOWN_BILL_METADATA_KEYS = frozenset({
+    'vendor_id', 'currency', 'date_opened', 'posted', 'payment',
+})
+
+KNOWN_ACCOUNT_METADATA_KEYS = frozenset({
+    'guid', 'type', 'placeholder', 'code', 'description', 'color',
+    'notes', 'tax_related', 'commodity.namespace', 'commodity.mnemonic',
+    'commodity_scu',
+})
+```
+
+### 2. Import (`services/gnucash_importer.py`)
+
+For each object type, after `CommitEdit()`, extract unknown keys and call
+`set_custom_metadata(obj, custom_meta)`:
+
+```python
+# import_customer
+custom_meta = {k: v for k, v in directive.metadata.items()
+               if k not in KNOWN_CUSTOMER_METADATA_KEYS and v is not None}
+if custom_meta:
+    set_custom_metadata(customer, custom_meta)
+```
+
+Same pattern for `import_vendor`, `import_invoice`, `import_bill`, and
+`create_account`.
+
+**Note on invoices/bills**: only top-level `directive.metadata` keys are
+considered.  Keys inside sub-directives (`entry:`, `posted:`, `payment:`)
+are sub-directive metadata and are not relevant here.
+
+### 3. Export
+
+#### `use_cases/export_business_objects.py`
+
+After emitting all standard fields in `_export_customers`, `_export_vendors`,
+`_export_invoices`, and `_export_bills`, append KVP metadata lines:
+
+```python
+from infrastructure.gnucash.kvp import get_custom_metadata
+
+custom_meta = get_custom_metadata(cust)
+for k, v in sorted(custom_meta.items()):
+    lines.append(f'  {k}: "{v}"')
+```
+
+#### `use_cases/export_transactions.py` — `_format_account`
+
+After all standard field lines, append KVP metadata using tab indentation
+(matching the account block style):
+
+```python
+custom_meta = get_custom_metadata(account)
+for k, v in sorted(custom_meta.items()):
+    lines.append(f'\t{k}: {encode_value_as_string(v)}')
+```
+
+### 4. `get_custom_metadata` already works on business objects
+
+`get_custom_metadata` calls `_get_string_slot` → `obj.GetSlots()` (SWIG path)
+or `qof_instance_get_kvp` (ctypes path).  Both `Customer` and `Account` are
+`QofInstance` subclasses, so the same code path works — no infrastructure
+changes needed.
+
+**Verify** that `Customer.GetSlots()` and `Account.GetSlots()` exist on the
+supported platforms (Debian 11/12/13, Ubuntu 20/22/24) and fall back to
+ctypes correctly if not.
+
+---
+
+## Test Cases
+
+All tests should use real GnuCash sessions (no mocks), following the pattern
+in `tests/unit/services/test_kvp_metadata.py`.
+
+Add a new test file: **`tests/integration/test_kvp_all_objects.py`**
+
+### Customer
+
+| ID | Test | Expected |
+|---|---|---|
+| C-KVP-01 | Import customer with `jw.country: "CA"` and `jw.postal_code: "H3A 3H3"` | Both keys persisted in GnuCash KVP after save/reload |
+| C-KVP-02 | Export customer with `jw.country` and `jw.postal_code` in KVP slot | Both keys appear in plaintext output after standard fields |
+| C-KVP-03 | Full round-trip: import → save → export | Custom keys survive without loss |
+| C-KVP-04 | Two customers: KVP on CUST-001 must not appear on CUST-002 | Isolation between objects |
+| C-KVP-05 | Known keys (`name`, `addr1`, `email`) still work correctly | No regression |
+| C-KVP-06 | `jw:country` (colon in key) on import raises `ValueError` | Error on import, not silent drop |
+
+### Vendor
+
+| ID | Test | Expected |
+|---|---|---|
+| V-KVP-01 | Import vendor with `erp.vendor_code: "V-42"` | Key persisted in KVP |
+| V-KVP-02 | Export vendor with KVP key | Key appears in output |
+| V-KVP-03 | Full round-trip | Key survives |
+
+### Invoice
+
+| ID | Test | Expected |
+|---|---|---|
+| I-KVP-01 | Import invoice with `jw.po_ref: "PO-2024-001"` | Key persisted in invoice KVP |
+| I-KVP-02 | Export invoice with KVP key | Key appears after standard invoice fields |
+| I-KVP-03 | Full round-trip | Key survives |
+
+### Bill
+
+| ID | Test | Expected |
+|---|---|---|
+| B-KVP-01 | Import bill with `erp.ref: "ERP-001"` | Key persisted in bill KVP |
+| B-KVP-02 | Export bill with KVP key | Key appears after standard bill fields |
+| B-KVP-03 | Full round-trip | Key survives |
+
+### Account
+
+| ID | Test | Expected |
+|---|---|---|
+| A-KVP-01 | Import account with `erp.cost_centre: "DEPT-42"` | Key persisted in account KVP |
+| A-KVP-02 | Export account with KVP key | Key appears after standard account fields (tab-indented) |
+| A-KVP-03 | Full round-trip | Key survives |
+| A-KVP-04 | Known account keys (`guid`, `type`, `notes`, etc.) are not stored as KVP | No regression |
+
+---
+
+## Acceptance Criteria
+
+1. All C-KVP, V-KVP, I-KVP, B-KVP, A-KVP tests pass on Debian 13 (primary CI target).
+2. No regressions in existing business-objects tests (`tests/integration/test_business_objects.py`).
+3. No regressions in existing KVP tests (`tests/unit/services/test_kvp_metadata.py`).
+4. Known-key constants defined in `infrastructure/gnucash/kvp.py` (not scattered across importer).
+
+---
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `infrastructure/gnucash/kvp.py` | Add `KNOWN_CUSTOMER_METADATA_KEYS`, `KNOWN_VENDOR_METADATA_KEYS`, `KNOWN_INVOICE_METADATA_KEYS`, `KNOWN_BILL_METADATA_KEYS`, `KNOWN_ACCOUNT_METADATA_KEYS` |
+| `services/gnucash_importer.py` | `import_customer`, `import_vendor`, `import_invoice`, `import_bill`, `create_account` — write unknown keys to KVP |
+| `use_cases/export_business_objects.py` | `_export_customers`, `_export_vendors`, `_export_invoices`, `_export_bills` — emit KVP metadata |
+| `use_cases/export_transactions.py` | `_format_account` — emit KVP metadata |
+| `tests/integration/test_kvp_all_objects.py` | New comprehensive test file |
+
+---
+
+## Notes
+
+- The `plaintext_metadata` slot name and JSON serialisation format are
+  unchanged — all existing transaction/split KVP data on disk is unaffected.
+- `get_custom_metadata` already sanitises stored colon keys (drops them with
+  a warning), so any legacy data from before the key-validation rule was added
+  will not cause failures on export.
+- Invoice and bill sub-directives (`entry:`, `posted:`, `payment:`) do **not**
+  need KVP support in this issue; they are structural not free-form metadata.

--- a/infrastructure/gnucash/kvp.py
+++ b/infrastructure/gnucash/kvp.py
@@ -47,6 +47,34 @@ KNOWN_SPLIT_METADATA_KEYS = frozenset({
     'account.commodity.namespace',
 })
 
+# Customer metadata keys that have dedicated GnuCash setters.
+KNOWN_CUSTOMER_METADATA_KEYS = frozenset({
+    'name', 'currency', 'addr1', 'addr2', 'addr3', 'addr4', 'email',
+})
+
+# Vendor metadata keys that have dedicated GnuCash setters.
+KNOWN_VENDOR_METADATA_KEYS = frozenset({
+    'name', 'currency',
+})
+
+# Invoice metadata keys that have dedicated GnuCash setters.
+KNOWN_INVOICE_METADATA_KEYS = frozenset({
+    'customer_id', 'currency', 'date_opened', 'billing_id', 'notes',
+    'posted', 'payment',
+})
+
+# Bill metadata keys that have dedicated GnuCash setters.
+KNOWN_BILL_METADATA_KEYS = frozenset({
+    'vendor_id', 'currency', 'date_opened', 'posted', 'payment',
+})
+
+# Account metadata keys that have dedicated GnuCash setters.
+KNOWN_ACCOUNT_METADATA_KEYS = frozenset({
+    'guid', 'type', 'placeholder', 'code', 'description', 'color',
+    'notes', 'tax_related', 'commodity.namespace', 'commodity.mnemonic',
+    'commodity_scu',
+})
+
 
 # ---------------------------------------------------------------------------
 # GLib GValue helper (used for GnuCash 3.8 ctypes path)

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -29,8 +29,13 @@ from gnucash.gnucash_core_c import (
 )
 
 from infrastructure.gnucash.kvp import (
+    KNOWN_ACCOUNT_METADATA_KEYS,
+    KNOWN_BILL_METADATA_KEYS,
+    KNOWN_CUSTOMER_METADATA_KEYS,
+    KNOWN_INVOICE_METADATA_KEYS,
     KNOWN_SPLIT_METADATA_KEYS,
     KNOWN_TX_METADATA_KEYS,
+    KNOWN_VENDOR_METADATA_KEYS,
     get_custom_metadata,
     set_custom_metadata,
 )
@@ -169,6 +174,11 @@ class GnuCashImporter:
         account.SetCode(code)
         account.SetDescription(description)
         account.SetTaxRelated(tax_related)
+
+        custom_meta = {k: v for k, v in directive.metadata.items()
+                       if k not in KNOWN_ACCOUNT_METADATA_KEYS and v is not None}
+        if custom_meta:
+            set_custom_metadata(account, custom_meta)
 
         if 'commodity_scu' in directive.metadata:
             commodity_scu = directive.metadata['commodity_scu']
@@ -485,6 +495,10 @@ class GnuCashImporter:
         addr.SetEmail(directive.metadata.get('email', ''))
 
         customer.CommitEdit()
+        custom_meta = {k: v for k, v in directive.metadata.items()
+                       if k not in KNOWN_CUSTOMER_METADATA_KEYS and v is not None}
+        if custom_meta:
+            set_custom_metadata(customer, custom_meta)
         logging.debug(f"Created customer {directive.props['id']}")
 
     @staticmethod
@@ -496,6 +510,10 @@ class GnuCashImporter:
         vendor.BeginEdit()
         vendor.SetName(directive.metadata['name'])
         vendor.CommitEdit()
+        custom_meta = {k: v for k, v in directive.metadata.items()
+                       if k not in KNOWN_VENDOR_METADATA_KEYS and v is not None}
+        if custom_meta:
+            set_custom_metadata(vendor, custom_meta)
         logging.debug(f"Created vendor {directive.props['id']}")
 
     @staticmethod
@@ -625,6 +643,10 @@ class GnuCashImporter:
                 invoice.ApplyPayment(None, bank_account, amount, GncNumeric(1, 1), pay_date, memo, num)
 
         invoice.CommitEdit()
+        custom_meta = {k: v for k, v in directive.metadata.items()
+                       if k not in KNOWN_INVOICE_METADATA_KEYS and v is not None}
+        if custom_meta:
+            set_custom_metadata(invoice, custom_meta)
         logging.debug(f"Created invoice {directive.props['id']}")
 
     @staticmethod
@@ -722,6 +744,10 @@ class GnuCashImporter:
                 bill.ApplyPayment(None, bank_account, neg_amount, GncNumeric(1, 1), pay_date, memo, num)
 
         bill.CommitEdit()
+        custom_meta = {k: v for k, v in directive.metadata.items()
+                       if k not in KNOWN_BILL_METADATA_KEYS and v is not None}
+        if custom_meta:
+            set_custom_metadata(bill, custom_meta)
         logging.debug(f"Created bill {directive.props['id']}")
 
     def import_business_objects(self, directives: List[PlaintextDirective], book: Book):

--- a/tests/integration/test_kvp_all_objects.py
+++ b/tests/integration/test_kvp_all_objects.py
@@ -1,0 +1,838 @@
+"""
+Integration tests for KVP metadata on customer, vendor, invoice, bill, and account objects.
+
+Covers test cases C-KVP-01 through A-KVP-04 as described in F-010.
+
+Tests use real GnuCash sessions (no mocks). Run in Docker via scripts/test.sh.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Session helpers (same pattern as test_kvp_metadata.py)
+# ---------------------------------------------------------------------------
+
+def _make_session(path):
+    """Open a new GnuCash session at *path* (SESSION_NEW_STORE)."""
+    from gnucash import Session
+    try:
+        from gnucash import SessionOpenMode
+        return Session(f'xml://{path}', SessionOpenMode.SESSION_NEW_STORE)
+    except ImportError:
+        return Session(f'xml://{path}', is_new=True)
+
+
+def _open_session(path):
+    """Open an existing GnuCash session at *path*."""
+    from gnucash import Session
+    try:
+        from gnucash import SessionOpenMode
+        return Session(f'xml://{path}', SessionOpenMode.SESSION_NORMAL_OPEN)
+    except ImportError:
+        return Session(f'xml://{path}')
+
+
+def _make_biz_book():
+    """
+    Create a minimal GnuCash book with accounts needed for business objects:
+      - Assets:Accounts Receivable  (RECEIVABLE)
+      - Assets:Bank:Checking        (BANK)
+      - Liabilities:Accounts Payable (PAYABLE)
+      - Income:Services             (INCOME)
+      - Expenses:Purchases          (EXPENSE)
+
+    Returns (session, book, path). Caller is responsible for cleanup.
+    """
+    import gnucash
+    from gnucash import Account
+
+    fd, path = tempfile.mkstemp(suffix='.gnucash')
+    os.close(fd)
+    os.unlink(path)
+
+    session = _make_session(path)
+    book = session.book
+    root = book.get_root_account()
+    cad = book.get_table().lookup('CURRENCY', 'CAD')
+
+    def _acct(name, acct_type, parent):
+        a = Account(book)
+        a.SetName(name)
+        a.SetType(acct_type)
+        a.SetCommodity(cad)
+        parent.append_child(a)
+        return a
+
+    assets = _acct('Assets', gnucash.ACCT_TYPE_ASSET, root)
+    _acct('Accounts Receivable', gnucash.ACCT_TYPE_RECEIVABLE, assets)
+    bank = _acct('Bank', gnucash.ACCT_TYPE_BANK, assets)
+    _acct('Checking', gnucash.ACCT_TYPE_BANK, bank)
+
+    liabilities = _acct('Liabilities', gnucash.ACCT_TYPE_LIABILITY, root)
+    _acct('Accounts Payable', gnucash.ACCT_TYPE_PAYABLE, liabilities)
+
+    income = _acct('Income', gnucash.ACCT_TYPE_INCOME, root)
+    _acct('Services', gnucash.ACCT_TYPE_INCOME, income)
+
+    expenses = _acct('Expenses', gnucash.ACCT_TYPE_EXPENSE, root)
+    _acct('Purchases', gnucash.ACCT_TYPE_EXPENSE, expenses)
+
+    return session, book, path
+
+
+def _cleanup(path):
+    """Remove GnuCash file and its lock file if they exist."""
+    if os.path.exists(path):
+        os.unlink(path)
+    lock = path + '.LCK'
+    if os.path.exists(lock):
+        os.unlink(lock)
+
+
+def _build_customer_directive(cust_id, name, currency='CAD', extra_meta=None):
+    """Build a PlaintextDirective for a CUSTOMER."""
+    from services.plaintext_parser import DirectiveType, PlaintextDirective
+
+    d = PlaintextDirective(DirectiveType.CUSTOMER, level=0, line='')
+    d.props = {'id': cust_id}
+    d.metadata = {'name': name, 'currency': currency}
+    if extra_meta:
+        d.metadata.update(extra_meta)
+    d.children = []
+    return d
+
+
+def _build_vendor_directive(vendor_id, name, currency='CAD', extra_meta=None):
+    """Build a PlaintextDirective for a VENDOR."""
+    from services.plaintext_parser import DirectiveType, PlaintextDirective
+
+    d = PlaintextDirective(DirectiveType.VENDOR, level=0, line='')
+    d.props = {'id': vendor_id}
+    d.metadata = {'name': name, 'currency': currency}
+    if extra_meta:
+        d.metadata.update(extra_meta)
+    d.children = []
+    return d
+
+
+def _build_invoice_directive(inv_id, customer_id, currency='CAD', extra_meta=None):
+    """Build a minimal unposted PlaintextDirective for an INVOICE."""
+    from services.plaintext_parser import DirectiveType, PlaintextDirective
+
+    d = PlaintextDirective(DirectiveType.INVOICE, level=0, line='')
+    d.props = {'id': inv_id}
+    d.metadata = {
+        'customer_id': customer_id,
+        'currency': currency,
+        'date_opened': '2024-01-01',
+        'posted': 'none',
+        'payment': 'none',
+    }
+    if extra_meta:
+        d.metadata.update(extra_meta)
+    d.children = []
+    return d
+
+
+def _build_bill_directive(bill_id, vendor_id, currency='CAD', extra_meta=None):
+    """Build a minimal unposted PlaintextDirective for a BILL."""
+    from services.plaintext_parser import DirectiveType, PlaintextDirective
+
+    d = PlaintextDirective(DirectiveType.BILL, level=0, line='')
+    d.props = {'id': bill_id}
+    d.metadata = {
+        'vendor_id': vendor_id,
+        'currency': currency,
+        'date_opened': '2024-01-01',
+        'posted': 'none',
+        'payment': 'none',
+    }
+    if extra_meta:
+        d.metadata.update(extra_meta)
+    d.children = []
+    return d
+
+
+def _build_account_directive(account_full_name, acct_type, currency_namespace='CURRENCY',
+                              currency_mnemonic='CAD', extra_meta=None):
+    """Build a PlaintextDirective for an OPEN_ACCOUNT."""
+    from services.plaintext_parser import DirectiveType, PlaintextDirective
+
+    d = PlaintextDirective(DirectiveType.OPEN_ACCOUNT, level=0, line='')
+    d.props = {'account': account_full_name}
+    d.metadata = {
+        'type': acct_type,
+        'placeholder': False,
+        'code': '',
+        'description': '',
+        'tax_related': False,
+        'commodity.namespace': currency_namespace,
+        'commodity.mnemonic': currency_mnemonic,
+    }
+    if extra_meta:
+        d.metadata.update(extra_meta)
+    d.children = []
+    return d
+
+
+def _lookup_customers(book):
+    """Return all Customer objects from book via QOF query."""
+    import gnucash.gnucash_business as gb
+    from gnucash import Query
+    q = Query()
+    q.search_for('gncCustomer')
+    q.set_book(book)
+    customers = [gb.Customer(instance=r) for r in q.run()]
+    q.destroy()
+    return customers
+
+
+def _lookup_vendors(book):
+    """Return all Vendor objects from book via QOF query."""
+    import gnucash.gnucash_business as gb
+    from gnucash import Query
+    q = Query()
+    q.search_for('gncVendor')
+    q.set_book(book)
+    vendors = [gb.Vendor(instance=r) for r in q.run()]
+    q.destroy()
+    return vendors
+
+
+def _lookup_invoices(book):
+    """Return all Invoice objects from book via QOF query."""
+    import gnucash.gnucash_business as gb
+    from gnucash import Query
+    q = Query()
+    q.search_for('gncInvoice')
+    q.set_book(book)
+    invoices = [gb.Invoice(instance=r) for r in q.run()]
+    q.destroy()
+    return invoices
+
+
+# ---------------------------------------------------------------------------
+# TestCustomerKvp
+# ---------------------------------------------------------------------------
+
+class TestCustomerKvp:
+    def test_import_stores_custom_keys(self):
+        """C-KVP-01: import_customer with jw.country stores it as KVP."""
+        from infrastructure.gnucash.kvp import get_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_biz_book()
+        try:
+            d = _build_customer_directive(
+                'CUST-001', 'Acme Logistics',
+                extra_meta={'jw.country': 'CA', 'jw.postal_code': 'H3A 3H3'},
+            )
+            GnuCashImporter.import_customer(d, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            customers = _lookup_customers(book2)
+            assert len(customers) == 1
+            custom = get_custom_metadata(customers[0])
+            assert custom.get('jw.country') == 'CA'
+            assert custom.get('jw.postal_code') == 'H3A 3H3'
+            session2.end()
+        finally:
+            _cleanup(path)
+
+    def test_export_emits_custom_keys(self):
+        """C-KVP-02: get_custom_metadata on customer → export includes custom keys."""
+        from infrastructure.gnucash.kvp import get_custom_metadata, set_custom_metadata
+        from use_cases.export_business_objects import ExportBusinessObjectsUseCase
+
+        session, book, path = _make_biz_book()
+        try:
+            d = _build_customer_directive('CUST-002', 'Beta Corp')
+            from services.gnucash_importer import GnuCashImporter
+            GnuCashImporter.import_customer(d, book)
+
+            customers = _lookup_customers(book)
+            assert len(customers) == 1
+            set_custom_metadata(customers[0], {'jw.country': 'US', 'erp.id': 'ERP-42'})
+
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            use_case = ExportBusinessObjectsUseCase(book2)
+            output = use_case.execute()
+            session2.end()
+
+            assert 'jw.country: "US"' in output
+            assert 'erp.id: "ERP-42"' in output
+        finally:
+            _cleanup(path)
+
+    def test_roundtrip(self):
+        """C-KVP-03: import → save → export → custom keys present in output."""
+        from services.gnucash_importer import GnuCashImporter
+        from use_cases.export_business_objects import ExportBusinessObjectsUseCase
+
+        session, book, path = _make_biz_book()
+        try:
+            d = _build_customer_directive(
+                'CUST-003', 'Gamma Ltd',
+                extra_meta={'jw.country': 'CA', 'jw.tier': 'premium'},
+            )
+            GnuCashImporter.import_customer(d, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            use_case = ExportBusinessObjectsUseCase(book2)
+            output = use_case.execute()
+            session2.end()
+
+            assert 'jw.country: "CA"' in output
+            assert 'jw.tier: "premium"' in output
+        finally:
+            _cleanup(path)
+
+    def test_kvp_isolation_between_customers(self):
+        """C-KVP-04: custom KVP on one customer does not appear on another."""
+        from services.gnucash_importer import GnuCashImporter
+        from use_cases.export_business_objects import ExportBusinessObjectsUseCase
+
+        session, book, path = _make_biz_book()
+        try:
+            d1 = _build_customer_directive(
+                'CUST-010', 'Alpha Inc',
+                extra_meta={'jw.secret': 'alpha-only'},
+            )
+            d2 = _build_customer_directive('CUST-011', 'Beta Inc')
+            GnuCashImporter.import_customer(d1, book)
+            GnuCashImporter.import_customer(d2, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            use_case = ExportBusinessObjectsUseCase(book2)
+            output = use_case.execute()
+            session2.end()
+
+            # Split output into customer blocks
+            blocks = [b for b in output.split('\n\n') if b.startswith('customer')]
+            cust10_block = next((b for b in blocks if '"CUST-010"' in b), '')
+            cust11_block = next((b for b in blocks if '"CUST-011"' in b), '')
+            assert 'jw.secret' in cust10_block
+            assert 'jw.secret' not in cust11_block
+        finally:
+            _cleanup(path)
+
+    def test_known_keys_not_stored_as_kvp(self):
+        """C-KVP-05: name, addr1, email must NOT appear in custom KVP."""
+        from infrastructure.gnucash.kvp import get_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_biz_book()
+        try:
+            d = _build_customer_directive(
+                'CUST-020', 'Delta Corp',
+                extra_meta={
+                    'addr1': '123 Main St',
+                    'email': 'test@example.com',
+                    'jw.country': 'CA',
+                },
+            )
+            GnuCashImporter.import_customer(d, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            customers = _lookup_customers(book2)
+            assert len(customers) == 1
+            custom = get_custom_metadata(customers[0])
+            assert 'name' not in custom
+            assert 'addr1' not in custom
+            assert 'email' not in custom
+            # Only the truly custom key should be present
+            assert custom.get('jw.country') == 'CA'
+            session2.end()
+        finally:
+            _cleanup(path)
+
+    def test_colon_key_raises(self):
+        """C-KVP-06: a key with ':' in directive.metadata raises ValueError."""
+        from infrastructure.gnucash.kvp import set_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_biz_book()
+        try:
+            # We test set_custom_metadata directly — import_customer only calls it
+            # for keys not in KNOWN_CUSTOMER_METADATA_KEYS, but 'jw:country' is not
+            # a known key so it would be passed through.
+            d = _build_customer_directive('CUST-030', 'Epsilon Corp')
+            GnuCashImporter.import_customer(d, book)
+            customers = _lookup_customers(book)
+            assert len(customers) == 1
+
+            with pytest.raises(ValueError, match="must not contain ':'"):
+                set_custom_metadata(customers[0], {'jw:country': 'CA'})
+
+            session.end()
+        finally:
+            _cleanup(path)
+
+
+# ---------------------------------------------------------------------------
+# TestVendorKvp
+# ---------------------------------------------------------------------------
+
+class TestVendorKvp:
+    def test_import_stores_custom_keys(self):
+        """V-KVP-01: import_vendor with custom keys stores them as KVP."""
+        from infrastructure.gnucash.kvp import get_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_biz_book()
+        try:
+            d = _build_vendor_directive(
+                'VEND-001', 'Office Supplies Inc',
+                extra_meta={'jw.country': 'CA', 'jw.vendor_type': 'supplies'},
+            )
+            GnuCashImporter.import_vendor(d, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            vendors = _lookup_vendors(book2)
+            assert len(vendors) == 1
+            custom = get_custom_metadata(vendors[0])
+            assert custom.get('jw.country') == 'CA'
+            assert custom.get('jw.vendor_type') == 'supplies'
+            session2.end()
+        finally:
+            _cleanup(path)
+
+    def test_export_emits_custom_keys(self):
+        """V-KVP-02: custom KVP on vendor appears in export output."""
+        from infrastructure.gnucash.kvp import set_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+        from use_cases.export_business_objects import ExportBusinessObjectsUseCase
+
+        session, book, path = _make_biz_book()
+        try:
+            d = _build_vendor_directive('VEND-002', 'Tech Parts Ltd')
+            GnuCashImporter.import_vendor(d, book)
+            vendors = _lookup_vendors(book)
+            assert len(vendors) == 1
+            set_custom_metadata(vendors[0], {'jw.rating': 'preferred', 'erp.code': 'V-007'})
+
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            use_case = ExportBusinessObjectsUseCase(book2)
+            output = use_case.execute()
+            session2.end()
+
+            assert 'jw.rating: "preferred"' in output
+            assert 'erp.code: "V-007"' in output
+        finally:
+            _cleanup(path)
+
+    def test_roundtrip(self):
+        """V-KVP-03: import → save → export → custom keys present in output."""
+        from services.gnucash_importer import GnuCashImporter
+        from use_cases.export_business_objects import ExportBusinessObjectsUseCase
+
+        session, book, path = _make_biz_book()
+        try:
+            d = _build_vendor_directive(
+                'VEND-003', 'Cloud Services Co',
+                extra_meta={'jw.country': 'US', 'jw.payment_terms': 'net30'},
+            )
+            GnuCashImporter.import_vendor(d, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            use_case = ExportBusinessObjectsUseCase(book2)
+            output = use_case.execute()
+            session2.end()
+
+            assert 'jw.country: "US"' in output
+            assert 'jw.payment_terms: "net30"' in output
+        finally:
+            _cleanup(path)
+
+
+# ---------------------------------------------------------------------------
+# TestInvoiceKvp
+# ---------------------------------------------------------------------------
+
+class TestInvoiceKvp:
+    def test_import_stores_custom_keys(self):
+        """I-KVP-01: import_invoice with jw.po_ref stores it as KVP."""
+        from infrastructure.gnucash.kvp import get_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_biz_book()
+        try:
+            # Create customer first
+            cust_d = _build_customer_directive('CUST-INV-001', 'Invoice Customer')
+            GnuCashImporter.import_customer(cust_d, book)
+
+            inv_d = _build_invoice_directive(
+                'INV-KVP-001', 'CUST-INV-001',
+                extra_meta={'jw.po_ref': 'PO-2024-001', 'jw.project': 'Alpha'},
+            )
+            GnuCashImporter.import_invoice(inv_d, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            invoices = _lookup_invoices(book2)
+            # Filter to customer invoices only (not bills)
+            cust_invoices = []
+            for inv in invoices:
+                try:
+                    cust = inv.GetOwner().GetCustomer()
+                    if cust is not None:
+                        cust_invoices.append(inv)
+                except Exception:
+                    pass
+            assert len(cust_invoices) == 1
+            custom = get_custom_metadata(cust_invoices[0])
+            assert custom.get('jw.po_ref') == 'PO-2024-001'
+            assert custom.get('jw.project') == 'Alpha'
+            session2.end()
+        finally:
+            _cleanup(path)
+
+    def test_export_emits_custom_keys(self):
+        """I-KVP-02: custom KVP on invoice appears in export output."""
+        from infrastructure.gnucash.kvp import set_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+        from use_cases.export_business_objects import ExportBusinessObjectsUseCase
+
+        session, book, path = _make_biz_book()
+        try:
+            cust_d = _build_customer_directive('CUST-INV-002', 'Export Invoice Customer')
+            GnuCashImporter.import_customer(cust_d, book)
+
+            inv_d = _build_invoice_directive('INV-KVP-002', 'CUST-INV-002')
+            GnuCashImporter.import_invoice(inv_d, book)
+
+            invoices = _lookup_invoices(book)
+            cust_invoices = []
+            for inv in invoices:
+                try:
+                    cust = inv.GetOwner().GetCustomer()
+                    if cust is not None:
+                        cust_invoices.append(inv)
+                except Exception:
+                    pass
+            assert len(cust_invoices) == 1
+            set_custom_metadata(cust_invoices[0], {'jw.po_ref': 'PO-EXPORT-001'})
+
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            use_case = ExportBusinessObjectsUseCase(book2)
+            output = use_case.execute()
+            session2.end()
+
+            assert 'jw.po_ref: "PO-EXPORT-001"' in output
+        finally:
+            _cleanup(path)
+
+    def test_roundtrip(self):
+        """I-KVP-03: import → save → export → custom keys present in output."""
+        from services.gnucash_importer import GnuCashImporter
+        from use_cases.export_business_objects import ExportBusinessObjectsUseCase
+
+        session, book, path = _make_biz_book()
+        try:
+            cust_d = _build_customer_directive('CUST-INV-003', 'Roundtrip Invoice Customer')
+            GnuCashImporter.import_customer(cust_d, book)
+
+            inv_d = _build_invoice_directive(
+                'INV-KVP-003', 'CUST-INV-003',
+                extra_meta={'jw.po_ref': 'PO-2024-RT', 'jw.department': 'engineering'},
+            )
+            GnuCashImporter.import_invoice(inv_d, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            use_case = ExportBusinessObjectsUseCase(book2)
+            output = use_case.execute()
+            session2.end()
+
+            assert 'jw.po_ref: "PO-2024-RT"' in output
+            assert 'jw.department: "engineering"' in output
+        finally:
+            _cleanup(path)
+
+
+# ---------------------------------------------------------------------------
+# TestBillKvp
+# ---------------------------------------------------------------------------
+
+class TestBillKvp:
+    def test_import_stores_custom_keys(self):
+        """B-KVP-01: import_bill with custom keys stores them as KVP."""
+        from infrastructure.gnucash.kvp import get_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_biz_book()
+        try:
+            vend_d = _build_vendor_directive('VEND-BILL-001', 'Bill Vendor')
+            GnuCashImporter.import_vendor(vend_d, book)
+
+            bill_d = _build_bill_directive(
+                'BILL-KVP-001', 'VEND-BILL-001',
+                extra_meta={'jw.po_ref': 'PO-BILL-001', 'jw.approver': 'Alice'},
+            )
+            GnuCashImporter.import_bill(bill_d, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            invoices = _lookup_invoices(book2)
+            bills = []
+            for inv in invoices:
+                try:
+                    vendor = inv.GetOwner().GetVendor()
+                    if vendor is not None:
+                        bills.append(inv)
+                except Exception:
+                    pass
+            assert len(bills) == 1
+            custom = get_custom_metadata(bills[0])
+            assert custom.get('jw.po_ref') == 'PO-BILL-001'
+            assert custom.get('jw.approver') == 'Alice'
+            session2.end()
+        finally:
+            _cleanup(path)
+
+    def test_export_emits_custom_keys(self):
+        """B-KVP-02: custom KVP on bill appears in export output."""
+        from infrastructure.gnucash.kvp import set_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+        from use_cases.export_business_objects import ExportBusinessObjectsUseCase
+
+        session, book, path = _make_biz_book()
+        try:
+            vend_d = _build_vendor_directive('VEND-BILL-002', 'Export Bill Vendor')
+            GnuCashImporter.import_vendor(vend_d, book)
+
+            bill_d = _build_bill_directive('BILL-KVP-002', 'VEND-BILL-002')
+            GnuCashImporter.import_bill(bill_d, book)
+
+            invoices = _lookup_invoices(book)
+            bills = []
+            for inv in invoices:
+                try:
+                    vendor = inv.GetOwner().GetVendor()
+                    if vendor is not None:
+                        bills.append(inv)
+                except Exception:
+                    pass
+            assert len(bills) == 1
+            set_custom_metadata(bills[0], {'jw.cost_centre': 'DEPT-42'})
+
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            use_case = ExportBusinessObjectsUseCase(book2)
+            output = use_case.execute()
+            session2.end()
+
+            assert 'jw.cost_centre: "DEPT-42"' in output
+        finally:
+            _cleanup(path)
+
+    def test_roundtrip(self):
+        """B-KVP-03: import → save → export → custom keys present in output."""
+        from services.gnucash_importer import GnuCashImporter
+        from use_cases.export_business_objects import ExportBusinessObjectsUseCase
+
+        session, book, path = _make_biz_book()
+        try:
+            vend_d = _build_vendor_directive('VEND-BILL-003', 'Roundtrip Bill Vendor')
+            GnuCashImporter.import_vendor(vend_d, book)
+
+            bill_d = _build_bill_directive(
+                'BILL-KVP-003', 'VEND-BILL-003',
+                extra_meta={'jw.po_ref': 'PO-BILL-RT', 'jw.category': 'office'},
+            )
+            GnuCashImporter.import_bill(bill_d, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            use_case = ExportBusinessObjectsUseCase(book2)
+            output = use_case.execute()
+            session2.end()
+
+            assert 'jw.po_ref: "PO-BILL-RT"' in output
+            assert 'jw.category: "office"' in output
+        finally:
+            _cleanup(path)
+
+
+# ---------------------------------------------------------------------------
+# TestAccountKvp
+# ---------------------------------------------------------------------------
+
+class TestAccountKvp:
+    def test_import_stores_custom_keys(self):
+        """A-KVP-01: create_account with erp.cost_centre stores it as KVP."""
+        from infrastructure.gnucash.kvp import get_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_biz_book()
+        try:
+            # The book already has an 'Expenses' root parent; add a child
+            d = _build_account_directive(
+                'Expenses:Operations',
+                'Expense',
+                extra_meta={'erp.cost_centre': 'DEPT-42', 'erp.gl_code': 'GL-500'},
+            )
+            GnuCashImporter.create_account(d, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            root = book2.get_root_account()
+            acct = root.lookup_by_name('Expenses').lookup_by_name('Operations')
+            assert acct is not None, "Account 'Expenses:Operations' not found"
+            custom = get_custom_metadata(acct)
+            assert custom.get('erp.cost_centre') == 'DEPT-42'
+            assert custom.get('erp.gl_code') == 'GL-500'
+            session2.end()
+        finally:
+            _cleanup(path)
+
+    def test_export_emits_custom_keys(self):
+        """A-KVP-02: custom KVP on account appears in export output (tab-indented)."""
+        from infrastructure.gnucash.kvp import set_custom_metadata
+        from repositories.gnucash_repository import GnuCashRepository
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        session, book, path = _make_biz_book()
+        try:
+            root = book.get_root_account()
+            acct = root.lookup_by_name('Expenses').lookup_by_name('Purchases')
+            assert acct is not None
+            set_custom_metadata(acct, {'erp.cost_centre': 'DEPT-42'})
+
+            session.save()
+            session.end()
+
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                use_case = ExportTransactionsUseCase(repo)
+                # Use all_accounts=True so accounts are exported even when there
+                # are no transactions referencing them (book has no transactions).
+                result = use_case.execute(all_accounts=True)
+                output = use_case.format_as_plaintext(result)
+            finally:
+                repo.close()
+
+            # The key should appear inside an 'open' block (tab-indented)
+            assert 'erp.cost_centre: "DEPT-42"' in output
+        finally:
+            _cleanup(path)
+
+    def test_roundtrip(self):
+        """A-KVP-03: create_account with custom KVP → save → export → key in output."""
+        from repositories.gnucash_repository import GnuCashRepository
+        from services.gnucash_importer import GnuCashImporter
+        from use_cases.export_transactions import ExportTransactionsUseCase
+
+        session, book, path = _make_biz_book()
+        try:
+            d = _build_account_directive(
+                'Expenses:Consulting',
+                'Expense',
+                extra_meta={'erp.cost_centre': 'DEPT-99', 'erp.project': 'consulting'},
+            )
+            GnuCashImporter.create_account(d, book)
+            session.save()
+            session.end()
+
+            repo = GnuCashRepository(path)
+            repo.open()
+            try:
+                use_case = ExportTransactionsUseCase(repo)
+                # Use all_accounts=True so accounts are exported even when there
+                # are no transactions referencing them (book has no transactions).
+                result = use_case.execute(all_accounts=True)
+                output = use_case.format_as_plaintext(result)
+            finally:
+                repo.close()
+
+            assert 'erp.cost_centre: "DEPT-99"' in output
+            assert 'erp.project: "consulting"' in output
+        finally:
+            _cleanup(path)
+
+    def test_known_keys_not_stored_as_kvp(self):
+        """A-KVP-04: guid, type, notes etc. must NOT appear in custom KVP."""
+        from infrastructure.gnucash.kvp import get_custom_metadata
+        from services.gnucash_importer import GnuCashImporter
+
+        session, book, path = _make_biz_book()
+        try:
+            d = _build_account_directive(
+                'Expenses:Research',
+                'Expense',
+                extra_meta={
+                    'description': 'R&D expenses',
+                    'notes': 'Research budget',
+                    'code': 'EXP-R',
+                    'erp.cost_centre': 'DEPT-RD',
+                },
+            )
+            GnuCashImporter.create_account(d, book)
+            session.save()
+            session.end()
+
+            session2 = _open_session(path)
+            book2 = session2.book
+            root = book2.get_root_account()
+            acct = root.lookup_by_name('Expenses').lookup_by_name('Research')
+            assert acct is not None
+            custom = get_custom_metadata(acct)
+            # Known keys must NOT be in custom KVP
+            for known_key in ('guid', 'type', 'placeholder', 'code', 'description',
+                              'notes', 'tax_related', 'commodity.namespace',
+                              'commodity.mnemonic', 'commodity_scu', 'color'):
+                assert known_key not in custom, (
+                    f"Known key '{known_key}' should not be stored as custom KVP"
+                )
+            # Custom key must be present
+            assert custom.get('erp.cost_centre') == 'DEPT-RD'
+            session2.end()
+        finally:
+            _cleanup(path)

--- a/use_cases/export_business_objects.py
+++ b/use_cases/export_business_objects.py
@@ -13,6 +13,7 @@ import gnucash.gnucash_core_c as gc
 from gnucash import Book, Query, Split
 
 from infrastructure.gnucash.engine import iterate_glist, load_gnc_engine, safe_ctypes_string
+from infrastructure.gnucash.kvp import get_custom_metadata
 from infrastructure.gnucash.utils import get_account_full_name
 
 
@@ -102,6 +103,9 @@ class ExportBusinessObjectsUseCase:
             ]:
                 if val:
                     lines.append(f'  {field}: "{val}"')
+            custom_meta = get_custom_metadata(cust)
+            for k, v in sorted(custom_meta.items()):
+                lines.append(f'  {k}: "{v}"')
             lines_list.append('\n'.join(lines))
         return '\n\n'.join(lines_list)
 
@@ -121,6 +125,9 @@ class ExportBusinessObjectsUseCase:
                 f'  name: "{v.GetName()}"',
                 f'  currency: {v.GetCurrency().get_mnemonic()}',
             ]
+            custom_meta = get_custom_metadata(v)
+            for k, v_val in sorted(custom_meta.items()):
+                lines.append(f'  {k}: "{v_val}"')
             lines_list.append('\n'.join(lines))
         return '\n\n'.join(lines_list)
 
@@ -199,6 +206,10 @@ class ExportBusinessObjectsUseCase:
                 lines.append(f'  billing_id: "{inv.GetBillingID()}"')
             if inv.GetNotes():
                 lines.append(f'  notes: "{inv.GetNotes()}"')
+
+            custom_meta = get_custom_metadata(inv)
+            for k, v in sorted(custom_meta.items()):
+                lines.append(f'  {k}: "{v}"')
 
             for raw_entry in inv.GetEntries():
                 lines += self._format_inv_entry(lib, raw_entry)
@@ -382,6 +393,10 @@ class ExportBusinessObjectsUseCase:
                 f'  currency: {inv.GetCurrency().get_mnemonic()}',
                 f'  date_opened: {inv.GetDateOpened().strftime("%Y-%m-%d")}',
             ]
+
+            custom_meta = get_custom_metadata(inv)
+            for k, v in sorted(custom_meta.items()):
+                lines.append(f'  {k}: "{v}"')
 
             for raw_entry in inv.GetEntries():
                 lines += self._format_bill_entry(lib, raw_entry)

--- a/use_cases/export_transactions.py
+++ b/use_cases/export_transactions.py
@@ -428,6 +428,10 @@ class ExportTransactionsUseCase:
         if commodity_scu != fraction:
             lines.append(f'\tcommodity_scu: {encode_value_as_string(commodity_scu)}')
 
+        custom_meta = get_custom_metadata(account)
+        for k, v in sorted(custom_meta.items()):
+            lines.append(f'\t{k}: {encode_value_as_string(v)}')
+
     def _format_transaction(
         self,
         transaction,


### PR DESCRIPTION
Previously, custom KVP metadata only worked for transactions and splits. Any namespace-prefixed tag (e.g. jw.country, erp.cost_centre) placed on a customer, vendor, invoice, bill, or account block was silently dropped on import and never emitted on export. This broke the round-trip guarantee that gnucash-plaintext is built on, and made it impossible to use the format as a source of truth for extended business object data.

This change makes custom metadata work the same way for every object type the format supports. Unknown fields on any block are stored in the GnuCash KVP layer and re-emitted on export, exactly as already happened for transactions. A customer can now carry jw.country and jw.postal_code alongside its billing address; an account can carry erp.cost_centre; an invoice can carry a jw.po_ref — all without touching the standard GnuCash fields and all invisible to the GnuCash desktop UI.

The known-field boundaries for each object type are defined as explicit frozensets in kvp.py so the distinction between "standard field" and "custom metadata" is a single, auditable list rather than scattered conditionals across the codebase.

README is updated to document the reserved fields for every object type and show customer and account KVP examples alongside the existing transaction examples.