### PR TITLE
feat(F-011): active flag round-trip, delete-customers, archive commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,11 @@ customer "CUST-001"
   name: "Acme Corp"
   currency: CAD
 
+customer "CUST-002"
+  name: "Retired Client"
+  currency: CAD
+  active: false
+
 vendor "VEND-001"
   name: "Office Supplies Co."
   currency: CAD
@@ -769,6 +774,61 @@ invoice "INV-2026-004"
     bank_account: "Assets:Bank"
     memo: "Second instalment"
 ```
+
+### Retiring customers and vendors (archive)
+
+Use `archive-customers` or `archive-vendors` to soft-hide one or more
+entities by setting them inactive (`SetActive(False)`). Archived entities
+are hidden from the GnuCash UI but remain in the book with all their invoice
+and bill history intact. The `active: false` field is preserved on export and
+restored on import.
+
+```bash
+# Archive one or more customers
+gnucash-plaintext archive-customers mybook.gnucash CUST-001 CUST-002
+
+# Archive one or more vendors
+gnucash-plaintext archive-vendors mybook.gnucash VEND-001
+```
+
+Per-ID status is printed for every ID requested:
+
+```
+CUST-001: archived
+CUST-002: archived — 5 invoice(s) linked
+CUST-003: already archived
+CUST-004: not found
+```
+
+The linked invoice/bill count is informational — archiving always succeeds for
+a found, currently-active entity. Exit code 1 if any ID was not found or
+already archived.
+
+### Deleting customers permanently
+
+`delete-customers` hard-deletes a customer from the book. This is irreversible.
+**Archiving is almost always the better choice** — it preserves all invoice
+history and can be undone by re-importing the record without `active: false`.
+
+Use `delete-customers` only for customers created by mistake that have **never
+had any invoices raised against them**. Deletion is blocked if any invoices
+exist (paid or unpaid):
+
+```bash
+gnucash-plaintext delete-customers mybook.gnucash CUST-001 CUST-002
+```
+
+```
+CUST-001: deleted
+CUST-002: failed — cannot delete, 3 invoice(s) linked
+CUST-003: not found
+```
+
+Exit code 1 if any ID failed or was not found.
+
+> **Note:** Vendor deletion is not supported. GnuCash's vendor entity does not
+> persist correctly through the XML backend when `Destroy()` is called — the
+> vendor reappears after save/reload. Use `archive-vendors` instead.
 
 ### Print an invoice to PDF
 

--- a/cli/delete_cmd.py
+++ b/cli/delete_cmd.py
@@ -1,0 +1,155 @@
+"""
+CLI commands for deleting and archiving GnuCash customers and vendors.
+
+delete-customers
+    Hard-delete customers by ID. Blocked if any invoices are linked (any status).
+    Exit code 1 if any ID failed or was not found.
+    NOTE: delete-vendors is NOT implemented — GnuCash's vendor Destroy() does
+    not persist correctly. Use archive-vendors to soft-hide vendors instead.
+
+archive-customers / archive-vendors
+    Soft-hide by setting active=False. Never corrupts linked invoices/bills.
+    Prints invoice/bill count as informational context when records exist.
+    Exit code 1 if any ID was not found or already archived.
+
+Per-ID output examples:
+    CUST001: deleted
+    CUST002: failed — cannot delete, 3 invoice(s) linked
+    CUST003: not found
+    VEND001: archived
+    VEND002: archived — 2 invoice(s) linked
+    VEND003: already archived
+"""
+
+import sys
+
+import click
+
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from use_cases.delete_business_objects import (
+    ArchiveCustomersUseCase,
+    ArchiveStatus,
+    ArchiveVendorsUseCase,
+    DeleteCustomersUseCase,
+    DeleteStatus,
+)
+
+
+def _run_delete(gnucash_file, ids, use_case_cls):
+    repo = GnuCashRepository(gnucash_file)
+    repo.open(mode=SessionMode.NORMAL)
+    try:
+        use_case = use_case_cls(repo.book)
+        results = use_case.execute(list(ids))
+
+        all_ok = True
+        for r in results:
+            click.echo(f'{r.id}: {r.message()}')
+            if r.status != DeleteStatus.DELETED:
+                all_ok = False
+
+        if all_ok:
+            try:
+                repo.save()
+            except Exception as e:
+                if 'ERR_FILEIO_BACKUP_ERROR' not in str(e):
+                    raise click.ClickException(f'Failed to save: {e}') from e
+        else:
+            # Only save if at least one deletion succeeded
+            if any(r.status == DeleteStatus.DELETED for r in results):
+                try:
+                    repo.save()
+                except Exception as e:
+                    if 'ERR_FILEIO_BACKUP_ERROR' not in str(e):
+                        raise click.ClickException(f'Failed to save: {e}') from e
+
+        if not all_ok:
+            sys.exit(1)
+    finally:
+        repo.close()
+
+
+def _run_archive(gnucash_file, ids, use_case_cls):
+    repo = GnuCashRepository(gnucash_file)
+    repo.open(mode=SessionMode.NORMAL)
+    try:
+        use_case = use_case_cls(repo.book)
+        results = use_case.execute(list(ids))
+
+        all_ok = True
+        for r in results:
+            click.echo(f'{r.id}: {r.message()}')
+            if r.status != ArchiveStatus.ARCHIVED:
+                all_ok = False
+
+        if any(r.status == ArchiveStatus.ARCHIVED for r in results):
+            try:
+                repo.save()
+            except Exception as e:
+                if 'ERR_FILEIO_BACKUP_ERROR' not in str(e):
+                    raise click.ClickException(f'Failed to save: {e}') from e
+
+        if not all_ok:
+            sys.exit(1)
+    finally:
+        repo.close()
+
+
+@click.command('delete-customers')
+@click.argument('gnucash_file', type=click.Path(exists=True))
+@click.argument('ids', nargs=-1, required=True)
+def delete_customers(gnucash_file, ids):
+    """
+    Hard-delete one or more customers by ID.
+
+    Deletion is blocked if the customer has any linked invoices (paid or
+    unpaid). Use archive-customers to soft-hide instead.
+
+    Exit code 1 if any ID was not deleted.
+
+    \b
+    Examples:
+      gnucash-plaintext delete-customers ledger.gnucash CUST001
+      gnucash-plaintext delete-customers ledger.gnucash CUST001 CUST002 CUST003
+    """
+    _run_delete(gnucash_file, ids, DeleteCustomersUseCase)
+
+
+@click.command('archive-customers')
+@click.argument('gnucash_file', type=click.Path(exists=True))
+@click.argument('ids', nargs=-1, required=True)
+def archive_customers(gnucash_file, ids):
+    """
+    Archive (hide) one or more customers by setting them inactive.
+
+    Linked invoices are unaffected. The invoice count is shown as
+    informational context when records exist.
+
+    Exit code 1 if any ID was not found or already archived.
+
+    \b
+    Examples:
+      gnucash-plaintext archive-customers ledger.gnucash CUST001
+      gnucash-plaintext archive-customers ledger.gnucash CUST001 CUST002
+    """
+    _run_archive(gnucash_file, ids, ArchiveCustomersUseCase)
+
+
+@click.command('archive-vendors')
+@click.argument('gnucash_file', type=click.Path(exists=True))
+@click.argument('ids', nargs=-1, required=True)
+def archive_vendors(gnucash_file, ids):
+    """
+    Archive (hide) one or more vendors by setting them inactive.
+
+    Linked bills are unaffected. The bill count is shown as informational
+    context when records exist.
+
+    Exit code 1 if any ID was not found or already archived.
+
+    \b
+    Examples:
+      gnucash-plaintext archive-vendors ledger.gnucash VEND001
+      gnucash-plaintext archive-vendors ledger.gnucash VEND001 VEND002
+    """
+    _run_archive(gnucash_file, ids, ArchiveVendorsUseCase)

--- a/cli/main.py
+++ b/cli/main.py
@@ -9,6 +9,7 @@ import click
 
 from cli.account_balance_cmd import account_balance
 from cli.close_books_cmd import close_books
+from cli.delete_cmd import archive_customers, archive_vendors, delete_customers
 from cli.delete_transaction_cmd import delete_transaction_by_guid
 from cli.export_accounts_cmd import export_accounts
 from cli.export_beancount_cmd import export_beancount
@@ -56,6 +57,9 @@ cli.add_command(income_statement, name='income-statement')
 cli.add_command(print_invoice, name='print-invoice')
 cli.add_command(account_balance, name='account-balance')
 cli.add_command(delete_transaction_by_guid, name='delete-transaction-by-guid')
+cli.add_command(delete_customers, name='delete-customers')
+cli.add_command(archive_customers, name='archive-customers')
+cli.add_command(archive_vendors, name='archive-vendors')
 
 
 if __name__ == '__main__':

--- a/docs/issues/F-011-customer-active-delete.md
+++ b/docs/issues/F-011-customer-active-delete.md
@@ -1,0 +1,255 @@
+# F-011 — Customer/Vendor Active Flag Round-Trip and Safe Deletion
+
+## Status
+Open
+
+## Problem
+
+### 1. `active` flag is silently lost on export/import
+
+GnuCash customers and vendors have an `active` boolean (managed via
+`SetActive(bool)` / `GetActive()`).  A customer marked inactive
+(`SetActive(False)`) is hidden from the GnuCash UI but remains in the book.
+
+Currently:
+
+- **Exporter** never emits the `active` field → inactive customers look
+  identical to active ones in the plaintext file.
+- **Importer** never calls `SetActive` → re-importing silently resurrects
+  every previously deactivated customer/vendor back to active.
+
+A round-trip through plaintext is therefore **data-lossy** for any book that
+uses the retire/hide workflow.
+
+### 2. No way to delete a customer that has no invoices
+
+Clients occasionally want to fully remove a customer they created by mistake
+(typo in name, duplicate entry, etc.) before any invoices are raised against
+it.
+
+> **Note on customer deletion**: deletion is a destructive, irreversible
+> operation. The recommended approach for retiring a customer is always
+> `archive-customers` (soft-hide via `SetActive(False)`), which preserves all
+> invoice history. `delete-customers` should only be used for customers that
+> were created by mistake and have never had any invoices raised against them.
+
+GnuCash exposes two options via Python bindings:
+- `SetActive(False)` — hides the customer; invoices are unaffected.
+- `Destroy()` — hard-deletes the customer from the QOF entity store.
+
+**Research findings** (verified in Docker, GnuCash 5.x):
+
+| Scenario | Customer lookup | Invoice owner after reload |
+|---|---|---|
+| `SetActive(False)` | found, `active=False` | intact, correct GUID |
+| `Destroy()` with no invoices | NOT FOUND | n/a |
+| `Destroy()` with invoices | NOT FOUND | `owner:id = 000...000` (null GUID) |
+
+`Destroy()` with linked invoices produces **permanent XML corruption**: the
+invoice's `<owner:id>` is written as the null GUID
+(`00000000000000000000000000000000`), making it an unrecoverable orphan.
+GnuCash itself logs `qof_commit_edit(): unbalanced call` during the destroy.
+
+Safe rule: **only allow `Destroy()` when the customer has zero invoices**.
+
+---
+
+## Proposed Changes
+
+### A. Active flag round-trip (customers and vendors)
+
+#### Exporter (`use_cases/export_business_objects.py`)
+
+Emit `active: false` on the customer/vendor block when `GetActive()` is
+`False`. Omit the field entirely when `True` (default — no noise for the
+common case).
+
+```
+customer "CUST001"
+  name: "Retired Corp"
+  currency: CAD
+  active: false
+```
+
+Same for vendor blocks.
+
+#### Importer (`services/gnucash_importer.py`)
+
+After `CommitEdit()`, check for the `active` key and call `SetActive(False)`
+when the value evaluates to falsy. Accepted falsy literals: `false`, `0`,
+`no`, `False` (case-insensitive). Any other value (or absent key) → leave
+active (default `True`).
+
+```python
+_FALSY = {'false', '0', 'no'}
+
+def _is_falsy(val: str) -> bool:
+    return val.strip().lower() in _FALSY
+```
+
+Note: `active` must be added to `KNOWN_CUSTOMER_METADATA_KEYS` and
+`KNOWN_VENDOR_METADATA_KEYS` in `infrastructure/gnucash/kvp.py` so it is not
+mistakenly written as KVP custom metadata.
+
+### B. CLI commands: `delete-customers` and `archive`
+
+Both operations are imperative and do not belong in the declarative plaintext
+format. They are exposed as CLI commands that accept one or more IDs and
+report per-ID status.
+
+#### `delete-customers` — hard remove customers (blocked if invoices exist)
+
+> **Vendor deletion is not implemented.** GnuCash's `gncVendorDestroy()`
+> does not properly remove the vendor from the XML backend's serialization
+> path — the vendor entity persists in the saved file regardless of the
+> in-memory state. This is a GnuCash-level issue that cannot be worked around
+> from Python. Use `archive-vendors` to soft-hide vendors instead.
+> Customer deletion (`gncCustomerDestroy`) works correctly.
+
+```
+gnucash-plaintext delete-customers FILE ID [ID ...]
+```
+
+Per-ID logic:
+1. Look up by ID. If not found → `ID: not found`, mark failed.
+2. Query all invoices for this customer (any status — paid, unpaid,
+   posted, unposted all count).
+3. If any linked → `ID: failed — cannot delete, N invoice(s) linked`, mark failed.
+4. If none → call `Destroy()`, save, print `ID: deleted`.
+
+Sample output (same IDs as archive for comparison):
+```
+CUST001: deleted
+CUST002: failed — cannot delete, 3 invoice(s) linked
+CUST003: failed — cannot delete, 3 invoice(s) linked
+CUST004: not found
+```
+
+Note that CUST002 (has invoices) and CUST003 (already archived, but has
+invoices) both fail delete for the same reason — the active flag is
+irrelevant to whether delete is allowed.
+
+#### `archive` — soft hide via `SetActive(False)` (always succeeds per found ID)
+
+```
+gnucash-plaintext archive-customers FILE ID [ID ...]
+gnucash-plaintext archive-vendors   FILE ID [ID ...]
+```
+
+Per-ID logic:
+1. Look up by ID. If not found → `ID: not found`, mark failed.
+2. If already inactive → `ID: already archived`, mark failed.
+3. Count linked invoices/bills.
+4. Call `SetActive(False)`, save.
+   - If linked count > 0 → `ID: archived — N invoice(s) linked` (informational, not a failure).
+   - Otherwise → `ID: archived`.
+
+Sample output:
+```
+CUST001: archived
+CUST002: archived — 3 invoice(s) linked
+CUST003: already archived
+CUST004: not found
+```
+
+`SetActive(False)` never corrupts linked invoices/bills — the invoice count
+is informational only, telling the user why `delete` would have been blocked.
+Verified in Docker: invoice owner GUID remains intact after save/reload.
+
+#### Exit codes (both commands)
+
+Exit code `0` only when every requested ID succeeded. Any failed or
+not-found ID → exit code `1`.
+
+#### Why payment status does not matter for `delete-customers`
+
+Verified in Docker: `Destroy()` on a customer with a fully **paid** invoice
+produces the same null-GUID XML corruption as an unpaid invoice. The invoice
+stores the customer GUID as a foreign key regardless of payment state —
+once the customer entity is freed, GnuCash writes
+`<owner:id type="guid">00000000000000000000000000000000</owner:id>`.
+
+---
+
+## Files to Change
+
+| File | Change |
+|---|---|
+| `infrastructure/gnucash/kvp.py` | Add `'active'` to `KNOWN_CUSTOMER_METADATA_KEYS` and `KNOWN_VENDOR_METADATA_KEYS` |
+| `use_cases/export_business_objects.py` | Emit `active: false` in `_export_customers` and `_export_vendors` when inactive |
+| `services/gnucash_importer.py` | Call `SetActive(False)` in `import_customer`/`import_vendor` when `active` field is present and falsy |
+| `use_cases/delete_business_objects.py` | New: `DeleteCustomersUseCase`, `ArchiveCustomersUseCase`, `ArchiveVendorsUseCase`; each returns list of `(id, status, detail)` |
+| `cli/delete_cmd.py` | New Click commands `delete-customers`, `archive-customers`, `archive-vendors`; print per-ID status; exit 1 if any failed |
+| `cli/main.py` | Register the three new commands |
+| `tests/fixtures/business_objects.txt` | Add an inactive customer and inactive vendor to the round-trip fixture |
+| `tests/integration/test_business_objects.py` | Assert `active: false` survives round-trip |
+| `tests/integration/test_delete_business_objects.py` | New: delete succeeds with no invoices; delete fails with linked invoices; archive sets inactive; archive on already-inactive; not-found; exit codes |
+
+---
+
+## Out of Scope
+
+- Deleting invoices/bills (out of scope — too destructive without a full audit trail).
+- Deleting tax tables (GnuCash does not garbage-collect orphan tables; out of scope).
+- `active` flag on invoices themselves (`gncInvoiceSetActive` exists but is
+  internal to GnuCash's posting workflow — not user-facing).
+
+---
+
+## Research Notes
+
+### Compatibility matrix (verified in Docker across all supported distros)
+
+| Distro | GnuCash | `SetActive(False)` persists | `GetActive()` after reload | Invoice owner intact | `Destroy()` (no invoices) removes customer |
+|---|---|---|---|---|---|
+| Debian 13 (latest) | 5.x | ✅ | ✅ `False` | ✅ | ✅ |
+| Debian 12 | 4.13 | ✅ | ✅ `False` | ✅ | ✅ |
+| Debian 11 | 4.4 | ✅ | ✅ `False` | ✅ | ✅ |
+| Ubuntu 22.04 | 4.8 | ✅ | ✅ `False` | ✅ | ✅ |
+| Ubuntu 20.04 | 3.8 | ✅ | ✅ `False` | ✅ | ✅ |
+
+All distros confirmed with save/reload cycle and XML inspection.
+
+**Ubuntu 20.04 API note**: `SessionOpenMode` does not exist on GnuCash 3.8.
+The importer and any new CLI commands must use the existing
+`make_session`/`reload_session` pattern from `conftest.py` (try/except
+`ImportError` on `SessionOpenMode`). The use-case and CLI layers already go
+through `GnuCashRepository` which handles this internally — no extra work
+needed.
+
+### XML behaviour
+
+- `SetActive(False)` writes `<cust:active>0</cust:active>` to XML.
+  Field is omitted entirely when active (default `True`) — no noise.
+- QOF query `search_for('gncCustomer')` returns **both** active and inactive
+  customers — no filtering needed in the exporter.
+- `Destroy()` on a customer with any linked invoice (paid or unpaid) writes
+  `<owner:id type="guid">00000000000000000000000000000000</owner:id>` to the
+  invoice XML — permanent orphan, unrecoverable after reload.
+- `Destroy()` with no linked invoices cleanly removes the customer; zero
+  customers found after reload, no XML corruption.
+
+### Why vendor deletion is not supported
+
+`gncVendorDestroy()` was empirically tested across all supported distros and
+confirmed broken: despite reporting success in memory (QOF query count drops
+by 1 after calling Destroy), the vendor entity is **always re-written to the
+XML file** on `session.save()`. After save/reload the vendor count and data
+are unchanged, as if Destroy() was never called.
+
+The same test on customers works correctly — `gncCustomerDestroy()` properly
+removes the customer from the serialized file.
+
+The root cause appears to be in GnuCash's XML backend serialization path for
+vendors (the backend iterates a different internal structure from the QOF
+collection for vendor entities). Calling `qof_collection_remove_entity()` via
+ctypes before `Destroy()` also does not help — the vendor still reappears
+after save.
+
+**This cannot be fixed from Python without modifying GnuCash's C code.**
+`archive-vendors` (`SetActive(False)`) works correctly and is the supported
+path for retiring vendors.
+
+---
+
+**Created**: 2026-05-05

--- a/infrastructure/gnucash/kvp.py
+++ b/infrastructure/gnucash/kvp.py
@@ -49,12 +49,12 @@ KNOWN_SPLIT_METADATA_KEYS = frozenset({
 
 # Customer metadata keys that have dedicated GnuCash setters.
 KNOWN_CUSTOMER_METADATA_KEYS = frozenset({
-    'name', 'currency', 'addr1', 'addr2', 'addr3', 'addr4', 'email',
+    'name', 'currency', 'addr1', 'addr2', 'addr3', 'addr4', 'email', 'active',
 })
 
 # Vendor metadata keys that have dedicated GnuCash setters.
 KNOWN_VENDOR_METADATA_KEYS = frozenset({
-    'name', 'currency',
+    'name', 'currency', 'active',
 })
 
 # Invoice metadata keys that have dedicated GnuCash setters.

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -57,6 +57,14 @@ def string_to_gnc_numeric_quantity(s):
         return GncNumeric(num, den)
 
 
+_FALSY_STRINGS = {'false', '0', 'no'}
+
+
+def _is_falsy(val: str) -> bool:
+    """Return True if val is a recognised falsy string (case-insensitive)."""
+    return val.strip().lower() in _FALSY_STRINGS
+
+
 ACCT_TYPE_MAP = {
     "Asset": ACCT_TYPE_ASSET,
     "Bank": ACCT_TYPE_BANK,
@@ -495,6 +503,8 @@ class GnuCashImporter:
         addr.SetEmail(directive.metadata.get('email', ''))
 
         customer.CommitEdit()
+        if _is_falsy(directive.metadata.get('active', 'true')):
+            customer.SetActive(False)
         custom_meta = {k: v for k, v in directive.metadata.items()
                        if k not in KNOWN_CUSTOMER_METADATA_KEYS and v is not None}
         if custom_meta:
@@ -510,6 +520,8 @@ class GnuCashImporter:
         vendor.BeginEdit()
         vendor.SetName(directive.metadata['name'])
         vendor.CommitEdit()
+        if _is_falsy(directive.metadata.get('active', 'true')):
+            vendor.SetActive(False)
         custom_meta = {k: v for k, v in directive.metadata.items()
                        if k not in KNOWN_VENDOR_METADATA_KEYS and v is not None}
         if custom_meta:

--- a/tests/fixtures/business_objects.txt
+++ b/tests/fixtures/business_objects.txt
@@ -43,9 +43,19 @@ customer "1"
   name: "Test Customer"
   currency: CAD
 
+customer "2"
+  name: "Retired Customer"
+  currency: CAD
+  active: false
+
 vendor "V001"
   name: "Test Vendor"
   currency: CAD
+
+vendor "V002"
+  name: "Retired Vendor"
+  currency: CAD
+  active: false
 
 taxtable "GST"
   entry:

--- a/tests/fixtures/business_objects_biz_only.txt
+++ b/tests/fixtures/business_objects_biz_only.txt
@@ -2,9 +2,19 @@ customer "1"
   name: "Test Customer"
   currency: CAD
 
+customer "2"
+  name: "Retired Customer"
+  currency: CAD
+  active: false
+
 vendor "V001"
   name: "Test Vendor"
   currency: CAD
+
+vendor "V002"
+  name: "Retired Vendor"
+  currency: CAD
+  active: false
 
 taxtable "GST"
   entry:

--- a/tests/fixtures/business_objects_only.txt
+++ b/tests/fixtures/business_objects_only.txt
@@ -2,9 +2,19 @@ customer "1"
   name: "Test Customer"
   currency: CAD
 
+customer "2"
+  name: "Retired Customer"
+  currency: CAD
+  active: false
+
 vendor "V001"
   name: "Test Vendor"
   currency: CAD
+
+vendor "V002"
+  name: "Retired Vendor"
+  currency: CAD
+  active: false
 
 taxtable "GST"
   entry:

--- a/tests/integration/test_delete_business_objects.py
+++ b/tests/integration/test_delete_business_objects.py
@@ -1,0 +1,343 @@
+"""
+Integration tests for delete-customers, delete-vendors,
+archive-customers, archive-vendors CLI commands (F-011).
+
+Covers:
+  - active flag round-trip: inactive customer/vendor exported with
+    "active: false" and re-imported correctly (GetActive() == False)
+  - delete: succeeds (exit 0) when no invoices/bills linked
+  - delete: fails (exit 1) when invoices/bills are linked; entity survives
+  - delete: fails (exit 1) for unknown ID; no file corruption
+  - delete: mixed batch — partial success still saves, exits 1
+  - archive: succeeds (exit 0) for active customer/vendor
+  - archive: reports invoice/bill count in output (informational)
+  - archive: fails (exit 1) for already-archived entity
+  - archive: fails (exit 1) for unknown ID
+  - archive: mixed batch
+"""
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURE = "tests/fixtures/business_objects.txt"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def import_fixture(runner, gnucash_file, fixture=FIXTURE):
+    import time
+    result = runner.invoke(cli, [
+        "import", "--new", str(gnucash_file), fixture, "--include-business-objects",
+    ])
+    assert result.exit_code == 0, f"Import failed:\n{result.output}"
+    # GnuCash backup filenames use a per-second timestamp. Without a pause,
+    # the next save in the same test would collide with the import's backup
+    # timestamp and fail silently. 1 second is enough to guarantee a new
+    # timestamp on the subsequent save.
+    time.sleep(1)
+
+
+def export_biz(runner, gnucash_file):
+    import os
+    import tempfile
+    fd, out = tempfile.mkstemp(suffix='.txt')
+    os.close(fd)
+    try:
+        result = runner.invoke(cli, ["export", str(gnucash_file), out,
+                                     "--include-business-objects"])
+        assert result.exit_code == 0, f"Export failed:\n{result.output}"
+        with open(out, encoding='utf-8') as f:
+            return f.read()
+    finally:
+        os.unlink(out)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A. Active flag round-trip
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_active_flag_roundtrip_customer(tmp_path):
+    """active: false on customer survives import → export cycle."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+    exported = export_biz(runner, gf)
+    # Customer "2" is inactive in the fixture
+    assert 'customer "2"' in exported
+    assert '  active: false' in exported
+
+
+def test_active_flag_roundtrip_vendor(tmp_path):
+    """active: false on vendor survives import → export cycle."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+    exported = export_biz(runner, gf)
+    assert 'vendor "V002"' in exported
+    assert '  active: false' in exported
+
+
+def test_active_customer_has_no_active_field(tmp_path):
+    """Active customers must NOT emit an 'active:' line (omit when true)."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+    exported = export_biz(runner, gf)
+    lines = exported.splitlines()
+    in_cust1 = False
+    for line in lines:
+        if line == 'customer "1"':
+            in_cust1 = True
+        elif in_cust1 and line and not line.startswith(' '):
+            break
+        elif in_cust1:
+            assert 'active:' not in line, \
+                "Active customer must not emit active: field"
+
+
+def test_active_vendor_has_no_active_field(tmp_path):
+    """Active vendors must NOT emit an 'active:' line."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+    exported = export_biz(runner, gf)
+    lines = exported.splitlines()
+    in_v001 = False
+    for line in lines:
+        if line == 'vendor "V001"':
+            in_v001 = True
+        elif in_v001 and line and not line.startswith(' '):
+            break
+        elif in_v001:
+            assert 'active:' not in line, \
+                "Active vendor must not emit active: field"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# B. delete-customers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_delete_customer_no_invoices(tmp_path):
+    """delete-customers succeeds (exit 0) when customer has no invoices."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    result = runner.invoke(cli, ["delete-customers", str(gf), "2"])
+    assert result.exit_code == 0, result.output
+    assert "2: deleted" in result.output
+
+    # Customer "2" must be gone from subsequent export
+    exported = export_biz(runner, gf)
+    assert 'customer "2"' not in exported
+
+
+def test_delete_customer_with_invoices_blocked(tmp_path):
+    """delete-customers fails (exit 1) when customer has linked invoices."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    # Customer "1" has invoices in the fixture
+    result = runner.invoke(cli, ["delete-customers", str(gf), "1"])
+    assert result.exit_code == 1
+    assert "1: failed" in result.output
+    assert "cannot delete" in result.output
+    assert "invoice" in result.output
+
+    # Customer "1" must still exist
+    exported = export_biz(runner, gf)
+    assert 'customer "1"' in exported
+
+
+def test_delete_customer_not_found(tmp_path):
+    """delete-customers exits 1 and reports not found for unknown ID."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    result = runner.invoke(cli, ["delete-customers", str(gf), "DOES-NOT-EXIST"])
+    assert result.exit_code == 1
+    assert "DOES-NOT-EXIST: not found" in result.output
+
+
+def test_delete_customers_batch_mixed(tmp_path):
+    """delete-customers batch: one succeeds, one blocked, exit 1 overall."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    result = runner.invoke(cli, ["delete-customers", str(gf), "2", "1"])
+    assert result.exit_code == 1
+    assert "2: deleted" in result.output
+    assert "1: failed" in result.output
+
+    exported = export_biz(runner, gf)
+    assert 'customer "2"' not in exported   # successfully deleted
+    assert 'customer "1"' in exported        # blocked, still present
+
+
+def test_delete_customer_inactive_no_invoices(tmp_path):
+    """Inactive customer with no invoices can still be hard-deleted."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    # "2" is inactive and has no invoices
+    result = runner.invoke(cli, ["delete-customers", str(gf), "2"])
+    assert result.exit_code == 0
+    assert "2: deleted" in result.output
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# C. archive-customers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_archive_customer_active_no_invoices(tmp_path):
+    """archive-customers on active customer with no invoices: archived, exit 0."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    # "2" is active-imported-as-inactive but after re-import it's inactive —
+    # use a fresh active customer without invoices by deleting "2" first and
+    # checking "1" archive shows invoice count.
+    # Instead: archive "2" which is already inactive → should show already archived
+    # Actually "2" is imported with active: false, so it IS already archived.
+    # We need to test with customer "1" (active, has invoices) to get invoice count.
+
+    result = runner.invoke(cli, ["archive-customers", str(gf), "1"])
+    assert result.exit_code == 0, result.output
+    assert "1: archived" in result.output
+    # "1" has invoices — should show count
+    assert "invoice" in result.output
+
+    exported = export_biz(runner, gf)
+    # "1" must still exist but now inactive
+    lines = exported.splitlines()
+    in_cust1 = False
+    found_active_false = False
+    for line in lines:
+        if line == 'customer "1"':
+            in_cust1 = True
+        elif in_cust1 and line and not line.startswith(' '):
+            break
+        elif in_cust1 and 'active: false' in line:
+            found_active_false = True
+    assert found_active_false, "Archived customer must have active: false in export"
+
+
+def test_archive_customer_already_archived(tmp_path):
+    """archive-customers on already-inactive customer: already archived, exit 1."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    # "2" is imported as inactive
+    result = runner.invoke(cli, ["archive-customers", str(gf), "2"])
+    assert result.exit_code == 1
+    assert "2: already archived" in result.output
+
+
+def test_archive_customer_not_found(tmp_path):
+    """archive-customers exits 1 for unknown ID."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    result = runner.invoke(cli, ["archive-customers", str(gf), "DOES-NOT-EXIST"])
+    assert result.exit_code == 1
+    assert "DOES-NOT-EXIST: not found" in result.output
+
+
+def test_archive_customers_batch_mixed(tmp_path):
+    """archive-customers batch: active succeeds, already-archived fails, exit 1."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    result = runner.invoke(cli, ["archive-customers", str(gf), "1", "2"])
+    assert result.exit_code == 1
+    assert "1: archived" in result.output
+    assert "2: already archived" in result.output
+
+
+def test_archive_customer_invoice_count_in_output(tmp_path):
+    """archive-customers shows linked invoice count when invoices exist."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    result = runner.invoke(cli, ["archive-customers", str(gf), "1"])
+    assert result.exit_code == 0
+    # Must show count of linked invoices, not just "archived"
+    import re
+    assert re.search(r'1: archived — \d+ invoice', result.output), \
+        f"Expected invoice count in output, got: {result.output!r}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# D. archive-vendors
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_archive_vendor_with_bills(tmp_path):
+    """archive-vendors on active vendor with bills: archived with count, exit 0."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    result = runner.invoke(cli, ["archive-vendors", str(gf), "V001"])
+    assert result.exit_code == 0, result.output
+    assert "V001: archived" in result.output
+    assert "invoice" in result.output
+
+    exported = export_biz(runner, gf)
+    lines = exported.splitlines()
+    in_v001 = False
+    found_active_false = False
+    for line in lines:
+        if line == 'vendor "V001"':
+            in_v001 = True
+        elif in_v001 and line and not line.startswith(' '):
+            break
+        elif in_v001 and 'active: false' in line:
+            found_active_false = True
+    assert found_active_false, "Archived vendor must have active: false in export"
+
+
+def test_archive_vendor_already_archived(tmp_path):
+    """archive-vendors on already-inactive vendor: already archived, exit 1."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    result = runner.invoke(cli, ["archive-vendors", str(gf), "V002"])
+    assert result.exit_code == 1
+    assert "V002: already archived" in result.output
+
+
+def test_archive_vendor_not_found(tmp_path):
+    """archive-vendors exits 1 for unknown ID."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    result = runner.invoke(cli, ["archive-vendors", str(gf), "DOES-NOT-EXIST"])
+    assert result.exit_code == 1
+    assert "DOES-NOT-EXIST: not found" in result.output
+
+
+def test_archive_vendors_batch_mixed(tmp_path):
+    """archive-vendors batch: active succeeds, already-archived fails, exit 1."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    result = runner.invoke(cli, ["archive-vendors", str(gf), "V001", "V002"])
+    assert result.exit_code == 1
+    assert "V001: archived" in result.output
+    assert "V002: already archived" in result.output

--- a/use_cases/delete_business_objects.py
+++ b/use_cases/delete_business_objects.py
@@ -1,0 +1,162 @@
+"""
+Use cases for deleting and archiving GnuCash customers and vendors.
+
+delete-customers — hard-removes a customer via Destroy(); blocked if any
+                   invoices are linked (paid or unpaid, posted or unposted).
+                   NOTE: vendor deletion is NOT supported — GnuCash's
+                   gncVendorDestroy does not properly remove the entity from
+                   the XML backend's serialization path, so the vendor
+                   reappears after save/reload regardless of the in-memory
+                   state. Use archive-vendors instead.
+
+archive — sets SetActive(False); always succeeds for a found, currently-active
+          entity; reports the linked invoice/bill count as informational context.
+
+Both use cases accept a list of IDs and return one result per ID so callers
+can display per-ID status lines and compute an overall exit code.
+"""
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import List
+
+import gnucash.gnucash_business as gb
+from gnucash import Book, Query
+
+
+class DeleteStatus(Enum):
+    DELETED = auto()
+    FAILED_HAS_INVOICES = auto()
+    NOT_FOUND = auto()
+
+
+class ArchiveStatus(Enum):
+    ARCHIVED = auto()
+    ALREADY_ARCHIVED = auto()
+    NOT_FOUND = auto()
+
+
+@dataclass
+class DeleteResult:
+    id: str
+    status: DeleteStatus
+    invoice_count: int = 0  # > 0 only for FAILED_HAS_INVOICES
+
+    def message(self) -> str:
+        if self.status == DeleteStatus.DELETED:
+            return 'deleted'
+        if self.status == DeleteStatus.FAILED_HAS_INVOICES:
+            noun = 'invoice(s)' if self.invoice_count != 1 else 'invoice'
+            return f'failed — cannot delete, {self.invoice_count} {noun} linked'
+        return 'not found'
+
+
+@dataclass
+class ArchiveResult:
+    id: str
+    status: ArchiveStatus
+    invoice_count: int = 0  # informational; > 0 when linked invoices exist
+
+    def message(self) -> str:
+        if self.status == ArchiveStatus.ALREADY_ARCHIVED:
+            return 'already archived'
+        if self.status == ArchiveStatus.NOT_FOUND:
+            return 'not found'
+        # ARCHIVED
+        if self.invoice_count > 0:
+            noun = 'invoice(s)' if self.invoice_count != 1 else 'invoice'
+            return f'archived — {self.invoice_count} {noun} linked'
+        return 'archived'
+
+
+def _count_invoices_for_owner(book: Book, owner_id: str, owner_type_int: int) -> int:
+    """Count invoices/bills linked to a given owner ID and owner-type integer.
+
+    owner_type_int: 2 = Customer (GNC_OWNER_CUSTOMER), 4 = Vendor (GNC_OWNER_VENDOR)
+    """
+    q = Query()
+    q.search_for('gncInvoice')
+    q.set_book(book)
+    invoices = list(q.run())
+    q.destroy()
+    count = 0
+    for r in invoices:
+        inv = gb.Invoice(instance=r)
+        if inv.GetOwnerType() != owner_type_int:
+            continue
+        try:
+            if owner_type_int == 2:  # Customer
+                owner = inv.GetOwner().GetCustomer()
+            else:                    # Vendor
+                owner = inv.GetOwner().GetVendor()
+            if owner and owner.GetID() == owner_id:
+                count += 1
+        except Exception:
+            pass
+    return count
+
+
+class DeleteCustomersUseCase:
+    """Hard-delete customers by ID; blocked if any invoices are linked."""
+
+    def __init__(self, book: Book):
+        self.book = book
+
+    def execute(self, ids: List[str]) -> List[DeleteResult]:
+        results = []
+        for cid in ids:
+            cust = self.book.CustomerLookupByID(cid)
+            if cust is None or not cust.GetID():
+                results.append(DeleteResult(id=cid, status=DeleteStatus.NOT_FOUND))
+                continue
+            n = _count_invoices_for_owner(self.book, cid, 2)
+            if n > 0:
+                results.append(DeleteResult(id=cid, status=DeleteStatus.FAILED_HAS_INVOICES, invoice_count=n))
+                continue
+            cust.Destroy()
+            results.append(DeleteResult(id=cid, status=DeleteStatus.DELETED))
+        return results
+
+
+class ArchiveCustomersUseCase:
+    """Set customers inactive (SetActive(False)); informational invoice count."""
+
+    def __init__(self, book: Book):
+        self.book = book
+
+    def execute(self, ids: List[str]) -> List[ArchiveResult]:
+        results = []
+        for cid in ids:
+            cust = self.book.CustomerLookupByID(cid)
+            if cust is None or not cust.GetID():
+                results.append(ArchiveResult(id=cid, status=ArchiveStatus.NOT_FOUND))
+                continue
+            if not cust.GetActive():
+                results.append(ArchiveResult(id=cid, status=ArchiveStatus.ALREADY_ARCHIVED))
+                continue
+            n = _count_invoices_for_owner(self.book, cid, 2)
+            cust.SetActive(False)
+            results.append(ArchiveResult(id=cid, status=ArchiveStatus.ARCHIVED, invoice_count=n))
+        return results
+
+
+class ArchiveVendorsUseCase:
+    """Set vendors inactive (SetActive(False)); informational bill count."""
+
+    def __init__(self, book: Book):
+        self.book = book
+
+    def execute(self, ids: List[str]) -> List[ArchiveResult]:
+        results = []
+        for vid in ids:
+            vendor = self.book.VendorLookupByID(vid)
+            if vendor is None or not vendor.GetID():
+                results.append(ArchiveResult(id=vid, status=ArchiveStatus.NOT_FOUND))
+                continue
+            if not vendor.GetActive():
+                results.append(ArchiveResult(id=vid, status=ArchiveStatus.ALREADY_ARCHIVED))
+                continue
+            n = _count_invoices_for_owner(self.book, vid, 4)
+            vendor.SetActive(False)
+            results.append(ArchiveResult(id=vid, status=ArchiveStatus.ARCHIVED, invoice_count=n))
+        return results

--- a/use_cases/export_business_objects.py
+++ b/use_cases/export_business_objects.py
@@ -82,7 +82,7 @@ class ExportBusinessObjectsUseCase:
         q = Query()
         q.search_for('gncCustomer')
         q.set_book(self.book)
-        customers = [gb.Customer(instance=r) for r in q.run()]
+        customers = sorted([gb.Customer(instance=r) for r in q.run()], key=lambda c: c.GetID())
         q.destroy()
 
         lines_list = []
@@ -93,6 +93,8 @@ class ExportBusinessObjectsUseCase:
                 f'  name: "{cust.GetName()}"',
                 f'  currency: {cust.GetCurrency().get_mnemonic()}',
             ]
+            if not cust.GetActive():
+                lines.append('  active: false')
             # Only emit optional address/contact fields when non-empty
             for field, val in [
                 ('addr1', addr.GetAddr1()),
@@ -115,7 +117,7 @@ class ExportBusinessObjectsUseCase:
         q = Query()
         q.search_for('gncVendor')
         q.set_book(self.book)
-        vendors = [gb.Vendor(instance=r) for r in q.run()]
+        vendors = sorted([gb.Vendor(instance=r) for r in q.run()], key=lambda v: v.GetID())
         q.destroy()
 
         lines_list = []
@@ -125,6 +127,8 @@ class ExportBusinessObjectsUseCase:
                 f'  name: "{v.GetName()}"',
                 f'  currency: {v.GetCurrency().get_mnemonic()}',
             ]
+            if not v.GetActive():
+                lines.append('  active: false')
             custom_meta = get_custom_metadata(v)
             for k, v_val in sorted(custom_meta.items()):
                 lines.append(f'  {k}: "{v_val}"')


### PR DESCRIPTION
Implements F-011 across three areas:

## A. active flag round-trip (customers and vendors)

Previously the exporter never emitted `active: false` for inactive customers/vendors, and the importer never called SetActive(False). A round-trip through plaintext silently resurrected every deactivated customer or vendor back to active.

Changes:
- export_business_objects.py: emit `active: false` when GetActive() is False; omit the field entirely when True (default — no noise). Also sort customers and vendors by ID so export order is deterministic.
- gnucash_importer.py: add _is_falsy() helper (accepts 'false', '0', 'no' case-insensitively); call SetActive(False) in import_customer() and import_vendor() when the 'active' field is present and falsy.
- kvp.py: add 'active' to KNOWN_CUSTOMER_METADATA_KEYS and KNOWN_VENDOR_METADATA_KEYS so it is not written as KVP custom metadata.
- fixtures: add inactive customer "2" and inactive vendor "V002" to the round-trip fixture (business_objects.txt, _only.txt, _biz_only.txt).

## B. delete-customers command

Hard-deletes customers by ID. Blocked with a clear error message if any invoices (paid or unpaid, posted or unposted) are linked — deleting a customer that has invoices would write null-GUID owner references to the XML and permanently orphan those invoices.

Supports batch operation; prints one status line per ID:
  CUST001: deleted
  CUST002: failed — cannot delete, 3 invoice(s) linked
  CUST003: not found
Exit code 1 if any ID failed.

NOTE: delete-vendors is intentionally NOT implemented. GnuCash's gncVendorDestroy() does not properly remove the vendor from the XML backend's serialisation path — the vendor entity reappears in the file after save/reload regardless of the in-memory state. This is a GnuCash-level issue that cannot be worked around from Python. The full investigation and findings are documented in docs/issues/F-011-*.md. Use archive-vendors to soft-hide vendors instead.

Customer deletion is also a last resort: the recommended approach for retiring a customer is always archive-customers (preserves all invoice history). delete-customers should only be used for customers created by mistake that have never had any invoices raised against them.

## C. archive-customers / archive-vendors commands

Sets SetActive(False) on one or more entities by ID. Safe for both customers and vendors regardless of whether invoices/bills are linked (SetActive never corrupts invoice owner GUIDs, verified across all supported distros via save/reload cycle and XML inspection).

Output includes linked invoice/bill count as informational context:
  CUST001: archived
  CUST002: archived — 3 invoice(s) linked
  CUST003: already archived
  CUST004: not found
Exit code 1 if any ID was already archived or not found.

## Testing

18 new integration tests in test_delete_business_objects.py covering:
- active: false round-trip for customers and vendors (both directions)
- active customers/vendors do NOT emit active: field (omit-when-true)
- delete-customers: success with no invoices
- delete-customers: blocked when invoices linked
- delete-customers: not found
- delete-customers: batch mixed (partial success still saves, exits 1)
- delete-customers: inactive customer with no invoices can still be deleted
- archive-customers/archive-vendors: all four status codes
- archive: linked invoice count appears in output
- archive: batch mixed

All 792 existing tests pass (no regressions).

Compatibility verified on Debian 11/12/13 and Ubuntu 20.04/22.04.