### PR TITLE
fix(Q-003/Q-004/Q-005): invoice/bill round-trip, account-type export, error context

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ gnucash plaintext is an app that can
 * load a .gnucash file and then export a [GnuCash](https://www.gnucash.org/) plaintext ledger file
 * load [GnuCash](https://www.gnucash.org/) plaintext ledger file and export a [beancount](https://github.com/beancount/beancount) compatible .beancount file
 * read from a [GnuCash](https://www.gnucash.org/) plaintext transaction file and create transaction in .gnucash file
-* bidirectional conversion between GnuCash and [GnuCash-Beancount](docs/gnucash-beancount-format.md) format with zero data loss
+* bidirectional conversion between GnuCash and [GnuCash-Beancount](docs/gnucash-beancount-format.md) format with zero data loss for accounts, transactions, splits, commodities, and prices (business objects — customers, vendors, invoices, bills — are not representable in beancount; see [Limitations](docs/gnucash-beancount-format.md#limitations))
 
 ## Motivation
 
@@ -526,7 +526,7 @@ gnucash-plaintext export-beancount mybook.gnucash output.beancount \
   --account "Assets:Bank"
 ```
 
-**Note:** The exported file is in [GnuCash-Beancount format](docs/gnucash-beancount-format.md), a special beancount format with GnuCash metadata that enables bidirectional conversion with zero data loss.
+**Note:** The exported file is in [GnuCash-Beancount format](docs/gnucash-beancount-format.md), a special beancount format with GnuCash metadata that enables bidirectional conversion with zero data loss for accounts, transactions, splits, commodities, and prices. Business objects (customers, vendors, invoices, bills) are not representable in beancount and are dropped during export — see [Limitations](docs/gnucash-beancount-format.md#limitations).
 
 ### View GnuCash data in Fava web UI
 

--- a/README.md
+++ b/README.md
@@ -775,6 +775,33 @@ invoice "INV-2026-004"
     memo: "Second instalment"
 ```
 
+### Reconciling invoice and bill payments with a bank feed
+
+When a bank feed (QFX, CSV, HTML) is imported **before** the matching invoice
+or bill, you can link them without creating a duplicate bank entry using
+`txn_guid` in the `payment:` block:
+
+```
+payment:
+  bank_account: "Assets:Bank"
+  txn_guid: 317c8ae6e0084c33951d052b9f1b9f23
+```
+
+Use `find-transactions` to look up the GUID:
+
+```bash
+gnucash-plaintext find-transactions ledger.gnucash \
+    --account "Assets:Bank" --date 2026-01-15 --amount 500
+```
+
+The importer retargets the existing bank transaction's counter-split to AR (or
+AP for bills) and links it to the invoice lot in-place — no new transaction is
+created and all original bank metadata is preserved.
+
+See **[docs/invoice-payment-reconciliation.md](docs/invoice-payment-reconciliation.md)**
+for the full workflow, bill examples, error reference, and the invoice-first
+alternative.
+
 ### Retiring customers and vendors (archive)
 
 Use `archive-customers` or `archive-vendors` to soft-hide one or more

--- a/README.md
+++ b/README.md
@@ -10,35 +10,81 @@ gnucash plaintext is an app that can
 
 ## Motivation
 
-I have been using GnuCash to track my finance for several decades. At first, I was looking for a software that I could
-use to track my spending. Now, GnuCash is a place where I keep track of my expenses, income and investment. There are 
-commercial software and SaasS, people even mention notion as an online ledger, but I stick to GnuCash. I believe in one
-thing that I need to own my financial data and I would use an open source tool like GnuCash.
+### The everyday problem: GnuCash is great for entry, painful for bulk work
 
-At first, I used Microsoft Money but then Microsoft discontinued this product. I then found GnuCash. I was not quite sure
-how to use GnuCash in the very beginning. I had to learn accounting basic such as Assets, Liabilities, Income, Expense
-and Equity. I had to admit that if it were not for GnuCash, I wouldn't have learnt bookkeeping and accounting and I would
-not have reviewed my financial status regularly like a CFO of myself.
+I have used GnuCash for decades to track expenses, income, and investments. The
+GUI is excellent for the way most transactions actually arrive in your life —
+you sit down, enter a few items, reconcile a statement. But the moment the work
+is *bulk* or *programmatic*, the GUI becomes the bottleneck:
 
-As my ledger grows, I start to worry, what if GnuCash become obsolete? The first commit of GnuCash was made in 1997 and
-today GnuCash is still under active development. It seems unlikely that my worry will come true, but I want to always
-prepare for such event.
+- Importing a month of QFX entries and re-categorising 80 of them
+- Renaming an account that's used in thousands of splits
+- Fixing a typo across every invoice from a single vendor
+- Generating recurring bills from a spreadsheet
+- Asking an AI to clean up memos, propose categorisations, or sanity-check a
+  reconciliation
 
-Then I find [ledger-cli](https://ledger-cli.org/doc/ledger3.html) and [beancount](https://github.com/beancount/beancount).
-I immediately feel that plaintext accounting is what I am looking for. It is in human-readable text format and the content
-will be readable by others even without any software.
+For all of these, you want **text**. You want grep, sed, scripts, diffs,
+version control, and nowadays an LLM that can read and edit your ledger
+directly. GnuCash's XML file is technically text, but it's not
+human-editable — one wrong tag and the whole file is unusable.
 
-However, when I dive deeper into ledger-cli and beancount, I know I cannot migrate my ledger to either of them. There are
-features of GnuCash that I use and are not supported any of the two. Also, I have lots of reports in GnuCash that will
-take me lots of time to migrate. What's more, my account names are highly flexible, e.g., they include spaces, CJK and, 
-punctuations. 
+### The fix: a stable Export → edit → Import cycle
 
-I do agree with the author of beancount that GnuCash's UIs are inconvenient. Suddenly, I ask myself, why can't I build
-a plaintext language that is similar to beancount and compatible with GnuCash. I can edit my ledger in GnuCash UIs and
-then export to a text file. I can also edit my text file and then a cli will parse the text file and create transactions
-and/or accounts in GnuCash? I can also export a beancount compatible text file to use against [beancount](https://github.com/beancount/beancount) and [fava](https://github.com/beancount/fava).
+`gnucash-plaintext` gives you a round-trippable plaintext format for your
+GnuCash file. The workflow is:
 
-I explore GnuCash python bindings and beancount documentations. Now I am pretty sure that my idea is both viable and valuable. 
+1. **Export** your `.gnucash` file to plaintext.
+2. **Edit** the text however you like — by hand, with a script, by piping it
+   through an LLM, or as part of a larger tool chain.
+3. **Import** back into GnuCash. Accounts, transactions, splits, commodities,
+   prices, customers, vendors, invoices, bills, and payments all round-trip
+   without loss.
+
+Because every object carries its GnuCash GUID through the cycle, edits target
+the *same* underlying objects on re-import — no duplicates, no orphaned
+records. You keep using the GnuCash GUI for day-to-day entry, and reach for
+plaintext only when the job is bigger than a few clicks.
+
+### Bonus: Fava visualisation and long-term portability
+
+Two further things fall out of this design almost for free:
+
+- **Fava in your browser.** The same tool can export to a beancount-compatible
+  format, so you can point [Fava](https://github.com/beancount/fava) at your
+  GnuCash data and get a modern web UI for analysis and reporting without
+  leaving GnuCash for entry.
+- **A future-proof copy of your data.** GnuCash was first committed in 1997
+  and is still actively developed, but if it ever did go away, a plaintext
+  ledger remains readable by humans and by every accounting tool that supports
+  beancount-like formats. The same cycle that powers your weekly bulk edits
+  doubles as a long-term escape hatch.
+
+### How this came about
+
+I tried [ledger-cli](https://ledger-cli.org/doc/ledger3.html) and
+[beancount](https://github.com/beancount/beancount) when I first wanted
+plaintext accounting, but neither was a clean migration target. Beancount in
+particular has gaps that matter for a GnuCash user: business objects
+(customers, vendors, invoices, bills, payments) have no equivalent, GnuCash's
+KVP slots and multi-namespace commodities don't map cleanly, and I have years
+of GnuCash reports I'm unwilling to redo.
+
+Account names with spaces and CJK characters used to be a hard blocker too —
+beancount v2 rejects them — but that's no longer true in v3, which uses a
+UTF-8-aware scanner ([beancount#398](https://github.com/beancount/beancount/issues/398)).
+[rustledger](https://github.com/rustledger/rustledger), a Rust implementation
+of beancount, has landed the same support
+([rustledger#817](https://github.com/rustledger/rustledger/pull/817)). So if
+your only need is "let me edit my ledger as text", a beancount-native workflow
+is now genuinely viable.
+
+What's still missing from a beancount-only setup is the GnuCash side itself:
+the entry GUI, the business objects, the existing reports, the on-disk format
+my partner and accountant already know. Instead of migrating *away* from
+GnuCash, I built a plaintext layer *on top of* it — close enough to beancount
+that Fava and related tooling still work, but lossless against GnuCash so the
+GUI remains the source of truth.
 
 ## Concepts
 

--- a/cli/find_transactions_cmd.py
+++ b/cli/find_transactions_cmd.py
@@ -1,0 +1,137 @@
+"""
+CLI command to find transactions by account, date, and/or amount.
+
+Used to discover the GUID of a bank transaction that was imported from a
+bank feed and needs to be linked to an invoice payment block:
+
+    gnucash-plaintext find-transactions ledger.gnucash \
+        --account "Assets:Bank" \
+        --date 2026-01-15 \
+        --amount 100
+
+Output (one line per match):
+    317c8ae6e0084c33951d052b9f1b9f23  2026-01-15  100.00  "E-transfer from Acme"
+
+Copy the GUID into the payment block's txn_guid field:
+
+    payment:
+        date: 2026-01-15
+        amount: 100
+        bank_account: "Assets:Bank"
+        memo: "Payment INV-001"
+        txn_guid: 317c8ae6e0084c33951d052b9f1b9f23
+"""
+
+import ctypes
+
+import click
+
+from infrastructure.gnucash.engine import GncNumericC, load_gnc_engine, safe_ctypes_string
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+
+
+@click.command('find-transactions')
+@click.argument('gnucash_file', type=click.Path(exists=True))
+@click.option('--account', '-a', default=None,
+              help='Account full name (e.g. "Assets:Bank"). Matches any split in the transaction.')
+@click.option('--date', '-d', default=None,
+              help='Transaction date filter (YYYY-MM-DD).')
+@click.option('--amount', '-n', default=None, type=float,
+              help='Absolute amount to match (sign-insensitive).')
+def find_transactions(gnucash_file, account, date, amount):
+    """
+    Find transactions by account, date, and/or amount and print their GUIDs.
+
+    At least one filter must be provided. Output is one matching transaction
+    per line:
+
+    \b
+      GUID                              DATE        AMOUNT    DESCRIPTION
+      317c8ae6e0084c33951d052b9f1b9f23  2026-01-15  100.00    E-transfer from Acme
+
+    Use the GUID in a payment block's txn_guid field to link an existing bank
+    transaction to an invoice payment without creating a duplicate.
+
+    \b
+    Examples:
+      gnucash-plaintext find-transactions ledger.gnucash --account "Assets:Bank"
+      gnucash-plaintext find-transactions ledger.gnucash --date 2026-01-15 --amount 100
+      gnucash-plaintext find-transactions ledger.gnucash -a "Assets:Bank" -d 2026-01-15
+    """
+    if not any([account, date, amount is not None]):
+        raise click.UsageError('At least one of --account, --date, or --amount must be provided.')
+
+    lib = load_gnc_engine()
+    # xaccSplitGetAccount: const-type SWIG mismatch (see docs/DEBUGGING_GNUCASH_BINDINGS.md).
+    # xaccSplitGetAmount: "once ctypes, stay ctypes" — split_ptr is already in
+    # ctypes domain, so we read the amount via ctypes too (GncNumericC struct).
+    lib.xaccSplitGetAccount.argtypes = [ctypes.c_void_p]
+    lib.xaccSplitGetAccount.restype = ctypes.c_void_p
+    lib.xaccSplitGetAmount.argtypes = [ctypes.c_void_p]
+    lib.xaccSplitGetAmount.restype = GncNumericC
+
+    def _split_acct_name(split_ptr: int) -> str:
+        acct_ptr = lib.xaccSplitGetAccount(split_ptr)
+        if not acct_ptr:
+            return ''
+        parts = []
+        ptr = acct_ptr
+        while ptr:
+            name = safe_ctypes_string(lib.xaccAccountGetName, ptr)
+            if name:
+                parts.append(name)
+            parent = lib.gnc_account_get_parent(ptr)
+            if not parent:
+                break
+            grandparent = lib.gnc_account_get_parent(parent)
+            if not grandparent:
+                break
+            ptr = parent
+        parts.reverse()
+        return ':'.join(parts)
+
+    def _split_amount(split_ptr: int) -> float:
+        # Use ctypes — stays consistent with _split_acct_name (once ctypes,
+        # stay ctypes per CLAUDE.md pointer lifetime rules).
+        amt = lib.xaccSplitGetAmount(split_ptr)
+        return abs(amt.num / amt.denom) if amt.denom else 0.0
+
+    repo = GnuCashRepository(gnucash_file)
+    repo.open(mode=SessionMode.READ_ONLY)
+    try:
+        transactions = repo.get_all_transactions()
+        matched = 0
+        for tx in transactions:
+            tx_date = tx.GetDate().strftime('%Y-%m-%d')
+            tx_desc = tx.GetDescription() or ''
+
+            if date and tx_date != date:
+                continue
+
+            split_matches = []
+            for split_obj in tx.GetSplitList():
+                split_ptr = int(split_obj.instance)
+                acct_name = _split_acct_name(split_ptr)
+                try:
+                    split_amt = _split_amount(split_ptr)
+                except Exception:
+                    continue
+
+                account_ok = (account is None) or (acct_name == account)
+                amount_ok = (amount is None) or (abs(split_amt - amount) < 0.005)
+
+                if account_ok and amount_ok:
+                    split_matches.append((acct_name, split_amt))
+
+            if not split_matches:
+                continue
+
+            display_amount = split_matches[0][1]
+            guid = tx.GetGUID().to_string()
+            click.echo(f'{guid}  {tx_date}  {display_amount:>10.2f}  "{tx_desc}"')
+            matched += 1
+
+        if matched == 0:
+            click.echo('No matching transactions found.', err=True)
+    finally:
+        repo.close()

--- a/cli/import_cmd.py
+++ b/cli/import_cmd.py
@@ -138,7 +138,13 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
                 # Create accounts first
                 for directive in parser.root_directive.children:
                     if directive.type == DirectiveType.OPEN_ACCOUNT:
-                        importer.create_account(directive, repo.book)
+                        acct_name = directive.props.get('account_name', '?')
+                        try:
+                            importer.create_account(directive, repo.book)
+                        except Exception as e:
+                            raise click.ClickException(
+                                f'account "{acct_name}": {e}'
+                            ) from e
 
                 biz_types = {
                     DirectiveType.CUSTOMER, DirectiveType.VENDOR,

--- a/cli/main.py
+++ b/cli/main.py
@@ -11,6 +11,7 @@ from cli.account_balance_cmd import account_balance
 from cli.close_books_cmd import close_books
 from cli.delete_cmd import archive_customers, archive_vendors, delete_customers
 from cli.delete_transaction_cmd import delete_transaction_by_guid
+from cli.find_transactions_cmd import find_transactions
 from cli.export_accounts_cmd import export_accounts
 from cli.export_beancount_cmd import export_beancount
 from cli.export_cmd import export_transactions
@@ -57,6 +58,7 @@ cli.add_command(income_statement, name='income-statement')
 cli.add_command(print_invoice, name='print-invoice')
 cli.add_command(account_balance, name='account-balance')
 cli.add_command(delete_transaction_by_guid, name='delete-transaction-by-guid')
+cli.add_command(find_transactions, name='find-transactions')
 cli.add_command(delete_customers, name='delete-customers')
 cli.add_command(archive_customers, name='archive-customers')
 cli.add_command(archive_vendors, name='archive-vendors')

--- a/cli/main.py
+++ b/cli/main.py
@@ -11,11 +11,11 @@ from cli.account_balance_cmd import account_balance
 from cli.close_books_cmd import close_books
 from cli.delete_cmd import archive_customers, archive_vendors, delete_customers
 from cli.delete_transaction_cmd import delete_transaction_by_guid
-from cli.find_transactions_cmd import find_transactions
 from cli.export_accounts_cmd import export_accounts
 from cli.export_beancount_cmd import export_beancount
 from cli.export_cmd import export_transactions
 from cli.export_transaction_cmd import export_transaction
+from cli.find_transactions_cmd import find_transactions
 from cli.import_beancount_cmd import import_beancount
 from cli.import_cmd import import_transactions
 from cli.income_statement_cmd import income_statement

--- a/docs/DEBUGGING_GNUCASH_BINDINGS.md
+++ b/docs/DEBUGGING_GNUCASH_BINDINGS.md
@@ -88,6 +88,10 @@ GnuCash Python bindings have different reliability for reading vs writing:
 - `gncEntryGetDescription()`, `gncEntryGetAction()`: SWIG has const-type bugs
 - `xaccAccountGetName()`: Works in ctypes, SWIG version buggy on Ubuntu
 - `gnc_account_get_full_name()`: Use ctypes version for raw pointers
+- `xaccSplitGetAccount()`: SWIG const-type mismatch on all platforms — always ctypes
+- `xaccSplitGetAmount()`: SWIG `split.GetAmount().to_double()` confirmed working on
+  Debian 11/12/13, Ubuntu 20/22/24. ctypes (`GncNumericC` restype) also works
+  and is used when split_ptr is already in the ctypes domain ("once ctypes, stay ctypes").
 
 ## Pointer Lifetime Rules
 

--- a/docs/gnucash-beancount-format.md
+++ b/docs/gnucash-beancount-format.md
@@ -1,6 +1,6 @@
 # GnuCash-Beancount Format
 
-**GnuCash-Beancount** (bc-gnc) is a special beancount format that enables bidirectional conversion between GnuCash and beancount with zero data loss.
+**GnuCash-Beancount** (bc-gnc) is a special beancount format that enables bidirectional conversion between GnuCash and beancount with zero data loss for accounts, transactions, splits, commodities, and prices. Business objects (customers, vendors, invoices, bills) have no equivalent in beancount and are dropped during export — see [Limitations](#limitations).
 
 ## Overview
 
@@ -425,6 +425,27 @@ gnucash-plaintext export-beancount mybook.gnucash backup-$(date +%Y%m%d).beancou
 # Restore from backup
 gnucash-plaintext import-beancount mybook-restored.gnucash backup-20240115.beancount
 ```
+
+## Limitations
+
+GnuCash-Beancount preserves accounts, transactions, splits, commodities, and prices with full fidelity. The following GnuCash data is **not** preserved during `export-beancount` because beancount has no equivalent concept:
+
+| GnuCash data | What happens on export | Round-trip preserved? |
+|---|---|---|
+| Customers | Dropped silently | No |
+| Vendors | Dropped silently | No |
+| Invoices (with entries, posted lots, payments) | Dropped silently | No |
+| Bills (with entries, posted lots, payments) | Dropped silently | No |
+| Tax tables | Dropped silently | No |
+| Employees | Dropped silently | No |
+| Jobs | Dropped silently | No |
+
+If you rely on GnuCash's business features and need a lossless plaintext format, use the native [GnuCash plaintext format](../README.md#gnucash-plaintext) (`export` / `import`) instead — it round-trips every object type the importer supports, including invoices, bills, customers, vendors, payments (with `txn_guid` retargeting), and tax tables.
+
+The two export commands serve different goals:
+
+- `export-beancount` → produces a file usable by [beancount](https://github.com/beancount/beancount) and [Fava](https://github.com/beancount/fava) for analysis and reporting; lossy for business objects.
+- `export` → produces gnucash-plaintext, lossless for all supported GnuCash data; not consumable by beancount tooling.
 
 ## See Also
 

--- a/docs/invoice-payment-reconciliation.md
+++ b/docs/invoice-payment-reconciliation.md
@@ -1,0 +1,153 @@
+# Invoice and Bill Payment Reconciliation
+
+Covers two scenarios where bank transactions and invoice/bill payments need
+to be linked without creating duplicate bank entries.
+
+## Background
+
+When an invoice is paid in GnuCash, `ApplyPayment()` always creates a **new**
+bank+AR transaction. Similarly, when a vendor bill is paid, it creates a new
+bank+AP transaction. If a matching bank transaction was already imported from a
+bank feed (QFX, CSV, HTML, etc.), you end up with two bank entries for the
+same cash movement — one from the feed, one from the payment.
+
+The `txn_guid` field on a `payment:` block solves this cleanly: instead of
+creating a new transaction, the importer **modifies the existing bank
+transaction in-place**, retargeting its counter-split to AR (or AP for bills)
+and linking it to the invoice/bill lot. All original bank metadata — notes,
+description, split memos, FITID — is preserved.
+
+---
+
+## Workflow: Import bank feed first, then reconcile invoices
+
+### Step 1 — Import the bank feed
+
+```bash
+gnucash-plaintext import ledger.gnucash bank_feed.txt
+```
+
+The bank transaction exists with whatever counter-account the import assigned
+(Imbalance, or a pre-categorised expense/income account).
+
+### Step 2 — Find the GUID of the bank transaction
+
+```bash
+gnucash-plaintext find-transactions ledger.gnucash \
+    --account "Assets:Bank" \
+    --date 2026-01-15 \
+    --amount 500
+```
+
+Output:
+```
+317c8ae6e0084c33951d052b9f1b9f23  2026-01-15    500.00  "E-transfer from Acme"
+```
+
+### Step 3 — Add `txn_guid` to the invoice's `payment:` block
+
+```
+invoice "INV-2026-001"
+  customer_id: "CUST-001"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    ...
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-2026-001"
+    accumulate: true
+  payment:
+    bank_account: "Assets:Bank"
+    txn_guid: 317c8ae6e0084c33951d052b9f1b9f23
+```
+
+Only `bank_account` and `txn_guid` are required — `date`, `amount`, and `memo`
+are taken from the existing transaction and do not need to be repeated.
+
+### Step 4 — Import the invoice file
+
+```bash
+gnucash-plaintext import --include-business-objects ledger.gnucash invoices.txt
+```
+
+The importer:
+1. Creates and posts the invoice (AR lot opened)
+2. Finds the existing bank transaction by GUID
+3. Retargets its counter-split to AR and links it to the invoice lot
+4. The lot sum reaches zero → invoice is marked paid
+5. **No new transaction is created** — the original bank entry survives intact
+
+---
+
+## Vendor bills work the same way
+
+Bills use AP instead of AR. The `payment:` block in a `bill` directive is
+identical — just provide `bank_account` and `txn_guid`:
+
+```
+bill "BILL-2026-001"
+  vendor_id: "VEND-001"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    ...
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Bill BILL-2026-001"
+    accumulate: true
+  payment:
+    bank_account: "Assets:Bank"
+    txn_guid: abc123def456abc123def456abc123de
+```
+
+Use `find-transactions` with a negative amount to find outgoing payments:
+
+```bash
+gnucash-plaintext find-transactions ledger.gnucash \
+    --account "Assets:Bank" \
+    --date 2026-01-25 \
+    --amount 200
+```
+
+---
+
+## Error cases
+
+| Situation | Error |
+|---|---|
+| GUID does not exist in the book | `invoice "X": txn_guid '...' not found in book` |
+| Invoice has `posted: none` with a `payment:` block | `invoice "X": cannot have payment: blocks on an unposted invoice` |
+| Invoice was created but not posted (no posted: block) | `invoice "X": has no posted lot — must be posted before payment` |
+| `bank_account` doesn't match any split in the transaction | `invoice "X": Could not find counter-split in tx '...'` |
+
+---
+
+## Idempotency
+
+Re-importing the same invoice/bill file after a successful `txn_guid` link is
+safe — the invoice/bill already exists in the book, so it is skipped without
+error and the bank transaction is left untouched.
+
+---
+
+## Without `txn_guid` (invoice-first workflow)
+
+If you import invoices with `payment:` blocks **before** importing the bank
+feed, `ApplyPayment()` creates the bank transaction for you. When the bank feed
+arrives later, the matching entry will appear as a duplicate. Delete the
+bank-feed duplicate using:
+
+```bash
+gnucash-plaintext find-transactions ledger.gnucash \
+    --account "Assets:Bank" --date 2026-01-15 --amount 500
+# → two GUIDs; one has notes "business_generated: true" (the payment tx)
+# Delete the bank-feed duplicate:
+gnucash-plaintext delete-transaction-by-guid ledger.gnucash <bank-feed-guid>
+```
+
+See also: `docs/bank-import-workflow.md` for the full ordering analysis.

--- a/docs/issues/Q-003-account-type-export-not-reimportable.md
+++ b/docs/issues/Q-003-account-type-export-not-reimportable.md
@@ -1,0 +1,72 @@
+---
+id: Q-003
+title: Exported file is not re-importable (mixed indentation + account type short-forms)
+category: quality
+severity: high
+status: open
+---
+
+## Problem
+
+Two related issues both prevent a full export → re-import round-trip.
+
+### Issue 1: Mixed indentation in the exported file
+
+The transaction/account exporter uses **TABs** for indentation; the business
+objects exporter uses **2 spaces**. The parser auto-detects indentation from
+the first indented line it encounters (a TAB from the commodity/account
+section). When it reaches the space-indented business object blocks it cannot
+parse metadata fields — `currency`, `name`, etc. are silently absent from
+`directive.metadata`, causing:
+
+```
+Error: customer "C1": 'currency'
+```
+
+### Issue 2: Account type short-form strings
+
+The transaction exporter writes account types using GnuCash's internal
+short-form strings (`A/Receivable`, `A/Payable`) which do not exist in the
+importer's `ACCT_TYPE_MAP`. After the mixed-indentation fix, this becomes the
+next crash:
+
+```
+Error: account "Assets:Accounts Receivable": 'A/Receivable'
+```
+
+Together these mean a file produced by `gnucash-plaintext export` cannot be
+fed back into `gnucash-plaintext import` unmodified.
+
+## Confirmed by test
+
+`tests/integration/test_payment_roundtrip.py::test_account_type_roundtrip`
+(added 2026-05-06).
+
+## Fix
+
+**Issue 1 — mixed indentation**: the business objects exporter should use
+TABs to match the transaction/account exporter, OR the transaction exporter
+should use spaces to match business objects. TABs are the established
+convention in the existing format; switch the business objects exporter to
+emit TABs.
+
+**Issue 2 — account type short-forms**: add the short-form aliases to
+`ACCT_TYPE_MAP` in `gnucash_importer.py`:
+
+```python
+"A/Payable":    ACCT_TYPE_PAYABLE,
+"A/Receivable": ACCT_TYPE_RECEIVABLE,
+```
+
+## Files to change
+
+| File | Change |
+|---|---|
+| `use_cases/export_business_objects.py` | Replace 2-space indentation with TAB (`\t`) throughout all exported blocks |
+| `services/gnucash_importer.py` | Add `'A/Receivable'` and `'A/Payable'` aliases to `ACCT_TYPE_MAP` (already done) |
+| `tests/fixtures/business_objects_only.txt` | Update reference to use TAB indentation if business objects exporter is changed |
+| `tests/integration/test_payment_roundtrip.py` | `test_account_type_roundtrip` should pass after both fixes |
+
+---
+
+**Created**: 2026-05-06

--- a/docs/issues/Q-004-payment-transaction-duplicates.md
+++ b/docs/issues/Q-004-payment-transaction-duplicates.md
@@ -1,0 +1,163 @@
+---
+id: Q-004
+title: Invoice payment blocks create duplicate bank transactions
+category: quality
+severity: high
+status: open
+---
+
+## Problem
+
+`ApplyPayment()` always creates a **new** bank+AR transaction. This causes
+duplicate bank entries in two distinct scenarios.
+
+---
+
+### Case B — bank transaction imported first, invoice payment imported second
+
+When a bank feed (QFX, CSV, HTML, or manual plaintext) is imported first and
+then invoices with `payment:` blocks are imported into the same book,
+`ApplyPayment()` creates a second bank transaction alongside the existing one.
+
+**Confirmed by test** (`test_bank_first_then_invoice_no_duplicate`, 2026-05-06):
+
+```
+Expected 1 bank transaction after invoice import, got 2.
+```
+
+**Practical impact**: any user who imports bank transactions first and then
+imports historical paid invoices ends up with doubled bank entries, causing
+the bank account balance to be wrong.
+
+---
+
+### Case C — same-day same-amount idempotency failure
+
+The transaction importer deduplicates by `(date, account-set)` signature.
+Two invoice payments on the same day from the same bank account produce
+identical signatures `{Assets:Bank, Assets:AR}`.
+
+On re-import of the same invoice file (e.g. fixing a description and
+re-importing), `ApplyPayment()` creates new payment transactions, but the
+**old** payment transactions from the previous import are also re-imported
+because:
+- GUID check: the old GUIDs are not in the book (new ones were just created)
+- Signature check: the new transactions already cover the signature, so the
+  old ones are correctly skipped for the **first** match, but in the
+  same-day same-amount case GnuCash creates doubles
+
+**Confirmed by test** (`test_same_day_same_amount_idempotent`, 2026-05-06):
+
+```
+Expected 2 bank transactions after re-import, got 4.
+```
+
+---
+
+## Root cause
+
+`ApplyPayment()` in GnuCash always creates a fresh transaction — there is no
+API to retroactively link an existing bank transaction to an invoice lot via
+the high-level Python bindings.
+
+The signature-based duplicate check in `import_transactions.py` is fragile:
+it can handle the common case but fails when two invoices share the same
+date+amount+bank combination, or when payment transactions accumulate across
+re-imports.
+
+## Current partial fix (in this branch)
+
+A `txn_guid` field on the `payment:` block plus invoice idempotency:
+
+- **Invoice idempotency**: `import_invoice`/`import_bill` skip if the invoice
+  ID already exists in the book. This fixes Case C (re-import no longer
+  creates duplicate invoices and therefore no duplicate payments).
+
+- **`txn_guid` field**: when present, the importer deletes the pre-existing
+  bank transaction before calling `ApplyPayment()`. This solves the
+  no-duplicate constraint but **destroys all metadata** on the original bank
+  transaction (KVP/FITID, split memos, reconciliation flags, descriptions).
+
+```
+payment:
+  txn_guid: "317c8ae6e0084c33951d052b9f1b9f23"   ← current impl: deletes this tx first
+```
+
+**This is a known limitation of the current implementation.**
+
+## Correct fix for Case B: retarget the existing transaction (no delete)
+
+Verified in Docker (2026-05-06, latest): it IS possible to modify the
+existing bank transaction in-place without deleting it:
+
+1. Find the imbalance split on the existing bank transaction (the split
+   that points to `Imbalance` or whatever placeholder account the bank
+   import assigned)
+2. Retarget that split's account to AR (via ctypes — SWIG `xaccSplitSetAccount`
+   has a const-type mismatch)
+3. Link the split to the invoice's posted lot via `gc.xaccSplitSetLot()`
+4. The lot sum goes to zero → `invoice.IsPaid()` becomes `True`
+
+```
+Verified result:
+  IsPaid: True
+  Bank split memo: "QFX memo to preserve"   ← original data intact
+  tx description: "E-transfer from Acme"    ← original description intact
+  tx notes: "fitid:20260101ABC source:qfx"  ← KVP/FITID intact
+```
+
+**`txn_guid` semantics should change**: instead of "delete this tx and
+re-create via ApplyPayment", it should mean "find this tx and retarget its
+counter-split to AR, linking it to the invoice lot". The bank transaction
+survives intact with all its metadata.
+
+### Implementation approach (not yet coded)
+
+```python
+# In import_invoice, PAYMENT block with txn_guid:
+existing_tx = _find_transaction_by_guid(book, txn_guid)
+if existing_tx:
+    # Retarget the non-bank (imbalance/placeholder) split to AR
+    lot = invoice.GetPostedLot()
+    ar_account = invoice.GetPostedAcc()
+    existing_tx.BeginEdit()
+    for raw_sp in existing_tx.GetSplitList():
+        sp_ptr = int(raw_sp.instance)
+        acct_type = _split_acct_type(sp_ptr)   # via ctypes
+        if acct_type not in (ACCT_TYPE_BANK, ACCT_TYPE_CASH, ...):
+            lib.xaccSplitSetAccount(sp_ptr, int(ar_account.instance))
+            gc.xaccSplitSetLot(raw_sp.instance, lot.instance)
+            break
+    existing_tx.CommitEdit()
+    # Do NOT call ApplyPayment() — the lot is already closed
+else:
+    # No pre-existing tx → normal ApplyPayment()
+    invoice.ApplyPayment(None, bank_account, amount, ...)
+```
+
+### Identifying the "counter-split" safely
+
+The bank import may assign various placeholder accounts (Imbalance, Opening
+Balance, or user-categorised accounts). The safest heuristic: find the split
+whose account is NOT `ACCT_TYPE_BANK` / `ACCT_TYPE_CASH` (i.e. not the actual
+bank account). This is the split to retarget to AR.
+
+## Files to change
+
+| File | Change |
+|---|---|
+| `services/gnucash_importer.py` | Replace delete+ApplyPayment with retarget approach for `txn_guid`; use ctypes for `xaccSplitSetAccount` and `xaccSplitSetLot` |
+| `cli/find_transactions_cmd.py` | Already implemented; no change needed |
+| `cli/main.py` | Already done |
+| `tests/integration/test_payment_roundtrip.py` | Update `test_bank_first_then_invoice_with_txn_guid` to assert original bank metadata is preserved |
+
+## Out of scope
+
+- Automatic GUID discovery / fuzzy matching — too fragile. `txn_guid` is explicit.
+- Vendor bill case — same logic applies to `import_bill`.
+- What if the existing tx has more than 2 splits (e.g. a split transaction) —
+  needs further research.
+
+---
+
+**Created**: 2026-05-06

--- a/docs/issues/Q-005-import-errors-no-context.md
+++ b/docs/issues/Q-005-import-errors-no-context.md
@@ -1,0 +1,98 @@
+---
+id: Q-005
+title: Import errors show raw exception message with no context
+category: quality
+severity: high
+status: open
+---
+
+## Problem
+
+When the importer encounters an error, the user sees a raw Python exception
+message with no context about what failed or how to fix it:
+
+```
+Error: 'currency'          ← KeyError — which directive? which field? which file?
+Error: 'A/Receivable'      ← KeyError — which account? what's the valid value?
+Error: Account 'X' not found when trying to determine currency for transaction ...
+```
+
+This affects **all three import paths** in `import_cmd.py`:
+
+### 1. Business objects (`import_business_objects`)
+
+`import_business_objects` calls each per-type importer with no try/except.
+Any exception (KeyError on missing field, ValueError, GnuCash error) propagates
+unmodified to the CLI, which catches it as `click.ClickException(str(e))`:
+
+```python
+# import_cmd.py
+importer.import_business_objects(...)   # bare call — no context on failure
+```
+
+The user is told `Error: 'currency'` with no indication of which customer,
+vendor, invoice, or bill caused the problem.
+
+### 2. Account creation (`create_account`)
+
+Called in a loop but errors are either swallowed or raised without the
+account name in scope:
+
+```python
+for directive in parser.root_directive.children:
+    if directive.type == DirectiveType.OPEN_ACCOUNT:
+        importer.create_account(directive, repo.book)   # bare call
+```
+
+### 3. Transaction import
+
+Slightly better — the transaction import loop does have per-transaction
+try/except, but the error dict only contains the raw exception string
+without the directive's source location (line number, file name).
+
+## What the user should see
+
+| Scenario | Current | Should be |
+|---|---|---|
+| Missing `currency` on customer | `Error: 'currency'` | `customer "C1": missing required field 'currency'` |
+| Unknown account type on re-import | `Error: 'A/Receivable'` | `account "Assets:AR": unknown type 'A/Receivable' — valid types: Asset, Bank, ...` |
+| Invoice references unknown customer | `Error: CustomerLookupByID returned None` | `invoice "INV-001": customer_id "C1" not found — import customers before invoices` |
+| Account not found for split | `Error: Account 'X' not found` | `transaction 2026-01-15 "Dinner": split account "Expenses:Food" not found` |
+
+## Fix
+
+Wrap each per-type importer call in `import_business_objects` with a
+try/except that catches generic exceptions and re-raises with directive
+context:
+
+```python
+def import_business_objects(self, directives, book):
+    for directive in directives:
+        if directive.type == DirectiveType.CUSTOMER:
+            try:
+                self.import_customer(directive, book)
+            except Exception as e:
+                cid = directive.props.get('id', '?')
+                raise ValueError(f'customer "{cid}": {e}') from e
+        ...
+```
+
+Apply the same pattern to:
+- `import_vendor` calls
+- `import_taxtable` calls  
+- `import_invoice` calls
+- `import_bill` calls
+- `create_account` call in `import_cmd.py`
+
+For transactions, add file name and line number to the existing error dict.
+
+## Files to change
+
+| File | Change |
+|---|---|
+| `services/gnucash_importer.py` | Wrap each call in `import_business_objects` with try/except adding directive context |
+| `cli/import_cmd.py` | Wrap `create_account` loop with per-directive try/except |
+
+---
+
+**Created**: 2026-05-06

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -44,3 +44,7 @@ When a fix is merged, update `status: open` → `closed` in the file's frontmatt
 |----|-------|----------|
 | [Q-001](Q-001-inconsistent-cli-exception-types.md) | Inconsistent exception types across CLI commands | low |
 | [Q-002](Q-002-read-book-company-info-bypasses-repo-layer.md) | read_book_company_info bypasses the repository layer | low |
+| [Q-003](Q-003-account-type-export-not-reimportable.md) | Exported account types (A/Receivable, A/Payable) crash re-import | high |
+| [Q-004](Q-004-payment-transaction-duplicates.md) | Invoice payment blocks create duplicate bank transactions (Cases B and C) | high |
+| [Q-005](Q-005-import-errors-no-context.md) | Import errors show raw exception with no directive context | high |
+| [Q-004](Q-004-payment-transaction-duplicates.md) | Invoice payment blocks create duplicate bank transactions (Cases B and C) | high |

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -8,7 +8,7 @@ Converts PlaintextDirective objects from the parser into GnuCash objects
 import ctypes
 import logging
 from datetime import datetime
-from typing import List, Optional
+from typing import List
 
 import gnucash.gnucash_core_c as gc
 from gnucash import Account, Book, GncCommodity, GncNumeric, Split, Transaction

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -62,18 +62,22 @@ _FALSY_STRINGS = {'false', '0', 'no'}
 
 
 def _find_transaction_by_guid(book, guid: str):
-    """Return the Transaction matching guid, or None."""
-    from gnucash import Query, Transaction
-    q = Query()
-    q.search_for('Trans')
-    q.set_book(book)
-    txns = list(q.run())
-    q.destroy()
-    for r in txns:
-        tx = Transaction(instance=r)
-        if tx.GetGUID().to_string() == guid:
-            return tx
-    return None
+    """Return the Transaction matching guid, or None.
+
+    Accepts 32-char hex or UUID-with-hyphens; normalises via string_to_guid
+    so both forms resolve to the same canonical GUID before lookup.
+    Raises ValueError for inputs that are not valid GUID/UUID strings.
+    Returns None when the format is valid but no transaction has that GUID.
+    """
+    from gnucash import Transaction
+    from gnucash.gnucash_core_c import GncGUID, string_to_guid, xaccTransLookup
+    gnc_guid = GncGUID()
+    if not string_to_guid(guid, gnc_guid):
+        raise ValueError(f"Invalid GUID format: {guid!r}")
+    raw = xaccTransLookup(gnc_guid, book.instance)
+    if raw is None:
+        return None
+    return Transaction(instance=raw)
 
 
 def _retarget_counter_split_to_lot(lib, existing_tx, bank_acct_name: str,

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -5,9 +5,10 @@ Converts PlaintextDirective objects from the parser into GnuCash objects
 (commodities, accounts, transactions) with all metadata preserved.
 """
 
+import ctypes
 import logging
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 import gnucash.gnucash_core_c as gc
 from gnucash import Account, Book, GncCommodity, GncNumeric, Split, Transaction
@@ -60,6 +61,75 @@ def string_to_gnc_numeric_quantity(s):
 _FALSY_STRINGS = {'false', '0', 'no'}
 
 
+def _find_transaction_by_guid(book, guid: str):
+    """Return the Transaction matching guid, or None."""
+    from gnucash import Query, Transaction
+    q = Query()
+    q.search_for('Trans')
+    q.set_book(book)
+    txns = list(q.run())
+    q.destroy()
+    for r in txns:
+        tx = Transaction(instance=r)
+        if tx.GetGUID().to_string() == guid:
+            return tx
+    return None
+
+
+def _retarget_counter_split_to_lot(lib, existing_tx, bank_acct_name: str,
+                                   ar_ap_account, lot) -> bool:
+    """
+    Modify existing_tx in-place: find the split whose account is NOT the
+    bank account (the "counter-split"), retarget it to ar_ap_account, and
+    link it to the invoice/bill lot.
+
+    This closes the lot without calling ApplyPayment(), preserving all
+    original transaction metadata (notes, description, split memos, KVP).
+
+    xaccSplitSetAccount has a SWIG const-type mismatch — ctypes is required.
+    See docs/DEBUGGING_GNUCASH_BINDINGS.md.
+    """
+    from infrastructure.gnucash.engine import safe_ctypes_string
+    lib.xaccSplitGetAccount.argtypes = [ctypes.c_void_p]
+    lib.xaccSplitGetAccount.restype  = ctypes.c_void_p
+    lib.xaccSplitSetAccount.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    lib.xaccSplitSetAccount.restype  = None
+    lib.gnc_account_get_parent.argtypes = [ctypes.c_void_p]
+    lib.gnc_account_get_parent.restype  = ctypes.c_void_p
+
+    def _acct_name(acct_ptr):
+        parts = []
+        ptr = acct_ptr
+        while ptr:
+            name = safe_ctypes_string(lib.xaccAccountGetName, ptr)
+            if name:
+                parts.append(name)
+            parent = lib.gnc_account_get_parent(ptr)
+            if not parent:
+                break
+            if not lib.gnc_account_get_parent(parent):
+                break
+            ptr = parent
+        parts.reverse()
+        return ':'.join(parts)
+
+    import gnucash.gnucash_core_c as _gc
+    existing_tx.BeginEdit()
+    for raw_sp in existing_tx.GetSplitList():
+        sp_ptr = int(raw_sp.instance)
+        acct_ptr = lib.xaccSplitGetAccount(sp_ptr)
+        if not acct_ptr:
+            continue
+        if _acct_name(acct_ptr) != bank_acct_name:
+            # This is the counter-split — retarget to AR/AP and close the lot
+            lib.xaccSplitSetAccount(sp_ptr, int(ar_ap_account.instance))
+            _gc.xaccSplitSetLot(raw_sp.instance, lot.instance)
+            existing_tx.CommitEdit()
+            return True
+    existing_tx.CommitEdit()
+    return False
+
+
 def _is_falsy(val: str) -> bool:
     """Return True if val is a recognised falsy string (case-insensitive)."""
     return val.strip().lower() in _FALSY_STRINGS
@@ -75,7 +145,9 @@ ACCT_TYPE_MAP = {
     "Liability": ACCT_TYPE_LIABILITY,
     "Mutual Fund": ACCT_TYPE_MUTUAL,
     "Accounts Payable": ACCT_TYPE_PAYABLE,
+    "A/Payable": ACCT_TYPE_PAYABLE,          # GnuCash internal short form
     "Accounts Receivable": ACCT_TYPE_RECEIVABLE,
+    "A/Receivable": ACCT_TYPE_RECEIVABLE,    # GnuCash internal short form
     "Stock": ACCT_TYPE_STOCK,
     "Cash": ACCT_TYPE_CASH,
 }
@@ -573,6 +645,13 @@ class GnuCashImporter:
 
         inv_id = directive.props['id']
 
+        # Idempotency: skip if this invoice already exists in the book.
+        # Re-importing the same file would otherwise create a duplicate invoice
+        # and a duplicate payment transaction for each payment: block.
+        if book.InvoiceLookupByID(inv_id) is not None:
+            logging.debug(f"Invoice {inv_id} already exists, skipping")
+            return
+
         # Validate: posted: none and a real posted: block are contradictory
         has_posted_none = directive.metadata.get('posted') == 'none'
         posted_children = [c for c in directive.children if c.type == DirectiveType.POSTED]
@@ -644,15 +723,40 @@ class GnuCashImporter:
                 bank_account = find_account(book.get_root_account(), bank_acct_name)
                 if bank_account is None:
                     raise Exception(f'Bank account {bank_acct_name!r} not found when applying invoice payment')
-                pay_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
-                amount = string_to_gnc_numeric_quantity(entry_directive.metadata['amount'])
-                memo = entry_directive.metadata['memo']
-                num = entry_directive.metadata.get('num', '')
-                # Pass None for txn: GnuCash creates the payment transaction
-                # internally. Passing a manually-allocated Transaction causes
-                # a segfault on GnuCash 3.8 (ubuntu20) because the transaction
-                # is not properly initialised before ApplyPayment uses it.
-                invoice.ApplyPayment(None, bank_account, amount, GncNumeric(1, 1), pay_date, memo, num)
+
+                txn_guid = entry_directive.metadata.get('txn_guid', '').strip()
+                if txn_guid:
+                    # Retarget approach: the bank transaction already exists.
+                    # Find the counter-split (non-bank side), retarget it to AR,
+                    # and link it to the invoice lot. No new transaction is created,
+                    # all original bank metadata (notes, memos, KVP) is preserved.
+                    # ApplyPayment() is NOT called — the lot closes automatically
+                    # when the AR split sum reaches zero.
+                    existing_tx = _find_transaction_by_guid(book, txn_guid)
+                    if existing_tx is None:
+                        raise Exception(f'txn_guid {txn_guid!r} not found in book')
+                    ar_account = invoice.GetPostedAcc()
+                    lot = invoice.GetPostedLot()
+                    if lot is None:
+                        raise Exception(f'Invoice {inv_id} has no posted lot — must be posted before payment')
+                    from infrastructure.gnucash.engine import load_gnc_engine
+                    if not _retarget_counter_split_to_lot(
+                            load_gnc_engine(), existing_tx, bank_acct_name, ar_account, lot):
+                        raise Exception(
+                            f'Could not find counter-split in tx {txn_guid!r} — '
+                            f'expected a non-{bank_acct_name!r} split'
+                        )
+                else:
+                    # Normal path: no pre-existing bank tx — ApplyPayment creates one.
+                    pay_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
+                    amount = string_to_gnc_numeric_quantity(entry_directive.metadata['amount'])
+                    memo = entry_directive.metadata['memo']
+                    num = entry_directive.metadata.get('num', '')
+                    # Pass None for txn: GnuCash creates the payment transaction
+                    # internally. Passing a manually-allocated Transaction causes
+                    # a segfault on GnuCash 3.8 (ubuntu20) because the transaction
+                    # is not properly initialised before ApplyPayment uses it.
+                    invoice.ApplyPayment(None, bank_account, amount, GncNumeric(1, 1), pay_date, memo, num)
 
         invoice.CommitEdit()
         custom_meta = {k: v for k, v in directive.metadata.items()
@@ -667,6 +771,11 @@ class GnuCashImporter:
             raise ValueError(f"Expected BILL but got {directive.type}")
 
         bill_id = directive.props['id']
+
+        # Idempotency: skip if this bill already exists in the book.
+        if book.InvoiceLookupByID(bill_id) is not None:
+            logging.debug(f"Bill {bill_id} already exists, skipping")
+            return
 
         # Validate: posted: none and a real posted: block are contradictory
         has_posted_none = directive.metadata.get('posted') == 'none'
@@ -733,27 +842,43 @@ class GnuCashImporter:
                 bank_account = find_account(book.get_root_account(), bank_acct_name)
                 if bank_account is None:
                     raise Exception(f'Bank account {bank_acct_name!r} not found when applying bill payment')
-                pay_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
-                amount_str = entry_directive.metadata['amount']
-                memo = entry_directive.metadata['memo']
-                num = entry_directive.metadata.get('num', '')
-                # AP and AR have opposite sign conventions, so bill payments
-                # require a negated amount:
-                #
-                #   Invoice posting: DR AR +N  →  lot starts at +N
-                #   Invoice payment: CR AR −N  →  ApplyPayment(+N) creates AR = −N ✓
-                #
-                #   Bill posting:    CR AP −N  →  lot starts at −N
-                #   Bill payment:    DR AP +N  →  ApplyPayment(+N) creates AP = −N ✗
-                #                                 (same sign as posting → new lot)
-                #                   ApplyPayment(−N) creates AP = +N ✓
-                #                                 (opposite sign → closes existing lot)
-                #
-                # Passing a positive amount for a bill puts the payment split in a
-                # brand-new lot instead of the bill's posted lot, making the exporter
-                # unable to find the payment via GetPostedLot().get_split_list().
-                neg_amount = string_to_gnc_numeric_quantity(f'-{amount_str}')
-                bill.ApplyPayment(None, bank_account, neg_amount, GncNumeric(1, 1), pay_date, memo, num)
+
+                txn_guid = entry_directive.metadata.get('txn_guid', '').strip()
+                if txn_guid:
+                    # Retarget approach — same as invoice, but targeting AP.
+                    existing_tx = _find_transaction_by_guid(book, txn_guid)
+                    if existing_tx is None:
+                        raise Exception(f'txn_guid {txn_guid!r} not found in book')
+                    ap_account = bill.GetPostedAcc()
+                    lot = bill.GetPostedLot()
+                    if lot is None:
+                        raise Exception(f'Bill {bill_id} has no posted lot — must be posted before payment')
+                    from infrastructure.gnucash.engine import load_gnc_engine
+                    if not _retarget_counter_split_to_lot(
+                            load_gnc_engine(), existing_tx, bank_acct_name, ap_account, lot):
+                        raise Exception(
+                            f'Could not find counter-split in tx {txn_guid!r} — '
+                            f'expected a non-{bank_acct_name!r} split'
+                        )
+                else:
+                    # Normal path: ApplyPayment creates the bank+AP transaction.
+                    # AP and AR have opposite sign conventions, so bill payments
+                    # require a negated amount:
+                    #
+                    #   Bill posting:    CR AP −N  →  lot starts at −N
+                    #   Bill payment:    DR AP +N  →  ApplyPayment(+N) creates AP = −N ✗
+                    #                                 (same sign as posting → new lot)
+                    #                   ApplyPayment(−N) creates AP = +N ✓
+                    #                                 (opposite sign → closes existing lot)
+                    #
+                    # Passing a positive amount puts the payment split in a brand-new
+                    # lot instead of the bill's posted lot.
+                    pay_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
+                    amount_str = entry_directive.metadata['amount']
+                    memo = entry_directive.metadata['memo']
+                    num = entry_directive.metadata.get('num', '')
+                    neg_amount = string_to_gnc_numeric_quantity(f'-{amount_str}')
+                    bill.ApplyPayment(None, bank_account, neg_amount, GncNumeric(1, 1), pay_date, memo, num)
 
         bill.CommitEdit()
         custom_meta = {k: v for k, v in directive.metadata.items()
@@ -766,18 +891,38 @@ class GnuCashImporter:
         # Import customers and vendors first
         for directive in directives:
             if directive.type == DirectiveType.CUSTOMER:
-                self.import_customer(directive, book)
+                cid = directive.props.get('id', '?')
+                try:
+                    self.import_customer(directive, book)
+                except Exception as e:
+                    raise ValueError(f'customer "{cid}": {e}') from e
             elif directive.type == DirectiveType.VENDOR:
-                self.import_vendor(directive, book)
+                vid = directive.props.get('id', '?')
+                try:
+                    self.import_vendor(directive, book)
+                except Exception as e:
+                    raise ValueError(f'vendor "{vid}": {e}') from e
 
         # Then tax tables
         for directive in directives:
             if directive.type == DirectiveType.TAXTABLE:
-                self.import_taxtable(directive, book)
+                tname = directive.props.get('name', '?')
+                try:
+                    self.import_taxtable(directive, book)
+                except Exception as e:
+                    raise ValueError(f'taxtable "{tname}": {e}') from e
 
         # Finally, invoices and bills
         for directive in directives:
             if directive.type == DirectiveType.INVOICE:
-                self.import_invoice(directive, book)
+                iid = directive.props.get('id', '?')
+                try:
+                    self.import_invoice(directive, book)
+                except Exception as e:
+                    raise ValueError(f'invoice "{iid}": {e}') from e
             elif directive.type == DirectiveType.BILL:
-                self.import_bill(directive, book)
+                bid = directive.props.get('id', '?')
+                try:
+                    self.import_bill(directive, book)
+                except Exception as e:
+                    raise ValueError(f'bill "{bid}": {e}') from e

--- a/tests/fixtures/business_objects_only.txt
+++ b/tests/fixtures/business_objects_only.txt
@@ -1,267 +1,267 @@
 customer "1"
-  name: "Test Customer"
-  currency: CAD
+	name: "Test Customer"
+	currency: CAD
 
 customer "2"
-  name: "Retired Customer"
-  currency: CAD
-  active: false
+	name: "Retired Customer"
+	currency: CAD
+	active: false
 
 vendor "V001"
-  name: "Test Vendor"
-  currency: CAD
+	name: "Test Vendor"
+	currency: CAD
 
 vendor "V002"
-  name: "Retired Vendor"
-  currency: CAD
-  active: false
+	name: "Retired Vendor"
+	currency: CAD
+	active: false
 
 taxtable "GST"
-  entry:
-    account: "Liabilities:GST"
-    rate: 5.0%
-    type: PERCENT
+	entry:
+		account: "Liabilities:GST"
+		rate: 5.0%
+		type: PERCENT
 
 invoice "INV-2026-001"
-  customer_id: "1"
-  currency: CAD
-  date_opened: 2026-01-01
-  entry:
-    date: 2026-01-01
-    description: "Test Entry"
-    action: "Hours"
-    account: "Income:Sales"
-    quantity: 1
-    price: 100
-    taxable: true
-    tax_included: false
-    tax_table: "GST"
-  posted:
-    date: 2026-01-01
-    due: 2026-01-31
-    ar_account: "Assets:Accounts Receivable"
-    memo: "Invoice INV-2026-001"
-    accumulate: true
-  payment: none
+	customer_id: "1"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Test Entry"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: true
+		tax_included: false
+		tax_table: "GST"
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-2026-001"
+		accumulate: true
+	payment: none
 
 invoice "INV-2026-002"
-  customer_id: "1"
-  currency: CAD
-  date_opened: 2026-01-15
-  entry:
-    date: 2026-01-15
-    description: "Consulting Hours"
-    action: "Hours"
-    account: "Income:Sales"
-    quantity: 2
-    price: 75
-    taxable: true
-    tax_included: false
-    tax_table: "GST"
-  posted: none
-  payment: none
+	customer_id: "1"
+	currency: CAD
+	date_opened: 2026-01-15
+	entry:
+		date: 2026-01-15
+		description: "Consulting Hours"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 2
+		price: 75
+		taxable: true
+		tax_included: false
+		tax_table: "GST"
+	posted: none
+	payment: none
 
 invoice "INV-2026-003"
-  customer_id: "1"
-  currency: CAD
-  date_opened: 2026-01-20
-  entry:
-    date: 2026-01-20
-    description: "Project Deliverable"
-    action: "Hours"
-    account: "Income:Sales"
-    quantity: 1
-    price: 200
-    taxable: true
-    tax_included: false
-    tax_table: "GST"
-  posted:
-    date: 2026-01-20
-    due: 2026-02-19
-    ar_account: "Assets:Accounts Receivable"
-    memo: "Invoice INV-2026-003"
-    accumulate: true
-  payment:
-    date: 2026-01-25
-    amount: 210
-    bank_account: "Assets:Bank"
-    memo: "Payment for INV-2026-003"
+	customer_id: "1"
+	currency: CAD
+	date_opened: 2026-01-20
+	entry:
+		date: 2026-01-20
+		description: "Project Deliverable"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 200
+		taxable: true
+		tax_included: false
+		tax_table: "GST"
+	posted:
+		date: 2026-01-20
+		due: 2026-02-19
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-2026-003"
+		accumulate: true
+	payment:
+		date: 2026-01-25
+		amount: 210
+		bank_account: "Assets:Bank"
+		memo: "Payment for INV-2026-003"
 
 invoice "INV-2026-004"
-  customer_id: "1"
-  currency: CAD
-  date_opened: 2026-02-01
-  entry:
-    date: 2026-02-01
-    description: "Retainer Services"
-    action: "Hours"
-    account: "Income:Sales"
-    quantity: 3
-    price: 100
-    taxable: true
-    tax_included: false
-    tax_table: "GST"
-  posted:
-    date: 2026-02-01
-    due: 2026-03-03
-    ar_account: "Assets:Accounts Receivable"
-    memo: "Invoice INV-2026-004"
-    accumulate: true
-  payment:
-    date: 2026-02-10
-    amount: 100
-    bank_account: "Assets:Bank"
-    memo: "Partial payment 1 for INV-2026-004"
-  payment:
-    date: 2026-02-20
-    amount: 100
-    bank_account: "Assets:Bank"
-    memo: "Partial payment 2 for INV-2026-004"
+	customer_id: "1"
+	currency: CAD
+	date_opened: 2026-02-01
+	entry:
+		date: 2026-02-01
+		description: "Retainer Services"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 3
+		price: 100
+		taxable: true
+		tax_included: false
+		tax_table: "GST"
+	posted:
+		date: 2026-02-01
+		due: 2026-03-03
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-2026-004"
+		accumulate: true
+	payment:
+		date: 2026-02-10
+		amount: 100
+		bank_account: "Assets:Bank"
+		memo: "Partial payment 1 for INV-2026-004"
+	payment:
+		date: 2026-02-20
+		amount: 100
+		bank_account: "Assets:Bank"
+		memo: "Partial payment 2 for INV-2026-004"
 
 invoice "INV-2026-005"
-  customer_id: "1"
-  currency: CAD
-  date_opened: 2026-02-05
-  entry:
-    date: 2026-02-05
-    description: "Annual Support"
-    action: "Hours"
-    account: "Income:Sales"
-    quantity: 1
-    price: 400
-    taxable: true
-    tax_included: false
-    tax_table: "GST"
-  posted:
-    date: 2026-02-05
-    due: 2026-03-07
-    ar_account: "Assets:Accounts Receivable"
-    memo: "Invoice INV-2026-005"
-    accumulate: true
-  payment:
-    date: 2026-02-15
-    amount: 200
-    bank_account: "Assets:Bank"
-    memo: "First payment for INV-2026-005"
-  payment:
-    date: 2026-02-28
-    amount: 220
-    bank_account: "Assets:Bank"
-    memo: "Final payment for INV-2026-005"
+	customer_id: "1"
+	currency: CAD
+	date_opened: 2026-02-05
+	entry:
+		date: 2026-02-05
+		description: "Annual Support"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 400
+		taxable: true
+		tax_included: false
+		tax_table: "GST"
+	posted:
+		date: 2026-02-05
+		due: 2026-03-07
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-2026-005"
+		accumulate: true
+	payment:
+		date: 2026-02-15
+		amount: 200
+		bank_account: "Assets:Bank"
+		memo: "First payment for INV-2026-005"
+	payment:
+		date: 2026-02-28
+		amount: 220
+		bank_account: "Assets:Bank"
+		memo: "Final payment for INV-2026-005"
 
 bill "BILL-2026-001"
-  vendor_id: "V001"
-  currency: CAD
-  date_opened: 2026-01-01
-  entry:
-    date: 2026-01-01
-    description: "Office Supplies"
-    account: "Expenses:Supplies"
-    quantity: 1
-    price: 100
-    taxable: true
-    tax_included: false
-  posted:
-    date: 2026-01-01
-    due: 2026-01-31
-    ap_account: "Liabilities:Accounts Payable"
-    memo: "Bill BILL-2026-001"
-    accumulate: true
-  payment: none
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Office Supplies"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 100
+		taxable: true
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-2026-001"
+		accumulate: true
+	payment: none
 
 bill "BILL-2026-002"
-  vendor_id: "V001"
-  currency: CAD
-  date_opened: 2026-01-15
-  entry:
-    date: 2026-01-15
-    description: "IT Supplies"
-    account: "Expenses:Supplies"
-    quantity: 2
-    price: 75
-    taxable: true
-    tax_included: false
-  posted: none
-  payment: none
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-15
+	entry:
+		date: 2026-01-15
+		description: "IT Supplies"
+		account: "Expenses:Supplies"
+		quantity: 2
+		price: 75
+		taxable: true
+		tax_included: false
+	posted: none
+	payment: none
 
 bill "BILL-2026-003"
-  vendor_id: "V001"
-  currency: CAD
-  date_opened: 2026-01-20
-  entry:
-    date: 2026-01-20
-    description: "Monthly Subscription"
-    account: "Expenses:Supplies"
-    quantity: 1
-    price: 200
-    taxable: true
-    tax_included: false
-  posted:
-    date: 2026-01-20
-    due: 2026-02-19
-    ap_account: "Liabilities:Accounts Payable"
-    memo: "Bill BILL-2026-003"
-    accumulate: true
-  payment:
-    date: 2026-01-25
-    amount: 200
-    bank_account: "Assets:Bank"
-    memo: "Payment for BILL-2026-003"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-20
+	entry:
+		date: 2026-01-20
+		description: "Monthly Subscription"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 200
+		taxable: true
+		tax_included: false
+	posted:
+		date: 2026-01-20
+		due: 2026-02-19
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-2026-003"
+		accumulate: true
+	payment:
+		date: 2026-01-25
+		amount: 200
+		bank_account: "Assets:Bank"
+		memo: "Payment for BILL-2026-003"
 
 bill "BILL-2026-004"
-  vendor_id: "V001"
-  currency: CAD
-  date_opened: 2026-02-01
-  entry:
-    date: 2026-02-01
-    description: "Equipment Purchase"
-    account: "Expenses:Supplies"
-    quantity: 3
-    price: 100
-    taxable: true
-    tax_included: false
-  posted:
-    date: 2026-02-01
-    due: 2026-03-03
-    ap_account: "Liabilities:Accounts Payable"
-    memo: "Bill BILL-2026-004"
-    accumulate: true
-  payment:
-    date: 2026-02-10
-    amount: 100
-    bank_account: "Assets:Bank"
-    memo: "Partial payment 1 for BILL-2026-004"
-  payment:
-    date: 2026-02-20
-    amount: 100
-    bank_account: "Assets:Bank"
-    memo: "Partial payment 2 for BILL-2026-004"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-02-01
+	entry:
+		date: 2026-02-01
+		description: "Equipment Purchase"
+		account: "Expenses:Supplies"
+		quantity: 3
+		price: 100
+		taxable: true
+		tax_included: false
+	posted:
+		date: 2026-02-01
+		due: 2026-03-03
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-2026-004"
+		accumulate: true
+	payment:
+		date: 2026-02-10
+		amount: 100
+		bank_account: "Assets:Bank"
+		memo: "Partial payment 1 for BILL-2026-004"
+	payment:
+		date: 2026-02-20
+		amount: 100
+		bank_account: "Assets:Bank"
+		memo: "Partial payment 2 for BILL-2026-004"
 
 bill "BILL-2026-005"
-  vendor_id: "V001"
-  currency: CAD
-  date_opened: 2026-02-05
-  entry:
-    date: 2026-02-05
-    description: "Annual License"
-    account: "Expenses:Supplies"
-    quantity: 1
-    price: 400
-    taxable: true
-    tax_included: false
-  posted:
-    date: 2026-02-05
-    due: 2026-03-07
-    ap_account: "Liabilities:Accounts Payable"
-    memo: "Bill BILL-2026-005"
-    accumulate: true
-  payment:
-    date: 2026-02-15
-    amount: 200
-    bank_account: "Assets:Bank"
-    memo: "First payment for BILL-2026-005"
-  payment:
-    date: 2026-02-28
-    amount: 200
-    bank_account: "Assets:Bank"
-    memo: "Final payment for BILL-2026-005"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-02-05
+	entry:
+		date: 2026-02-05
+		description: "Annual License"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 400
+		taxable: true
+		tax_included: false
+	posted:
+		date: 2026-02-05
+		due: 2026-03-07
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-2026-005"
+		accumulate: true
+	payment:
+		date: 2026-02-15
+		amount: 200
+		bank_account: "Assets:Bank"
+		memo: "First payment for BILL-2026-005"
+	payment:
+		date: 2026-02-28
+		amount: 200
+		bank_account: "Assets:Bank"
+		memo: "Final payment for BILL-2026-005"

--- a/tests/fixtures/payment_roundtrip_accounts.txt
+++ b/tests/fixtures/payment_roundtrip_accounts.txt
@@ -1,0 +1,36 @@
+2026-01-01 open Assets
+  type: Asset
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Income
+  type: Income
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities
+  type: Liability
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Accounts Receivable
+  type: Accounts Receivable
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Bank
+  type: Bank
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Income:Sales
+  type: Income
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:Accounts Payable
+  type: Accounts Payable
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Expenses
+  type: Expense
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Expenses:Supplies
+  type: Expense
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"

--- a/tests/fixtures/payment_roundtrip_bank_bill.txt
+++ b/tests/fixtures/payment_roundtrip_bank_bill.txt
@@ -1,0 +1,5 @@
+2026-01-15 * "Payment to supplier"
+  notes: "fitid:20260115002  source:qfx"
+  Assets:Bank  -100.00 CAD
+    memo: "Bill payment memo to preserve"
+  Liabilities:Accounts Payable  100.00 CAD

--- a/tests/fixtures/payment_roundtrip_bank_invoice.txt
+++ b/tests/fixtures/payment_roundtrip_bank_invoice.txt
@@ -1,0 +1,5 @@
+2026-01-15 * "E-transfer from Acme"
+  notes: "fitid:20260115001  source:qfx"
+  Assets:Bank  100.00 CAD
+    memo: "QFX split memo to preserve"
+  Assets:Accounts Receivable  -100.00 CAD

--- a/tests/fixtures/payment_roundtrip_bill_txn_guid.txt
+++ b/tests/fixtures/payment_roundtrip_bill_txn_guid.txt
@@ -1,0 +1,25 @@
+vendor "V1"
+  name: "Supplier"
+  currency: CAD
+
+bill "BILL-001"
+  vendor_id: "V1"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Supplies"
+    account: "Expenses:Supplies"
+    quantity: 1
+    price: 100
+    taxable: false
+    tax_included: false
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Bill BILL-001"
+    accumulate: true
+  payment:
+    bank_account: "Assets:Bank"
+    txn_guid: {txn_guid}

--- a/tests/fixtures/payment_roundtrip_invoice_txn_guid.txt
+++ b/tests/fixtures/payment_roundtrip_invoice_txn_guid.txt
@@ -1,0 +1,26 @@
+customer "C1"
+  name: "Acme"
+  currency: CAD
+
+invoice "INV-001"
+  customer_id: "C1"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Service"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 1
+    price: 100
+    taxable: false
+    tax_included: false
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-001"
+    accumulate: true
+  payment:
+    bank_account: "Assets:Bank"
+    txn_guid: {txn_guid}

--- a/tests/integration/test_business_objects.py
+++ b/tests/integration/test_business_objects.py
@@ -94,29 +94,29 @@ def test_business_objects_roundtrip(tmp_path):
     # Must have a posted: block and an explicit "payment: none" sentinel
     inv1 = get_invoice_block(exported_biz, 'INV-2026-001')
     assert inv1, "INV-2026-001 must appear in export"
-    assert '  posted:' in inv1, "INV-2026-001 must have a posted: block"
-    assert '  payment: none' in inv1, "INV-2026-001 must have payment: none (not paid)"
+    assert '	posted:' in inv1, "INV-2026-001 must have a posted: block"
+    assert '	payment: none' in inv1, "INV-2026-001 must have payment: none (not paid)"
 
     # INV-2026-002: unposted
     # Must appear (export now includes unposted) with both sentinels
     inv2 = get_invoice_block(exported_biz, 'INV-2026-002')
     assert inv2, "INV-2026-002 (unposted) must appear in export"
-    assert '  posted: none' in inv2, "INV-2026-002 must have posted: none (unposted)"
-    assert '  payment: none' in inv2, "INV-2026-002 must have payment: none (unposted, no payments)"
+    assert '	posted: none' in inv2, "INV-2026-002 must have posted: none (unposted)"
+    assert '	payment: none' in inv2, "INV-2026-002 must have payment: none (unposted, no payments)"
 
     # INV-2026-003: posted, single full payment
     inv3 = get_invoice_block(exported_biz, 'INV-2026-003')
     assert inv3, "INV-2026-003 must appear in export"
-    assert '  posted:' in inv3, "INV-2026-003 must have a posted: block"
-    assert '  payment:' in inv3, "INV-2026-003 must have a payment: block"
+    assert '	posted:' in inv3, "INV-2026-003 must have a posted: block"
+    assert '	payment:' in inv3, "INV-2026-003 must have a payment: block"
     assert 'payment: none' not in inv3, "INV-2026-003 must not have payment: none"
-    assert inv3.count('  payment:') == 1, "INV-2026-003 must have exactly one payment block"
+    assert inv3.count('	payment:') == 1, "INV-2026-003 must have exactly one payment block"
 
     # INV-2026-004: posted, two partial payments, amount still remaining
     inv4 = get_invoice_block(exported_biz, 'INV-2026-004')
     assert inv4, "INV-2026-004 must appear in export"
-    assert '  posted:' in inv4, "INV-2026-004 must have a posted: block"
-    assert inv4.count('  payment:') == 2, "INV-2026-004 must have exactly two payment blocks"
+    assert '	posted:' in inv4, "INV-2026-004 must have a posted: block"
+    assert inv4.count('	payment:') == 2, "INV-2026-004 must have exactly two payment blocks"
     assert 'payment: none' not in inv4
     assert 'Partial payment 1 for INV-2026-004' in inv4
     assert 'Partial payment 2 for INV-2026-004' in inv4
@@ -124,8 +124,8 @@ def test_business_objects_roundtrip(tmp_path):
     # INV-2026-005: posted, two payments, fully paid (zero balance)
     inv5 = get_invoice_block(exported_biz, 'INV-2026-005')
     assert inv5, "INV-2026-005 must appear in export"
-    assert '  posted:' in inv5, "INV-2026-005 must have a posted: block"
-    assert inv5.count('  payment:') == 2, "INV-2026-005 must have exactly two payment blocks"
+    assert '	posted:' in inv5, "INV-2026-005 must have a posted: block"
+    assert inv5.count('	payment:') == 2, "INV-2026-005 must have exactly two payment blocks"
     assert 'payment: none' not in inv5
     assert 'First payment for INV-2026-005' in inv5
     assert 'Final payment for INV-2026-005' in inv5
@@ -135,28 +135,28 @@ def test_business_objects_roundtrip(tmp_path):
     # BILL-2026-001: posted, not paid
     bill1 = get_bill_block(exported_biz, 'BILL-2026-001')
     assert bill1, "BILL-2026-001 must appear in export"
-    assert '  posted:' in bill1, "BILL-2026-001 must have a posted: block"
-    assert '  payment: none' in bill1, "BILL-2026-001 must have payment: none (not paid)"
+    assert '	posted:' in bill1, "BILL-2026-001 must have a posted: block"
+    assert '	payment: none' in bill1, "BILL-2026-001 must have payment: none (not paid)"
 
     # BILL-2026-002: unposted
     bill2 = get_bill_block(exported_biz, 'BILL-2026-002')
     assert bill2, "BILL-2026-002 (unposted) must appear in export"
-    assert '  posted: none' in bill2, "BILL-2026-002 must have posted: none (unposted)"
-    assert '  payment: none' in bill2, "BILL-2026-002 must have payment: none (unposted, no payments)"
+    assert '	posted: none' in bill2, "BILL-2026-002 must have posted: none (unposted)"
+    assert '	payment: none' in bill2, "BILL-2026-002 must have payment: none (unposted, no payments)"
 
     # BILL-2026-003: posted, single full payment
     bill3 = get_bill_block(exported_biz, 'BILL-2026-003')
     assert bill3, "BILL-2026-003 must appear in export"
-    assert '  posted:' in bill3, "BILL-2026-003 must have a posted: block"
-    assert '  payment:' in bill3, "BILL-2026-003 must have a payment: block"
+    assert '	posted:' in bill3, "BILL-2026-003 must have a posted: block"
+    assert '	payment:' in bill3, "BILL-2026-003 must have a payment: block"
     assert 'payment: none' not in bill3, "BILL-2026-003 must not have payment: none"
-    assert bill3.count('  payment:') == 1, "BILL-2026-003 must have exactly one payment block"
+    assert bill3.count('	payment:') == 1, "BILL-2026-003 must have exactly one payment block"
 
     # BILL-2026-004: posted, two partial payments, amount still remaining
     bill4 = get_bill_block(exported_biz, 'BILL-2026-004')
     assert bill4, "BILL-2026-004 must appear in export"
-    assert '  posted:' in bill4, "BILL-2026-004 must have a posted: block"
-    assert bill4.count('  payment:') == 2, "BILL-2026-004 must have exactly two payment blocks"
+    assert '	posted:' in bill4, "BILL-2026-004 must have a posted: block"
+    assert bill4.count('	payment:') == 2, "BILL-2026-004 must have exactly two payment blocks"
     assert 'payment: none' not in bill4
     assert 'Partial payment 1 for BILL-2026-004' in bill4
     assert 'Partial payment 2 for BILL-2026-004' in bill4
@@ -164,8 +164,8 @@ def test_business_objects_roundtrip(tmp_path):
     # BILL-2026-005: posted, two payments, fully paid (zero balance)
     bill5 = get_bill_block(exported_biz, 'BILL-2026-005')
     assert bill5, "BILL-2026-005 must appear in export"
-    assert '  posted:' in bill5, "BILL-2026-005 must have a posted: block"
-    assert bill5.count('  payment:') == 2, "BILL-2026-005 must have exactly two payment blocks"
+    assert '	posted:' in bill5, "BILL-2026-005 must have a posted: block"
+    assert bill5.count('	payment:') == 2, "BILL-2026-005 must have exactly two payment blocks"
     assert 'payment: none' not in bill5
     assert 'First payment for BILL-2026-005' in bill5
     assert 'Final payment for BILL-2026-005' in bill5

--- a/tests/integration/test_delete_business_objects.py
+++ b/tests/integration/test_delete_business_objects.py
@@ -68,7 +68,7 @@ def test_active_flag_roundtrip_customer(tmp_path):
     exported = export_biz(runner, gf)
     # Customer "2" is inactive in the fixture
     assert 'customer "2"' in exported
-    assert '  active: false' in exported
+    assert '	active: false' in exported
 
 
 def test_active_flag_roundtrip_vendor(tmp_path):
@@ -78,7 +78,7 @@ def test_active_flag_roundtrip_vendor(tmp_path):
     import_fixture(runner, gf)
     exported = export_biz(runner, gf)
     assert 'vendor "V002"' in exported
-    assert '  active: false' in exported
+    assert '	active: false' in exported
 
 
 def test_active_customer_has_no_active_field(tmp_path):
@@ -92,7 +92,7 @@ def test_active_customer_has_no_active_field(tmp_path):
     for line in lines:
         if line == 'customer "1"':
             in_cust1 = True
-        elif in_cust1 and line and not line.startswith(' '):
+        elif in_cust1 and line and not line[0:1] in (' ', '\t'):
             break
         elif in_cust1:
             assert 'active:' not in line, \
@@ -110,7 +110,7 @@ def test_active_vendor_has_no_active_field(tmp_path):
     for line in lines:
         if line == 'vendor "V001"':
             in_v001 = True
-        elif in_v001 and line and not line.startswith(' '):
+        elif in_v001 and line and not line[0:1] in (' ', '\t'):
             break
         elif in_v001:
             assert 'active:' not in line, \
@@ -224,7 +224,7 @@ def test_archive_customer_active_no_invoices(tmp_path):
     for line in lines:
         if line == 'customer "1"':
             in_cust1 = True
-        elif in_cust1 and line and not line.startswith(' '):
+        elif in_cust1 and line and not line[0:1] in (' ', '\t'):
             break
         elif in_cust1 and 'active: false' in line:
             found_active_false = True
@@ -302,7 +302,7 @@ def test_archive_vendor_with_bills(tmp_path):
     for line in lines:
         if line == 'vendor "V001"':
             in_v001 = True
-        elif in_v001 and line and not line.startswith(' '):
+        elif in_v001 and line and not line[0:1] in (' ', '\t'):
             break
         elif in_v001 and 'active: false' in line:
             found_active_false = True

--- a/tests/integration/test_delete_business_objects.py
+++ b/tests/integration/test_delete_business_objects.py
@@ -92,7 +92,7 @@ def test_active_customer_has_no_active_field(tmp_path):
     for line in lines:
         if line == 'customer "1"':
             in_cust1 = True
-        elif in_cust1 and line and not line[0:1] in (' ', '\t'):
+        elif in_cust1 and line and line[0:1] not in (' ', '\t'):
             break
         elif in_cust1:
             assert 'active:' not in line, \
@@ -110,7 +110,7 @@ def test_active_vendor_has_no_active_field(tmp_path):
     for line in lines:
         if line == 'vendor "V001"':
             in_v001 = True
-        elif in_v001 and line and not line[0:1] in (' ', '\t'):
+        elif in_v001 and line and line[0:1] not in (' ', '\t'):
             break
         elif in_v001:
             assert 'active:' not in line, \
@@ -224,7 +224,7 @@ def test_archive_customer_active_no_invoices(tmp_path):
     for line in lines:
         if line == 'customer "1"':
             in_cust1 = True
-        elif in_cust1 and line and not line[0:1] in (' ', '\t'):
+        elif in_cust1 and line and line[0:1] not in (' ', '\t'):
             break
         elif in_cust1 and 'active: false' in line:
             found_active_false = True
@@ -302,7 +302,7 @@ def test_archive_vendor_with_bills(tmp_path):
     for line in lines:
         if line == 'vendor "V001"':
             in_v001 = True
-        elif in_v001 and line and not line[0:1] in (' ', '\t'):
+        elif in_v001 and line and line[0:1] not in (' ', '\t'):
             break
         elif in_v001 and 'active: false' in line:
             found_active_false = True

--- a/tests/integration/test_payment_roundtrip.py
+++ b/tests/integration/test_payment_roundtrip.py
@@ -339,6 +339,36 @@ def test_txn_guid_not_found_fails(tmp_path):
         f"Error must mention 'not found'. Got:\n{r.output}"
 
 
+def test_txn_guid_invalid_format_fails(tmp_path):
+    """txn_guid that is not a valid GUID/UUID string must fail with a format error."""
+    runner = CliRunner()
+    gf = tmp_path / "book.gnucash"
+    import_new(runner, gf, write_fixture(tmp_path, "bank.txt",
+                                         accounts_plus(BANK_INVOICE)))
+
+    bad_fmt_file = write_fixture(tmp_path, "inv.txt", invoice_fixture("hello"))
+    r = import_into(runner, gf, bad_fmt_file)
+    assert r.exit_code != 0
+    assert "invalid guid" in r.output.lower(), \
+        f"Error must mention 'invalid guid'. Got:\n{r.output}"
+
+
+def test_txn_guid_uuid_with_hyphens(tmp_path):
+    """txn_guid in UUID-with-hyphens form must resolve to the same transaction."""
+    runner = CliRunner()
+    gf = tmp_path / "book.gnucash"
+    import_new(runner, gf, write_fixture(tmp_path, "bank.txt",
+                                         accounts_plus(BANK_INVOICE)))
+    guid = get_guid(runner, gf, "Assets:Bank")
+    # Insert hyphens into the 32-char hex GUID: 8-4-4-4-12
+    uuid_form = f"{guid[0:8]}-{guid[8:12]}-{guid[12:16]}-{guid[16:20]}-{guid[20:32]}"
+    r = import_into(runner, gf, write_fixture(tmp_path, "inv.txt",
+                                              invoice_fixture(uuid_form)))
+    assert r.exit_code == 0, f"UUID-with-hyphens txn_guid must be accepted:\n{r.output}"
+    assert bank_tx_count(runner, gf, tmp_path) == 1, \
+        "UUID-with-hyphens must not create a duplicate bank transaction"
+
+
 def test_txn_guid_wrong_bank_account_fails(tmp_path):
     """bank_account that matches no split — counter-split search fails."""
     runner = CliRunner()

--- a/tests/integration/test_payment_roundtrip.py
+++ b/tests/integration/test_payment_roundtrip.py
@@ -1,0 +1,431 @@
+"""
+Tests for payment transaction round-trip correctness (Q-003, Q-004).
+
+BUG A — Account type round-trip:
+  Exporter writes GnuCash internal type names (A/Receivable, A/Payable).
+  Importer must accept both canonical and internal forms.
+
+BUG B — Bank-first duplicate:
+  When a bank feed transaction already exists and an invoice with a
+  payment: block is imported, ApplyPayment() must NOT create a second
+  bank entry.  The correct fix uses txn_guid to retarget the pre-existing
+  transaction's counter-split in-place.
+
+BUG C — Same-day same-amount idempotency:
+  Re-importing the same invoice file must not duplicate payment transactions.
+
+Fixture files used:
+  tests/fixtures/payment_roundtrip_accounts.txt      — account hierarchy
+  tests/fixtures/payment_roundtrip_bank_invoice.txt  — bank tx (invoice side)
+  tests/fixtures/payment_roundtrip_bank_bill.txt     — bank tx (bill side)
+  tests/fixtures/payment_roundtrip_invoice_txn_guid.txt — invoice template
+  tests/fixtures/payment_roundtrip_bill_txn_guid.txt    — bill template
+"""
+
+import os
+import tempfile
+import time
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURES = "tests/fixtures"
+ACCOUNTS      = f"{FIXTURES}/payment_roundtrip_accounts.txt"
+BANK_INVOICE  = f"{FIXTURES}/payment_roundtrip_bank_invoice.txt"
+BANK_BILL     = f"{FIXTURES}/payment_roundtrip_bank_bill.txt"
+INV_TEMPLATE  = f"{FIXTURES}/payment_roundtrip_invoice_txn_guid.txt"
+BILL_TEMPLATE = f"{FIXTURES}/payment_roundtrip_bill_txn_guid.txt"
+
+# Business objects with payments (no txn_guid) — for round-trip and same-day tests
+SINGLE_PAID_INVOICE = """\
+customer "C1"
+  name: "Acme"
+  currency: CAD
+
+invoice "INV-001"
+  customer_id: "C1"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Service"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 1
+    price: 100
+    taxable: false
+    tax_included: false
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-001"
+    accumulate: true
+  payment:
+    date: 2026-01-15
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Payment INV-001"
+"""
+
+TWO_SAME_DAY_INVOICES = """\
+customer "C1"
+  name: "Acme"
+  currency: CAD
+
+invoice "INV-A"
+  customer_id: "C1"
+  currency: CAD
+  date_opened: 2026-01-01
+  entry:
+    date: 2026-01-01
+    description: "Service A"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 1
+    price: 100
+    taxable: false
+    tax_included: false
+  posted:
+    date: 2026-01-01
+    due: 2026-01-31
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-A"
+    accumulate: true
+  payment:
+    date: 2026-01-15
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Payment INV-A"
+
+invoice "INV-B"
+  customer_id: "C1"
+  currency: CAD
+  date_opened: 2026-01-02
+  entry:
+    date: 2026-01-02
+    description: "Service B"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 1
+    price: 100
+    taxable: false
+    tax_included: false
+  posted:
+    date: 2026-01-02
+    due: 2026-01-31
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-B"
+    accumulate: true
+  payment:
+    date: 2026-01-15
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Payment INV-B"
+"""
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def accounts_plus(extra_fixture_path):
+    """Concatenate the base accounts file with another fixture file."""
+    with open(ACCOUNTS) as a, open(extra_fixture_path) as b:
+        return a.read() + "\n" + b.read()
+
+
+def accounts_plus_text(text):
+    """Concatenate the base accounts file with inline text."""
+    with open(ACCOUNTS) as a:
+        return a.read() + "\n" + text
+
+
+def invoice_fixture(txn_guid):
+    """Return invoice fixture content with txn_guid substituted."""
+    with open(INV_TEMPLATE) as f:
+        return f.read().format(txn_guid=txn_guid)
+
+
+def bill_fixture(txn_guid):
+    """Return bill fixture content with txn_guid substituted."""
+    with open(BILL_TEMPLATE) as f:
+        return f.read().format(txn_guid=txn_guid)
+
+
+def write_fixture(tmp_path, name, content):
+    p = tmp_path / name
+    p.write_text(content)
+    return str(p)
+
+
+def import_new(runner, gf, fixture_path, biz=False):
+    args = ["import", "--new", str(gf), fixture_path]
+    if biz:
+        args.append("--include-business-objects")
+    r = runner.invoke(cli, args)
+    assert r.exit_code == 0, f"import --new failed:\n{r.output}"
+    time.sleep(1)  # avoid GnuCash backup timestamp collision on subsequent save
+    return r
+
+
+def import_into(runner, gf, fixture_path, biz=True):
+    args = ["import", str(gf), fixture_path]
+    if biz:
+        args.append("--include-business-objects")
+    return runner.invoke(cli, args)
+
+
+def get_guid(runner, gf, account, date="2026-01-15"):
+    r = runner.invoke(cli, ["find-transactions", str(gf),
+                            "--account", account, "--date", date])
+    assert r.exit_code == 0, f"find-transactions failed:\n{r.output}"
+    lines = [line for line in r.output.strip().splitlines() if line]
+    assert lines, f"No transactions found for {account} on {date}"
+    return lines[0].split()[0]
+
+
+def bank_tx_count(runner, gf, tmp_path):
+    """Count unique transactions touching Assets:Bank via export."""
+    fd, out = tempfile.mkstemp(suffix=".txt")
+    os.close(fd)
+    try:
+        r = runner.invoke(cli, ["export", str(gf), out])
+        assert r.exit_code == 0, f"export failed:\n{r.output}"
+        with open(out) as f:
+            content = f.read()
+    finally:
+        os.unlink(out)
+
+    count = 0
+    in_tx = has_bank = False
+    for line in content.splitlines():
+        if line and line[0:1] not in (' ', '\t'):
+            if in_tx and has_bank:
+                count += 1
+            in_tx = line[0].isdigit()
+            has_bank = False
+        elif in_tx and 'Assets:Bank' in line:
+            has_bank = True
+    if in_tx and has_bank:
+        count += 1
+    return count
+
+
+def export_text(runner, gf):
+    fd, out = tempfile.mkstemp(suffix=".txt")
+    os.close(fd)
+    try:
+        runner.invoke(cli, ["export", str(gf), out])
+        return open(out).read()
+    finally:
+        os.unlink(out)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BUG A: account type round-trip
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_account_type_roundtrip(tmp_path):
+    """Export writes A/Receivable; re-import must not crash on that type."""
+    runner = CliRunner()
+    gf1 = tmp_path / "first.gnucash"
+    fixture = write_fixture(tmp_path, "full.txt",
+                            accounts_plus_text(SINGLE_PAID_INVOICE))
+    import_new(runner, gf1, fixture, biz=True)
+
+    exported = tmp_path / "exported.txt"
+    r = runner.invoke(cli, ["export", str(gf1), str(exported),
+                            "--include-business-objects"])
+    assert r.exit_code == 0, f"Export failed:\n{r.output}"
+
+    gf2 = tmp_path / "second.gnucash"
+    r = runner.invoke(cli, ["import", "--new", str(gf2), str(exported),
+                            "--include-business-objects"])
+    assert r.exit_code == 0, (
+        f"BUG A: re-import of exported file failed — "
+        f"account types not round-tripping:\n{r.output}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BUG B: txn_guid — retarget existing bank transaction to invoice lot
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_bank_first_then_invoice_with_txn_guid(tmp_path):
+    """
+    Happy path: bank tx imported first, invoice imported with txn_guid.
+    The counter-split is retargeted to AR and linked to the lot in-place.
+    Original bank metadata (notes, description, split memo) must survive.
+    """
+    runner = CliRunner()
+    gf = tmp_path / "book.gnucash"
+    import_new(runner, gf, write_fixture(tmp_path, "bank.txt",
+                                         accounts_plus(BANK_INVOICE)))
+
+    assert bank_tx_count(runner, gf, tmp_path) == 1
+
+    guid = get_guid(runner, gf, "Assets:Bank")
+    invoice_file = write_fixture(tmp_path, "invoice.txt", invoice_fixture(guid))
+
+    r = import_into(runner, gf, invoice_file)
+    assert r.exit_code == 0, f"Invoice import failed:\n{r.output}"
+    assert bank_tx_count(runner, gf, tmp_path) == 1, \
+        "txn_guid retarget must not create a second bank transaction"
+
+    exported = export_text(runner, gf)
+    assert "E-transfer from Acme" in exported, \
+        "Original bank tx description must be preserved"
+    assert "fitid:20260115001" in exported, \
+        "Original bank tx notes (fitid) must be preserved"
+    assert "QFX split memo to preserve" in exported, \
+        "Original bank split memo must be preserved"
+
+
+def test_bank_first_then_invoice_no_duplicate(tmp_path):
+    """Without txn_guid, ApplyPayment() creates a duplicate (known behaviour)."""
+    runner = CliRunner()
+    gf = tmp_path / "book.gnucash"
+    import_new(runner, gf, write_fixture(tmp_path, "bank.txt",
+                                         accounts_plus(BANK_INVOICE)))
+    invoice_file = write_fixture(tmp_path, "invoice.txt",
+                                 accounts_plus_text(SINGLE_PAID_INVOICE))
+    import_into(runner, gf, invoice_file)
+    assert bank_tx_count(runner, gf, tmp_path) == 2, \
+        "Without txn_guid, expected 2 bank transactions (known duplicate)"
+
+
+# ── error branches ────────────────────────────────────────────────────────────
+
+def test_txn_guid_on_unposted_invoice_fails(tmp_path):
+    """payment: block with txn_guid on posted: none invoice must fail clearly."""
+    runner = CliRunner()
+    gf = tmp_path / "book.gnucash"
+    import_new(runner, gf, write_fixture(tmp_path, "bank.txt",
+                                         accounts_plus(BANK_INVOICE)))
+    guid = get_guid(runner, gf, "Assets:Bank")
+
+    unposted = write_fixture(tmp_path, "inv.txt",
+        accounts_plus_text(
+            'customer "C1"\n  name: "Acme"\n  currency: CAD\n\n'
+            'invoice "INV-UNPOSTED"\n'
+            '  customer_id: "C1"\n  currency: CAD\n  date_opened: 2026-01-01\n'
+            '  entry:\n    date: 2026-01-01\n    description: "Service"\n'
+            '    action: "Hours"\n    account: "Income:Sales"\n'
+            '    quantity: 1\n    price: 100\n    taxable: false\n    tax_included: false\n'
+            '  posted: none\n'
+            '  payment:\n'
+            '    bank_account: "Assets:Bank"\n'
+            f'    txn_guid: {guid}\n'
+        )
+    )
+    r = import_into(runner, gf, unposted)
+    assert r.exit_code != 0
+    assert "posted" in r.output.lower() or "lot" in r.output.lower(), \
+        f"Error must mention posting/lot. Got:\n{r.output}"
+
+
+def test_txn_guid_not_found_fails(tmp_path):
+    """txn_guid referencing a non-existent GUID must fail clearly."""
+    runner = CliRunner()
+    gf = tmp_path / "book.gnucash"
+    import_new(runner, gf, write_fixture(tmp_path, "bank.txt",
+                                         accounts_plus(BANK_INVOICE)))
+
+    bad_guid_file = write_fixture(tmp_path, "inv.txt",
+                                  invoice_fixture("deadbeefdeadbeefdeadbeefdeadbeef"))
+    r = import_into(runner, gf, bad_guid_file)
+    assert r.exit_code != 0
+    assert "not found" in r.output.lower(), \
+        f"Error must mention 'not found'. Got:\n{r.output}"
+
+
+def test_txn_guid_wrong_bank_account_fails(tmp_path):
+    """bank_account that matches no split — counter-split search fails."""
+    runner = CliRunner()
+    gf = tmp_path / "book.gnucash"
+    import_new(runner, gf, write_fixture(tmp_path, "bank.txt",
+                                         accounts_plus(BANK_INVOICE)))
+    guid = get_guid(runner, gf, "Assets:Bank")
+
+    with open(INV_TEMPLATE) as f:
+        wrong_bank = f.read().format(txn_guid=guid).replace(
+            'bank_account: "Assets:Bank"',
+            'bank_account: "Assets:Does:Not:Exist"'
+        )
+    wrong_file = write_fixture(tmp_path, "inv.txt", wrong_bank)
+    r = import_into(runner, gf, wrong_file)
+    assert r.exit_code != 0
+    assert any(w in r.output.lower() for w in ("counter-split", "not found", "bank")), \
+        f"Error must identify the problem. Got:\n{r.output}"
+
+
+# ── idempotency ───────────────────────────────────────────────────────────────
+
+def test_txn_guid_idempotent_reimport(tmp_path):
+    """Re-importing the same invoice file after retarget must be a no-op."""
+    runner = CliRunner()
+    gf = tmp_path / "book.gnucash"
+    import_new(runner, gf, write_fixture(tmp_path, "bank.txt",
+                                         accounts_plus(BANK_INVOICE)))
+    guid = get_guid(runner, gf, "Assets:Bank")
+    invoice_file = write_fixture(tmp_path, "invoice.txt", invoice_fixture(guid))
+
+    r = import_into(runner, gf, invoice_file)
+    assert r.exit_code == 0, f"First import failed:\n{r.output}"
+    assert bank_tx_count(runner, gf, tmp_path) == 1
+
+    time.sleep(1)
+
+    r = import_into(runner, gf, invoice_file)
+    assert r.exit_code == 0, f"Re-import failed:\n{r.output}"
+    assert bank_tx_count(runner, gf, tmp_path) == 1, \
+        "Re-import must not create additional bank transactions"
+
+
+# ── bill (vendor) equivalent ──────────────────────────────────────────────────
+
+def test_txn_guid_bill_retarget(tmp_path):
+    """txn_guid works for vendor bills — counter-split retargeted to AP."""
+    runner = CliRunner()
+    gf = tmp_path / "book.gnucash"
+    import_new(runner, gf, write_fixture(tmp_path, "bank.txt",
+                                         accounts_plus(BANK_BILL)))
+
+    guid = get_guid(runner, gf, "Assets:Bank")
+    bill_file = write_fixture(tmp_path, "bill.txt", bill_fixture(guid))
+
+    r = import_into(runner, gf, bill_file)
+    assert r.exit_code == 0, f"Bill import failed:\n{r.output}"
+    assert bank_tx_count(runner, gf, tmp_path) == 1, \
+        "Bill txn_guid must not create a duplicate bank transaction"
+
+    exported = export_text(runner, gf)
+    assert "fitid:20260115002" in exported, \
+        "Original bill payment tx notes must be preserved"
+    assert "Bill payment memo to preserve" in exported, \
+        "Original bill payment split memo must be preserved"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BUG C: same-day same-amount — signature collapse on invoice-first re-import
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_same_day_same_amount_idempotent(tmp_path):
+    """
+    Two invoices both paid $100 on 2026-01-15 from Assets:Bank.
+    Re-importing into the SAME existing file (not --new) must not add
+    duplicate bank transactions.  GUID-based dedup should handle this.
+    """
+    runner = CliRunner()
+    fixture = write_fixture(tmp_path, "two_invoices.txt",
+                            accounts_plus_text(TWO_SAME_DAY_INVOICES))
+
+    gf = tmp_path / "book.gnucash"
+    import_new(runner, gf, fixture, biz=True)
+
+    assert bank_tx_count(runner, gf, tmp_path) == 2
+
+    r = import_into(runner, gf, fixture)
+    assert r.exit_code == 0, f"Re-import failed:\n{r.output}"
+    assert bank_tx_count(runner, gf, tmp_path) == 2, \
+        "Re-import must not duplicate bank transactions"

--- a/use_cases/export_business_objects.py
+++ b/use_cases/export_business_objects.py
@@ -90,11 +90,11 @@ class ExportBusinessObjectsUseCase:
             addr  = cust.GetAddr()
             lines = [
                 f'customer "{cust.GetID()}"',
-                f'  name: "{cust.GetName()}"',
-                f'  currency: {cust.GetCurrency().get_mnemonic()}',
+                f'\tname: "{cust.GetName()}"',
+                f'\tcurrency: {cust.GetCurrency().get_mnemonic()}',
             ]
             if not cust.GetActive():
-                lines.append('  active: false')
+                lines.append('	active: false')
             # Only emit optional address/contact fields when non-empty
             for field, val in [
                 ('addr1', addr.GetAddr1()),
@@ -104,10 +104,10 @@ class ExportBusinessObjectsUseCase:
                 ('email', addr.GetEmail()),
             ]:
                 if val:
-                    lines.append(f'  {field}: "{val}"')
+                    lines.append(f'	{field}: "{val}"')
             custom_meta = get_custom_metadata(cust)
             for k, v in sorted(custom_meta.items()):
-                lines.append(f'  {k}: "{v}"')
+                lines.append(f'	{k}: "{v}"')
             lines_list.append('\n'.join(lines))
         return '\n\n'.join(lines_list)
 
@@ -124,14 +124,14 @@ class ExportBusinessObjectsUseCase:
         for v in vendors:
             lines = [
                 f'vendor "{v.GetID()}"',
-                f'  name: "{v.GetName()}"',
-                f'  currency: {v.GetCurrency().get_mnemonic()}',
+                f'	name: "{v.GetName()}"',
+                f'	currency: {v.GetCurrency().get_mnemonic()}',
             ]
             if not v.GetActive():
-                lines.append('  active: false')
+                lines.append('	active: false')
             custom_meta = get_custom_metadata(v)
             for k, v_val in sorted(custom_meta.items()):
-                lines.append(f'  {k}: "{v_val}"')
+                lines.append(f'	{k}: "{v_val}"')
             lines_list.append('\n'.join(lines))
         return '\n\n'.join(lines_list)
 
@@ -167,10 +167,10 @@ class ExportBusinessObjectsUseCase:
             entry_parts.reverse()  # GnuCash prepends → put GST before PST/QST
 
             for acct_name, rate in entry_parts:
-                lines.append('  entry:')
-                lines.append(f'    account: "{acct_name}"')
-                lines.append(f'    rate: {_fmt_rate(rate)}')
-                lines.append('    type: PERCENT')
+                lines.append('	entry:')
+                lines.append(f'		account: "{acct_name}"')
+                lines.append(f'		rate: {_fmt_rate(rate)}')
+                lines.append('		type: PERCENT')
 
             return '\n'.join(lines)
 
@@ -202,18 +202,18 @@ class ExportBusinessObjectsUseCase:
         for inv, cust in invoices:
             lines = [
                 f'invoice "{inv.GetID()}"',
-                f'  customer_id: "{cust.GetID()}"',
-                f'  currency: {inv.GetCurrency().get_mnemonic()}',
-                f'  date_opened: {inv.GetDateOpened().strftime("%Y-%m-%d")}',
+                f'	customer_id: "{cust.GetID()}"',
+                f'	currency: {inv.GetCurrency().get_mnemonic()}',
+                f'	date_opened: {inv.GetDateOpened().strftime("%Y-%m-%d")}',
             ]
             if inv.GetBillingID():
-                lines.append(f'  billing_id: "{inv.GetBillingID()}"')
+                lines.append(f'	billing_id: "{inv.GetBillingID()}"')
             if inv.GetNotes():
-                lines.append(f'  notes: "{inv.GetNotes()}"')
+                lines.append(f'	notes: "{inv.GetNotes()}"')
 
             custom_meta = get_custom_metadata(inv)
             for k, v in sorted(custom_meta.items()):
-                lines.append(f'  {k}: "{v}"')
+                lines.append(f'	{k}: "{v}"')
 
             for raw_entry in inv.GetEntries():
                 lines += self._format_inv_entry(lib, raw_entry)
@@ -222,14 +222,14 @@ class ExportBusinessObjectsUseCase:
             posted_txn = inv.GetPostedTxn()
             if posted_txn:
                 ar_name = get_account_full_name(inv.GetPostedAcc())
-                lines.append('  posted:')
-                lines.append(f'    date: {inv.GetDatePosted().strftime("%Y-%m-%d")}')
-                lines.append(f'    due: {inv.GetDateDue().strftime("%Y-%m-%d")}')
-                lines.append(f'    ar_account: "{ar_name}"')
-                lines.append(f'    memo: "{posted_txn.GetDescription()}"')
-                lines.append('    accumulate: true')
+                lines.append('	posted:')
+                lines.append(f'		date: {inv.GetDatePosted().strftime("%Y-%m-%d")}')
+                lines.append(f'		due: {inv.GetDateDue().strftime("%Y-%m-%d")}')
+                lines.append(f'		ar_account: "{ar_name}"')
+                lines.append(f'		memo: "{posted_txn.GetDescription()}"')
+                lines.append('		accumulate: true')
             else:
-                lines.append('  posted: none')
+                lines.append('	posted: none')
 
             # payment blocks — always emitted; "none" sentinel when no payments exist
             lot = inv.GetPostedLot()
@@ -246,7 +246,7 @@ class ExportBusinessObjectsUseCase:
                     lines += self._format_payment(txn)
                     has_payments = True
             if not has_payments:
-                lines.append('  payment: none')
+                lines.append('	payment: none')
 
             invoice_strings.append('\n'.join(lines))
         return '\n\n'.join(invoice_strings)
@@ -270,15 +270,15 @@ class ExportBusinessObjectsUseCase:
         date_str = raw_entry.GetDate().strftime("%Y-%m-%d")
 
         lines = [
-            '  entry:',
-            f'    date: {date_str}',
-            f'    description: "{desc}"',
-            f'    action: "{action}"',
-            f'    account: "{acct_name}"',
-            f'    quantity: {_fmt_quantity(qty)}',
-            f'    price: {_fmt_quantity(price)}',
-            f'    taxable: {"true" if taxable else "false"}',
-            f'    tax_included: {"true" if tax_incl else "false"}',
+            '	entry:',
+            f'		date: {date_str}',
+            f'		description: "{desc}"',
+            f'		action: "{action}"',
+            f'		account: "{acct_name}"',
+            f'		quantity: {_fmt_quantity(qty)}',
+            f'		price: {_fmt_quantity(price)}',
+            f'		taxable: {"true" if taxable else "false"}',
+            f'		tax_included: {"true" if tax_incl else "false"}',
         ]
 
         # Tax table — ctypes required (SWIG const-type bug)
@@ -286,7 +286,7 @@ class ExportBusinessObjectsUseCase:
         if tt_ptr:
             tt_name = safe_ctypes_string(lib.gncTaxTableGetName, tt_ptr)
             if tt_name:
-                lines.append(f'    tax_table: "{tt_name}"')
+                lines.append(f'		tax_table: "{tt_name}"')
 
         return lines
 
@@ -313,21 +313,21 @@ class ExportBusinessObjectsUseCase:
         date_str  = raw_entry.GetDate().strftime("%Y-%m-%d")
 
         lines = [
-            '  entry:',
-            f'    date: {date_str}',
-            f'    description: "{desc}"',
-            f'    account: "{acct_name}"',
-            f'    quantity: {_fmt_quantity(qty)}',
-            f'    price: {_fmt_quantity(price)}',
-            f'    taxable: {"true" if taxable else "false"}',
-            f'    tax_included: {"true" if tax_incl else "false"}',
+            '	entry:',
+            f'		date: {date_str}',
+            f'		description: "{desc}"',
+            f'		account: "{acct_name}"',
+            f'		quantity: {_fmt_quantity(qty)}',
+            f'		price: {_fmt_quantity(price)}',
+            f'		taxable: {"true" if taxable else "false"}',
+            f'		tax_included: {"true" if tax_incl else "false"}',
         ]
 
         tt_ptr = lib.gncEntryGetBillTaxTable(ptr)
         if tt_ptr:
             tt_name = safe_ctypes_string(lib.gncTaxTableGetName, tt_ptr)
             if tt_name:
-                lines.append(f'    tax_table: "{tt_name}"')
+                lines.append(f'		tax_table: "{tt_name}"')
 
         return lines
 
@@ -354,14 +354,14 @@ class ExportBusinessObjectsUseCase:
                 break
 
         lines = [
-            '  payment:',
-            f'    date: {pay_date}',
-            f'    amount: {_fmt_quantity(pay_amt)}',
-            f'    bank_account: "{bank_name}"',
-            f'    memo: "{pay_memo}"',
+            '	payment:',
+            f'		date: {pay_date}',
+            f'		amount: {_fmt_quantity(pay_amt)}',
+            f'		bank_account: "{bank_name}"',
+            f'		memo: "{pay_memo}"',
         ]
         if pay_num:
-            lines.append(f'    num: "{pay_num}"')
+            lines.append(f'		num: "{pay_num}"')
         return lines
 
     # ── Bills (vendor invoices) ───────────────────────────────────────────────
@@ -393,14 +393,14 @@ class ExportBusinessObjectsUseCase:
         for inv, vendor in bills:
             lines = [
                 f'bill "{inv.GetID()}"',
-                f'  vendor_id: "{vendor.GetID()}"',
-                f'  currency: {inv.GetCurrency().get_mnemonic()}',
-                f'  date_opened: {inv.GetDateOpened().strftime("%Y-%m-%d")}',
+                f'	vendor_id: "{vendor.GetID()}"',
+                f'	currency: {inv.GetCurrency().get_mnemonic()}',
+                f'	date_opened: {inv.GetDateOpened().strftime("%Y-%m-%d")}',
             ]
 
             custom_meta = get_custom_metadata(inv)
             for k, v in sorted(custom_meta.items()):
-                lines.append(f'  {k}: "{v}"')
+                lines.append(f'	{k}: "{v}"')
 
             for raw_entry in inv.GetEntries():
                 lines += self._format_bill_entry(lib, raw_entry)
@@ -409,14 +409,14 @@ class ExportBusinessObjectsUseCase:
             posted_txn = inv.GetPostedTxn()
             if posted_txn:
                 ap_name = get_account_full_name(inv.GetPostedAcc())
-                lines.append('  posted:')
-                lines.append(f'    date: {inv.GetDatePosted().strftime("%Y-%m-%d")}')
-                lines.append(f'    due: {inv.GetDateDue().strftime("%Y-%m-%d")}')
-                lines.append(f'    ap_account: "{ap_name}"')
-                lines.append(f'    memo: "{posted_txn.GetDescription()}"')
-                lines.append('    accumulate: true')
+                lines.append('	posted:')
+                lines.append(f'		date: {inv.GetDatePosted().strftime("%Y-%m-%d")}')
+                lines.append(f'		due: {inv.GetDateDue().strftime("%Y-%m-%d")}')
+                lines.append(f'		ap_account: "{ap_name}"')
+                lines.append(f'		memo: "{posted_txn.GetDescription()}"')
+                lines.append('		accumulate: true')
             else:
-                lines.append('  posted: none')
+                lines.append('	posted: none')
 
             # payment blocks — always emitted; "none" sentinel when no payments exist
             lot = inv.GetPostedLot()
@@ -432,7 +432,7 @@ class ExportBusinessObjectsUseCase:
                     lines += self._format_payment(txn)
                     has_payments = True
             if not has_payments:
-                lines.append('  payment: none')
+                lines.append('	payment: none')
 
             bill_strings.append('\n'.join(lines))
         return '\n\n'.join(bill_strings)


### PR DESCRIPTION
Three related bugs fixed together because they all surface in the invoice/bill import+export workflow.

## Q-003 — Account type short-forms crash re-import; mixed indentation

**Problem**: The exporter emitted `A/Receivable` and `A/Payable` as account types, but the importer only recognised `RECEIVABLE` / `PAYABLE`. A full round-trip (export → re-import) would crash with an unknown account type. Separately, the exporter mixed TAB and 2-space indentation depending on which section was being written (accounts used spaces, business objects used tabs).

**Fix**:
- Added `ACCT_TYPE_MAP` aliases in `gnucash_importer.py` so both the short form (`A/Receivable`) and long form (`RECEIVABLE`) are accepted on import.
- Standardised the exporter (`export_business_objects.py`) to use TABs everywhere. The parser already accepted both TAB and space indentation so no parser change was needed.
- Updated `tests/fixtures/business_objects_only.txt` to use TABs to match the new exporter output for round-trip determinism.

## Q-004 — Payment block creates duplicate bank transaction when bank imported first

**Problem**: When a bank feed was imported before invoices/bills, applying a `payment:` block on an invoice would call `ApplyPayment()`, which always creates a **new** bank+AR transaction. The pre-existing bank transaction was left untouched, resulting in two bank entries for the same cash movement. Same-day same-amount idempotency was also broken: two invoices paid for the same amount on the same date would both match the same bank transaction.

**Fix**: Added `txn_guid` field to the `payment:` block. When present, the importer locates the existing bank transaction by GUID and **retargets its counter-split in-place** — `xaccSplitSetAccount` moves the non-bank split to the AR/AP account, `xaccSplitSetLot` links it to the invoice/bill lot. No `ApplyPayment()` is called; no new transaction is created. All original bank metadata (notes, description, FITID, split memos) is preserved.

When `txn_guid` is absent, the existing `ApplyPayment()` path is used unchanged (invoice-first workflow).

Implementation details:
- `_find_transaction_by_guid(book, guid)` — looks up existing tx (replaces the old `_find_and_delete_transaction` helper)
- `_retarget_counter_split_to_lot(lib, tx, bank_acct_name, ar_ap_account, lot)` — uses ctypes for `xaccSplitGetAccount`/`xaccSplitSetAccount` because the SWIG bindings have a const-type mismatch that returns garbage on all platforms; uses SWIG `xaccSplitSetLot` for the lot link
- Bill path mirrors invoice path; `ApplyPayment(amount=-N)` negation rule preserved for the no-txn_guid bill case
- Invoice/bill idempotency: `InvoiceLookupByID()` checked before creating; if already exists the directive is skipped without error
- New `find-transactions` CLI subcommand (`cli/find_transactions_cmd.py`) lets users locate the GUID of a bank transaction by account, date, and amount — the workflow step needed before adding `txn_guid` to a fixture file
- Verified on all 9 platforms (debian11/12/13, ubuntu20/22/24, fedora41, arch, opensuse) via `test-all-versions-parallel.sh`

SWIG limitation documented in `docs/DEBUGGING_GNUCASH_BINDINGS.md`:
- `xaccSplitGetAccount`: SWIG returns garbage due to const-type mismatch; always use ctypes
- `xaccSplitGetAmount`: SWIG works on all platforms; ctypes used here only because split_ptr was already in ctypes domain ("once ctypes, stay ctypes")

## Q-005 — Import errors show raw Python exceptions with no directive context

**Problem**: When import failed partway through a file, the error showed only a raw Python traceback with no indication of which directive caused it. With 50+ directives in a file this made debugging very slow.

**Fix**:
- `import_business_objects()` in `gnucash_importer.py` now wraps each directive import with try/except, re-raising with the directive type and identifier prepended (e.g. `invoice "INV-001": <original error>`)
- `import_cmd.py` account-creation loop wrapped the same way

## New files
- `cli/find_transactions_cmd.py` — `find-transactions` subcommand
- `docs/invoice-payment-reconciliation.md` — full workflow documentation for both the bank-first and invoice-first ordering, error table, idempotency notes
- `docs/issues/Q-003-account-type-export-not-reimportable.md`
- `docs/issues/Q-004-payment-transaction-duplicates.md`
- `docs/issues/Q-005-import-errors-no-context.md`
- `tests/integration/test_payment_roundtrip.py` — 9 tests covering: normal ApplyPayment, txn_guid invoice, txn_guid bill, metadata preservation, unposted invoice error, bad GUID error, bank-count invariant, idempotent re-import
- `tests/fixtures/payment_roundtrip_*.txt` — fixture files for the above