### PR TITLE
fix(Q-006): business-object id uniqueness, guid export, conflict detetion

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,8 +317,10 @@ open-ended metadata model.
 
 | Field | GnuCash field |
 |-------|--------------|
+| `guid` | Customer GUID (32-char hex; emitted on export, optional on import) |
 | `name` | Customer name |
 | `currency` | Customer currency |
+| `active` | Active flag (`true`/`false`; defaults `true`) |
 | `addr1`–`addr4` | Billing address lines |
 | `email` | Contact email |
 
@@ -326,14 +328,18 @@ open-ended metadata model.
 
 | Field | GnuCash field |
 |-------|--------------|
+| `guid` | Vendor GUID (32-char hex; emitted on export, optional on import) |
 | `name` | Vendor name |
 | `currency` | Vendor currency |
+| `active` | Active flag (`true`/`false`; defaults `true`) |
 
 **Invoice** — reserved fields:
 
 | Field | GnuCash field |
 |-------|--------------|
-| `customer_id` | Customer reference |
+| `guid` | Invoice GUID (32-char hex; emitted on export, optional on import) |
+| `customer_id` | Customer reference (by user-facing customer number) |
+| `customer_guid` | Customer reference (by GUID; must agree with `customer_id` when both present) |
 | `currency` | Invoice currency |
 | `date_opened` | Invoice open date |
 | `billing_id` | Billing ID |
@@ -345,11 +351,19 @@ open-ended metadata model.
 
 | Field | GnuCash field |
 |-------|--------------|
-| `vendor_id` | Vendor reference |
+| `guid` | Bill GUID (32-char hex; emitted on export, optional on import) |
+| `vendor_id` | Vendor reference (by user-facing vendor number) |
+| `vendor_guid` | Vendor reference (by GUID; must agree with `vendor_id` when both present) |
 | `currency` | Bill currency |
 | `date_opened` | Bill open date |
 | `posted` | Posted block / sentinel |
 | `payment` | Payment block / sentinel |
+
+**Tax table** — reserved fields:
+
+| Field | GnuCash field |
+|-------|--------------|
+| `guid` | Tax-table GUID (32-char hex; emitted on export, optional on import) |
 
 #### Any other key → KVP slot
 
@@ -820,6 +834,70 @@ invoice "INV-2026-004"
     bank_account: "Assets:Bank"
     memo: "Second instalment"
 ```
+
+### Identity and round-trip: `guid:`, `customer_guid:`, `vendor_guid:`
+
+Every business-object block (`customer`, `vendor`, `taxtable`, `invoice`,
+`bill`) carries a `guid:` field on export. The user-facing id (e.g.
+`customer "C001"`) is the human handle; the guid is GnuCash's internal
+primary key. Both are immutable once assigned.
+
+```
+customer "C001"
+	guid: "9f14a498cc894d50931f855a9a31d594"
+	name: "Acme Customer"
+	currency: CAD
+
+invoice "INV-001"
+	guid: "b61b7b200f5b41ad97a8f775e8ef6156"
+	customer_id: "C001"
+	customer_guid: "9f14a498cc894d50931f855a9a31d594"
+	currency: CAD
+	date_opened: 2026-01-01
+	...
+```
+
+**Hand-written files** can omit `guid:` entirely — GnuCash will assign a
+fresh one on first import. On subsequent re-imports (after the first export
+has put guids in the file) the importer uses the guid as the precise
+identity key.
+
+**Quote guid values.** Always quote: `guid: "abcd…"`. Mixed-hex unquoted
+forms (`guid: b2b3…b4`) work because the parser treats them as strings,
+but unquoted all-digit values like `guid: 22222222222222222222222222222222`
+are auto-converted to a number and lose their digit count. The exporter
+always emits quoted form.
+
+**Cross-references** (`customer_guid:` on invoices, `vendor_guid:` on
+bills) carry the *referenced* object's guid. `customer_id`/`vendor_id`
+keep the file readable; the guid is the authoritative key. When both are
+present they must resolve to the same record — otherwise the importer
+errors with the conflict spelled out.
+
+#### Re-import semantics: idempotent update
+
+Re-importing the same file is **idempotent**: existing records are
+*updated in place* rather than duplicated. The resolver looks up by `guid`
+first (when provided), falls back to lookup by id, and returns the
+existing record so the importer can update its mutable fields (name,
+address, active flag, custom KVP) without changing the GUID. This
+matches the natural workflow: edit the text, re-import, see your
+changes.
+
+The importer **errors** rather than silently doing the wrong thing in
+these cases:
+
+- the directive's `guid:` resolves to a record whose `id` doesn't match
+  (refusing to silently rename — invoices may reference the old id)
+- the directive's `guid:` is unknown but its `id` is taken (refusing to
+  rebuild because we cannot assign the new guid without overwriting the
+  existing record)
+- the book already contains multiple records with the same `id`
+  (legacy data needs cleanup in the GnuCash GUI before re-import)
+- an invoice/bill cross-reference has both `customer_id` (or `vendor_id`)
+  and the matching `_guid` field but they resolve to different records
+- the requested guid is already used by a different entity type
+  (transaction, account, etc.) — GnuCash GUIDs are unique book-wide
 
 ### Reconciling invoice and bill payments with a bank feed
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ gnucash plaintext is an app that can
 * load a .gnucash file and then export a [GnuCash](https://www.gnucash.org/) plaintext ledger file
 * load [GnuCash](https://www.gnucash.org/) plaintext ledger file and export a [beancount](https://github.com/beancount/beancount) compatible .beancount file
 * read from a [GnuCash](https://www.gnucash.org/) plaintext transaction file and create transaction in .gnucash file
-* bidirectional conversion between GnuCash and [GnuCash-Beancount](docs/gnucash-beancount-format.md) format with zero data loss for accounts, transactions, splits, commodities, and prices (business objects — customers, vendors, invoices, bills — are not representable in beancount; see [Limitations](docs/gnucash-beancount-format.md#limitations))
+* bidirectional conversion between GnuCash and [GnuCash-Beancount](docs/gnucash-beancount-format.md) format with zero data loss for accounts, transactions, splits, commodities, and prices (business objects and custom KVP slots are not preserved; see [Limitations](docs/gnucash-beancount-format.md#limitations))
 
 ## Motivation
 
@@ -586,7 +586,7 @@ gnucash-plaintext export-beancount mybook.gnucash output.beancount \
   --account "Assets:Bank"
 ```
 
-**Note:** The exported file is in [GnuCash-Beancount format](docs/gnucash-beancount-format.md), a special beancount format with GnuCash metadata that enables bidirectional conversion with zero data loss for accounts, transactions, splits, commodities, and prices. Business objects (customers, vendors, invoices, bills) are not representable in beancount and are dropped during export — see [Limitations](docs/gnucash-beancount-format.md#limitations).
+**Note:** The exported file is in [GnuCash-Beancount format](docs/gnucash-beancount-format.md), a special beancount format with GnuCash metadata that enables bidirectional conversion with zero data loss for accounts, transactions, splits, commodities, and prices. Business objects (customers, vendors, invoices, bills) and custom KVP slots are dropped during export — see [Limitations](docs/gnucash-beancount-format.md#limitations).
 
 ### View GnuCash data in Fava web UI
 

--- a/docs/DEBUGGING_GNUCASH_BINDINGS.md
+++ b/docs/DEBUGGING_GNUCASH_BINDINGS.md
@@ -261,6 +261,78 @@ generally null-safe, but GnuCash 3.8 on ubuntu20 is not.
 | Ubuntu 22/24 (GnuCash 4.8–4.9) | ✅ | ✅ | ✅ |
 | OpenSUSE / Fedora | ✅ | ✅ (txn.GetDescription ❌) | ✅ |
 
+## Business-Object ID and GUID — Hard-Won Findings (Q-006, 2026-05-07)
+
+### 1. `Customer(book, id, currency)` does NOT enforce id uniqueness
+
+Calling the SWIG constructor `Customer(book, "C001", currency)` always
+creates a new record. There is no precondition check; if a customer with
+id `"C001"` already exists, you end up with two records sharing the same
+user-facing id but with different GUIDs. The same applies to
+`Vendor(book, id, currency)`, and likely to `TaxTable` / `Employee` /
+`Job`.
+
+GnuCash keys business objects by **GUID** internally (the QofCollection
+hash table), not by the user-facing id. The id is just a string field on
+the entity, like `name`. The GnuCash GUI prevents duplicate ids through
+UX (the "New Customer" dialog auto-increments and rejects collisions),
+but the bindings bypass that constraint entirely.
+
+**Symptom**: `gnucash-plaintext export` after re-importing the same
+business-objects file emits N copies of every customer/vendor block.
+
+**Fix in this codebase**: `_resolve_existing_or_none` in
+`services/gnucash_importer.py` does `book.CustomerLookupByID(id)` /
+`VendorLookupByID(id)` (or a Query when guid lookup is needed) before
+the constructor and returns the existing record so the importer
+updates fields rather than creating a duplicate.
+
+### 2. GUID is unique book-wide across ALL entity types
+
+GnuCash GUIDs sit in a single book-wide entity table. Two records of
+*different* types (e.g. a customer and a transaction) cannot legally
+share a GUID. However, `qof_instance_set_guid` does **not** check —
+calling it with a GUID already used by some other entity silently
+corrupts the book.
+
+**Fix**: `_guid_in_use_anywhere` checks `xaccTransLookup`,
+`xaccAccountLookup`, the customer query, and the vendor query before
+`_set_object_guid` writes a custom GUID. Any collision raises a clear
+error naming the conflicting entity type.
+
+### 3. `Invoice` (SWIG) does not expose `GetGUID()` on all platforms
+
+Where `Customer.GetGUID()` and `Vendor.GetGUID()` work fine via SWIG,
+`Invoice.GetGUID()` raises `AttributeError` on debian13/ubuntu24. Use
+ctypes via `qof_instance_get_guid(int(invoice.instance))` +
+`guid_to_string_buff(buf)` instead. Tax tables only exist via ctypes
+(`gncTaxTableGetTables`) so they always need this path.
+
+### 4. `Account(instance=raw_ptr)` from a Query result is unsafe
+
+`Query.run()` for accounts returns raw int pointers. Wrapping them in
+`Account(instance=ptr)` segfaults inside the full test suite (state
+pollution from earlier tests). The safe alternative: walk the account
+tree from `book.get_root_account()` via `acct.get_children()`. Same
+pattern presumably applies to other types — prefer iteration over the
+SWIG hierarchy when available.
+
+### 5. Plaintext-format quirk: all-digit GUIDs need quotes
+
+`decode_value_from_string` in `infrastructure/gnucash/utils.py`
+auto-converts all-digit field values to Python `int`. So
+`guid: 22222222222222222222222222222222` (32 hex chars all `2`) decodes
+to int `22…22`, losing the original digit count — `0000…0022` and `22`
+both decode to int `22`.
+
+The exporter emits `guid: "<hex>"` (quoted) so this never bites the
+round-trip. Hand-written files must quote all-digit GUIDs; mixed-hex
+forms like `b2b3…b4` work unquoted because the parser keeps strings as
+strings.
+
+`_normalise_guid` rejects non-string inputs with a message asking the
+user to quote.
+
 ## Summary
 
 1. **No prediction possible** - test to discover failures
@@ -270,5 +342,9 @@ generally null-safe, but GnuCash 3.8 on ubuntu20 is not.
 5. **Use engine.py utilities** - safe ctypes patterns
 6. **`ApplyPayment(None, ...)`** - never pass a manually-allocated transaction
 7. **Payment memo on split** - never read from `txn.GetDescription()`
+8. **Business-object constructors don't dedupe by id** - lookup-before-create
+9. **GUIDs are unique book-wide** - check across all entity types before forcing
+10. **`Account(instance=raw_ptr)` from a Query result is unsafe** - walk the tree instead
+11. **All-digit GUID values need quoting** - parser auto-converts to int
 
 This approach has proven necessary for maximum compatibility across Ubuntu 20/22/24 and Debian 11/12/13.

--- a/docs/gnucash-beancount-format.md
+++ b/docs/gnucash-beancount-format.md
@@ -1,6 +1,6 @@
 # GnuCash-Beancount Format
 
-**GnuCash-Beancount** (bc-gnc) is a special beancount format that enables bidirectional conversion between GnuCash and beancount with zero data loss for accounts, transactions, splits, commodities, and prices. Business objects (customers, vendors, invoices, bills) have no equivalent in beancount and are dropped during export — see [Limitations](#limitations).
+**GnuCash-Beancount** (bc-gnc) is a special beancount format that enables bidirectional conversion between GnuCash and beancount with zero data loss for accounts, transactions, splits, commodities, and prices. Business objects (customers, vendors, invoices, bills) and user-defined KVP slots are not preserved — see [Limitations](#limitations).
 
 ## Overview
 
@@ -439,8 +439,11 @@ GnuCash-Beancount preserves accounts, transactions, splits, commodities, and pri
 | Tax tables | Dropped silently | No |
 | Employees | Dropped silently | No |
 | Jobs | Dropped silently | No |
+| Custom KVP slots on accounts/transactions/splits | Dropped silently | No |
 
-If you rely on GnuCash's business features and need a lossless plaintext format, use the native [GnuCash plaintext format](../README.md#gnucash-plaintext) (`export` / `import`) instead — it round-trips every object type the importer supports, including invoices, bills, customers, vendors, payments (with `txn_guid` retargeting), and tax tables.
+The custom KVP entry deserves a separate note: GnuCash exposes arbitrary key/value pairs (KVP slots) on every object, and the native plaintext format round-trips them via the custom-metadata mechanism (any unknown field on a block is stored in the object's KVP slot). The beancount export only emits the fixed set of `gnucash-*` metadata keys (`gnucash-guid`, `gnucash-type`, `gnucash-notes`, etc.); user-defined KVP entries are not extracted on export and would not be re-applied on import. If you store data in custom KVP slots and need a lossless cycle, stay on the native plaintext format.
+
+If you rely on GnuCash's business features or custom metadata and need a lossless plaintext format, use the native [GnuCash plaintext format](../README.md#gnucash-plaintext) (`export` / `import`) instead — it round-trips every object type the importer supports, including invoices, bills, customers, vendors, payments (with `txn_guid` retargeting), tax tables, and custom KVP metadata on every object type.
 
 The two export commands serve different goals:
 

--- a/docs/invoice-payment-reconciliation.md
+++ b/docs/invoice-payment-reconciliation.md
@@ -1,14 +1,15 @@
 # Invoice and Bill Payment Reconciliation
 
-Covers two scenarios where bank transactions and invoice/bill payments need
-to be linked without creating duplicate bank entries.
+Covers the scenarios where bank transactions and invoice/bill payments need
+to be linked without creating duplicate bank entries, and how the GUID-based
+identity model from Q-006 affects re-imports.
 
 ## Background
 
 When an invoice is paid in GnuCash, `ApplyPayment()` always creates a **new**
 bank+AR transaction. Similarly, when a vendor bill is paid, it creates a new
-bank+AP transaction. If a matching bank transaction was already imported from a
-bank feed (QFX, CSV, HTML, etc.), you end up with two bank entries for the
+bank+AP transaction. If a matching bank transaction was already imported from
+a bank feed (QFX, CSV, HTML, etc.), you end up with two bank entries for the
 same cash movement — one from the feed, one from the payment.
 
 The `txn_guid` field on a `payment:` block solves this cleanly: instead of
@@ -16,6 +17,16 @@ creating a new transaction, the importer **modifies the existing bank
 transaction in-place**, retargeting its counter-split to AR (or AP for bills)
 and linking it to the invoice/bill lot. All original bank metadata — notes,
 description, split memos, FITID — is preserved.
+
+This document describes:
+
+- [Workflow: Import bank feed first, then reconcile invoices](#workflow-import-bank-feed-first-then-reconcile-invoices)
+- [Vendor bills work the same way](#vendor-bills-work-the-same-way)
+- [GUID format conventions (Q-006)](#guid-format-conventions-q-006)
+- [Round-trip identity: the exporter writes back what you imported](#round-trip-identity-the-exporter-writes-back-what-you-imported)
+- [Idempotency after Q-006](#idempotency-after-q-006)
+- [Error cases](#error-cases)
+- [Without txn_guid (invoice-first workflow)](#without-txn_guid-invoice-first-workflow)
 
 ---
 
@@ -40,6 +51,7 @@ gnucash-plaintext find-transactions ledger.gnucash \
 ```
 
 Output:
+
 ```
 317c8ae6e0084c33951d052b9f1b9f23  2026-01-15    500.00  "E-transfer from Acme"
 ```
@@ -47,25 +59,37 @@ Output:
 ### Step 3 — Add `txn_guid` to the invoice's `payment:` block
 
 ```
+customer "CUST-001"
+	guid: "9f14a498cc894d50931f855a9a31d594"
+	name: "Acme Corp"
+	currency: CAD
+
 invoice "INV-2026-001"
-  customer_id: "CUST-001"
-  currency: CAD
-  date_opened: 2026-01-01
-  entry:
-    ...
-  posted:
-    date: 2026-01-01
-    due: 2026-01-31
-    ar_account: "Assets:Accounts Receivable"
-    memo: "Invoice INV-2026-001"
-    accumulate: true
-  payment:
-    bank_account: "Assets:Bank"
-    txn_guid: 317c8ae6e0084c33951d052b9f1b9f23
+	customer_id: "CUST-001"
+	customer_guid: "9f14a498cc894d50931f855a9a31d594"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		...
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-2026-001"
+		accumulate: true
+	payment:
+		bank_account: "Assets:Bank"
+		txn_guid: "317c8ae6e0084c33951d052b9f1b9f23"
 ```
 
-Only `bank_account` and `txn_guid` are required — `date`, `amount`, and `memo`
-are taken from the existing transaction and do not need to be repeated.
+Only `bank_account` and `txn_guid` are required in the `payment:` block —
+`date`, `amount`, and `memo` are taken from the existing transaction and do
+not need to be repeated.
+
+The `customer_guid:` line is optional in hand-written files but emitted on
+every export. When both `customer_id:` and `customer_guid:` are present,
+they must resolve to the same customer record (see
+[Error cases](#error-cases)).
 
 ### Step 4 — Import the invoice file
 
@@ -74,7 +98,9 @@ gnucash-plaintext import --include-business-objects ledger.gnucash invoices.txt
 ```
 
 The importer:
-1. Creates and posts the invoice (AR lot opened)
+
+1. Creates and posts the invoice (AR lot opened) — or finds the existing one
+   by id/guid and updates it
 2. Finds the existing bank transaction by GUID
 3. Retargets its counter-split to AR and links it to the invoice lot
 4. The lot sum reaches zero → invoice is marked paid
@@ -88,21 +114,27 @@ Bills use AP instead of AR. The `payment:` block in a `bill` directive is
 identical — just provide `bank_account` and `txn_guid`:
 
 ```
+vendor "VEND-001"
+	guid: "f66df24e6e75424ba08c2b0a47ec292c"
+	name: "Office Supplies Co."
+	currency: CAD
+
 bill "BILL-2026-001"
-  vendor_id: "VEND-001"
-  currency: CAD
-  date_opened: 2026-01-01
-  entry:
-    ...
-  posted:
-    date: 2026-01-01
-    due: 2026-01-31
-    ap_account: "Liabilities:Accounts Payable"
-    memo: "Bill BILL-2026-001"
-    accumulate: true
-  payment:
-    bank_account: "Assets:Bank"
-    txn_guid: abc123def456abc123def456abc123de
+	vendor_id: "VEND-001"
+	vendor_guid: "f66df24e6e75424ba08c2b0a47ec292c"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		...
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-2026-001"
+		accumulate: true
+	payment:
+		bank_account: "Assets:Bank"
+		txn_guid: "abc123def456abc123def456abc123de"
 ```
 
 Use `find-transactions` with a negative amount to find outgoing payments:
@@ -116,31 +148,129 @@ gnucash-plaintext find-transactions ledger.gnucash \
 
 ---
 
-## Error cases
+## GUID format conventions (Q-006)
 
-| Situation | Error |
-|---|---|
-| GUID does not exist in the book | `invoice "X": txn_guid '...' not found in book` |
-| Invoice has `posted: none` with a `payment:` block | `invoice "X": cannot have payment: blocks on an unposted invoice` |
-| Invoice was created but not posted (no posted: block) | `invoice "X": has no posted lot — must be posted before payment` |
-| `bank_account` doesn't match any split in the transaction | `invoice "X": Could not find counter-split in tx '...'` |
+`txn_guid`, `customer_guid`, `vendor_guid`, and the universal `guid:` field
+on every business-object block all carry GnuCash's 32-char hex GUID. A few
+syntactic rules are worth noting:
+
+| Form | Accepted on import | Emitted on export |
+|---|---|---|
+| Quoted hex (`"317c8ae6…"`) | yes (preferred) | yes |
+| Unquoted mixed hex (`317c8ae6…f23`, has letters) | yes | no |
+| Unquoted all-digit (e.g. `22222222222222222222222222222222`) | **no — error** | n/a |
+| UUID-with-hyphens (`317c8ae6-e008-4c33-951d-052b9f1b9f23`) | yes | no |
+
+**Why all-digit unquoted is rejected**: the plaintext parser auto-converts
+all-digit field values to Python integers, which silently loses leading
+zeros. `00000000000000000000000000000022` and `22` would both decode to the
+number `22`, making the original digit count unrecoverable. The importer
+raises a clear error asking you to quote the value:
+
+```
+guid must be a quoted string (got int 22…22); unquoted all-digit values
+are auto-converted to a number and lose their digit count.
+Quote the guid: e.g. guid: "00000000000000000000000000000022"
+```
+
+The exporter always emits quoted form, so this only matters for hand-written
+files.
 
 ---
 
-## Idempotency
+## Round-trip identity: the exporter writes back what you imported
 
-Re-importing the same invoice/bill file after a successful `txn_guid` link is
-safe — the invoice/bill already exists in the book, so it is skipped without
-error and the bank transaction is left untouched.
+After Q-006 the export is **identity-preserving** for every business object:
+
+- Customer/vendor/taxtable/invoice/bill blocks each carry a `guid:` field
+- Invoices reference their customer with both `customer_id:` and `customer_guid:`
+- Bills reference their vendor with both `vendor_id:` and `vendor_guid:`
+- `payment:` blocks linked via `txn_guid:` retain that link literally —
+  the next export still names the same bank transaction
+
+```
+invoice "INV-2026-001"
+	guid: "b61b7b200f5b41ad97a8f775e8ef6156"
+	customer_id: "CUST-001"
+	customer_guid: "9f14a498cc894d50931f855a9a31d594"
+	currency: CAD
+	date_opened: 2026-01-01
+	...
+```
+
+Re-importing this exported text into the same book is a no-op for identity
+(no new entities) and updates mutable fields in place (name, address,
+KVP slots, etc.).
+
+---
+
+## Idempotency after Q-006
+
+Before Q-006, re-importing a business-objects file *duplicated* customers
+and vendors silently. After Q-006, the rules are:
+
+| Object | Lookup key | Re-import behavior |
+|---|---|---|
+| Customer | `customer "ID"` directive header (and optional `guid:` field) | **Update** existing record's mutable fields |
+| Vendor | `vendor "ID"` (and optional `guid:` field) | **Update** existing record's mutable fields |
+| Tax table | `taxtable "Name"` (and optional `guid:` field) | **Update** existing record |
+| Invoice | `invoice "INV-001"` (`book.InvoiceLookupByID`) | **Skip** — invoices have lots and posted state; we never silently mutate posted invoices |
+| Bill | `bill "BILL-001"` (same as invoice) | **Skip** |
+
+Why invoices/bills skip rather than update: an invoice that is already
+posted has an open AR lot tied to a real transaction. Updating its entries
+or `customer_id` mid-flight would corrupt the lot. If you need to amend a
+posted invoice, do it through the GnuCash GUI or void+reissue.
+
+For a `payment:` block linked via `txn_guid`, re-importing is safe: the
+invoice is already paid, the bank transaction's counter-split is already
+retargeted to AR. The importer sees the invoice already exists and skips
+the whole block; the bank tx is left untouched.
+
+---
+
+## Error cases
+
+After Q-006 the importer halts on any inconsistency rather than silently
+doing the wrong thing. Common cases:
+
+### `payment:` / `txn_guid:` errors
+
+| Situation | Error |
+|---|---|
+| `txn_guid` does not exist in the book | `invoice "X": txn_guid '…' not found in book` |
+| `txn_guid` is not a valid GUID/UUID string | `Invalid GUID format: 'hello'` |
+| `txn_guid` is unquoted and all-digit | `guid must be a quoted string (got int …)` |
+| Invoice has `posted: none` with a `payment:` block | `invoice "X": cannot have payment: blocks on an unposted invoice` |
+| Invoice was created but not posted (no posted: block) | `invoice "X": has no posted lot — must be posted before payment` |
+| `bank_account` doesn't match any split in the transaction | `invoice "X": Could not find counter-split in tx '…'` |
+
+### Cross-reference errors (Q-006)
+
+| Situation | Error |
+|---|---|
+| `customer_id` and `customer_guid` resolve to different records | `customer_guid '…' resolves to customer with id "C002", but customer_id says "C001"` |
+| `customer_guid` provided but unknown | `customer_guid '…' does not resolve to any record` |
+| Invoice has neither `customer_id` nor `customer_guid` | `missing customer reference (need _id or _guid)` |
+| Same patterns apply to bill → vendor refs | (substitute "vendor" for "customer") |
+
+### Object identity errors (Q-006)
+
+| Situation | Error |
+|---|---|
+| Customer block's `guid:` resolves to record with a different id | `customer "C001": directive guid '…' resolves to a customer with id 'C002' — refusing to rename` |
+| Customer block's `guid:` is unknown but its `id` is taken | `customer "C001": directive guid '…' does not exist in the book, but a customer with this id already exists` |
+| Book contains pre-existing duplicates of the directive's id | `customer "C001": book already has 2 records with this id; resolve in GnuCash GUI before re-importing` |
+| Customer block requests a guid already in use by a transaction/account/vendor | `customer "C001": guid … is already used by an existing transaction in this book` |
 
 ---
 
 ## Without `txn_guid` (invoice-first workflow)
 
 If you import invoices with `payment:` blocks **before** importing the bank
-feed, `ApplyPayment()` creates the bank transaction for you. When the bank feed
-arrives later, the matching entry will appear as a duplicate. Delete the
-bank-feed duplicate using:
+feed, `ApplyPayment()` creates the bank transaction for you. When the bank
+feed arrives later, the matching entry will appear as a duplicate. Delete
+the bank-feed duplicate using:
 
 ```bash
 gnucash-plaintext find-transactions ledger.gnucash \

--- a/docs/invoice-payment-reconciliation.md
+++ b/docs/invoice-payment-reconciliation.md
@@ -2,7 +2,7 @@
 
 Covers the scenarios where bank transactions and invoice/bill payments need
 to be linked without creating duplicate bank entries, and how the GUID-based
-identity model from Q-006 affects re-imports.
+identity model affects re-imports.
 
 ## Background
 
@@ -22,9 +22,9 @@ This document describes:
 
 - [Workflow: Import bank feed first, then reconcile invoices](#workflow-import-bank-feed-first-then-reconcile-invoices)
 - [Vendor bills work the same way](#vendor-bills-work-the-same-way)
-- [GUID format conventions (Q-006)](#guid-format-conventions-q-006)
+- [GUID format conventions](#guid-format-conventions)
 - [Round-trip identity: the exporter writes back what you imported](#round-trip-identity-the-exporter-writes-back-what-you-imported)
-- [Idempotency after Q-006](#idempotency-after-q-006)
+- [Idempotency](#idempotency)
 - [Error cases](#error-cases)
 - [Without txn_guid (invoice-first workflow)](#without-txn_guid-invoice-first-workflow)
 
@@ -148,7 +148,7 @@ gnucash-plaintext find-transactions ledger.gnucash \
 
 ---
 
-## GUID format conventions (Q-006)
+## GUID format conventions
 
 `txn_guid`, `customer_guid`, `vendor_guid`, and the universal `guid:` field
 on every business-object block all carry GnuCash's 32-char hex GUID. A few
@@ -180,7 +180,7 @@ files.
 
 ## Round-trip identity: the exporter writes back what you imported
 
-After Q-006 the export is **identity-preserving** for every business object:
+The export is **identity-preserving** for every business object:
 
 - Customer/vendor/taxtable/invoice/bill blocks each carry a `guid:` field
 - Invoices reference their customer with both `customer_id:` and `customer_guid:`
@@ -204,10 +204,10 @@ KVP slots, etc.).
 
 ---
 
-## Idempotency after Q-006
+## Idempotency
 
-Before Q-006, re-importing a business-objects file *duplicated* customers
-and vendors silently. After Q-006, the rules are:
+Re-importing the same business-objects file is safe and predictable. The
+rules per object type:
 
 | Object | Lookup key | Re-import behavior |
 |---|---|---|
@@ -231,8 +231,8 @@ the whole block; the bank tx is left untouched.
 
 ## Error cases
 
-After Q-006 the importer halts on any inconsistency rather than silently
-doing the wrong thing. Common cases:
+The importer halts on any inconsistency rather than silently doing the wrong
+thing. Common cases:
 
 ### `payment:` / `txn_guid:` errors
 
@@ -245,7 +245,7 @@ doing the wrong thing. Common cases:
 | Invoice was created but not posted (no posted: block) | `invoice "X": has no posted lot — must be posted before payment` |
 | `bank_account` doesn't match any split in the transaction | `invoice "X": Could not find counter-split in tx '…'` |
 
-### Cross-reference errors (Q-006)
+### Cross-reference errors
 
 | Situation | Error |
 |---|---|
@@ -254,7 +254,7 @@ doing the wrong thing. Common cases:
 | Invoice has neither `customer_id` nor `customer_guid` | `missing customer reference (need _id or _guid)` |
 | Same patterns apply to bill → vendor refs | (substitute "vendor" for "customer") |
 
-### Object identity errors (Q-006)
+### Object identity errors
 
 | Situation | Error |
 |---|---|

--- a/docs/issues/Q-006-business-object-id-uniqueness-and-guid-export.md
+++ b/docs/issues/Q-006-business-object-id-uniqueness-and-guid-export.md
@@ -1,0 +1,262 @@
+---
+id: Q-006
+title: Business object IDs are not unique on re-import; GUIDs are not exported
+category: quality
+severity: high
+status: open
+---
+
+## Problem
+
+Re-importing a plaintext file that contains business objects produces
+**duplicate** records every time. After N imports of the same `customer "C001"`
+directive, the book contains N customers all with `id="C001"` and N different
+GUIDs.
+
+The same applies to `vendor` directives. Tax tables likely too. Invoices and
+bills are already protected via `book.InvoiceLookupByID()` (added in Q-004
+work).
+
+### Confirmed via CLI exploration (2026-05-06)
+
+Importing the same one-customer fixture three times into the same book and
+reloading after each:
+
+```
+After 1st import: count=1
+   id='C001'  guid=9f14a498cc894d50931f855a9a31d594
+After 2nd import: count=2
+   id='C001'  guid=bb63928499924429a0283205cc1f1278
+   id='C001'  guid=9f14a498cc894d50931f855a9a31d594
+After 3rd import: count=3
+   id='C001'  guid=f66df24e6e75424ba08c2b0a47ec292c
+   id='C001'  guid=bb63928499924429a0283205cc1f1278
+   id='C001'  guid=9f14a498cc894d50931f855a9a31d594
+```
+
+Subsequent `export --include-business-objects` emits **three** `customer "C001"`
+blocks — the duplicates are persisted to disk and round-trip through export.
+
+## Root cause
+
+In `services/gnucash_importer.py`:
+
+```python
+def import_customer(directive, book):
+    customer = Customer(book, directive.props['id'], ...)   # always creates
+    customer.SetName(directive.metadata['name'])
+    ...
+```
+
+`Customer(book, id, currency)` in the GnuCash bindings calls
+`gncCustomerCreate` + `gncCustomerSetID` with **no uniqueness check**. GnuCash
+keys customers by GUID internally, so any number of records can share the same
+user-facing `id`. `import_vendor` is structurally identical and has the same
+bug. `import_taxtable` likely too.
+
+## Why our tests miss this
+
+`test_business_objects_persisted_when_imported_into_existing_file`
+(`tests/integration/test_business_objects.py:437`) actually imports the same
+customer twice into one file but the only assertion on the customer side is:
+
+```python
+assert 'customer "1"' in exported_biz or 'Test Customer' in exported_biz
+```
+
+This passes whether the export contains **one** customer block or **three**.
+We never count.
+
+KVP-related tests (`tests/integration/test_kvp_all_objects.py`) all use
+distinct IDs (`CUST-010`, `CUST-011`, …), so they never re-import the same ID.
+
+## Conceptual point: ID is not really an ID
+
+GnuCash treats GUID as the primary key. The `id` field on a customer is just
+a user-facing number that the GUI happens to require to be unique through UX
+(the New Customer dialog auto-increments and rejects collisions). Programmatic
+creation via the bindings bypasses that constraint.
+
+For our plaintext format we should enforce ID uniqueness **at the importer
+layer** because:
+
+1. The plaintext `customer "C001"` directive uses ID as the natural handle —
+   the user reads and edits the file by ID, not GUID.
+2. Invoices reference customers by ID (`customer_id: "C001"`). If two
+   customers share that ID, the lookup `book.CustomerLookupByID("C001")`
+   returns whichever GnuCash finds first, which is non-deterministic. Invoice
+   posting could attach to the wrong customer.
+3. The user's mental model is "one ID = one customer". Silently allowing
+   duplicates breaks that contract.
+
+## Proposed fix
+
+### 1. Idempotent update on re-import (decision: update, not skip)
+
+On re-import, mutable fields (name, address, active flag, custom KVP) are
+**updated** on the existing record. This matches the user's mental model that
+"edit the text and re-import" should propagate changes. The Q-004 invoice
+idempotency was driven by "don't create a new lot for an already-paid
+invoice", which doesn't apply here — customer/vendor/tax-table fields are
+plain user data.
+
+### 2. ID and GUID are both immutable handles — conflicts must be errors
+
+Once a customer/vendor exists in GnuCash, two things cannot be changed
+programmatically without surprising the user:
+
+- **GUID** — GnuCash's internal primary key, immutable by design.
+- **Customer number / ID** — semantically the user-facing handle. The user's
+  mental contract is "one number = one customer". We refuse to silently
+  rename a customer because that would corrupt invoices that reference the
+  old number.
+
+So if a re-import directive provides both a `guid:` and an `id` (the
+directive header), they must agree with whatever is already in the book.
+Anything else is a user mistake we surface, not a thing we paper over.
+
+**Resolution table** for `import_customer` (vendor/taxtable analogous):
+
+| `guid:` provided? | GUID lookup | ID lookup | Action |
+|---|---|---|---|
+| no | — | not found | **create** new customer with given id |
+| no | — | found (1 match) | **update** fields on the matched customer |
+| no | — | found (multiple matches) | **error**: book has pre-existing duplicates for this id; user must resolve in GnuCash GUI |
+| yes | not found | not found | **create** new (and use the supplied GUID — see §3) |
+| yes | not found | found | **error**: directive's GUID is unknown but its id matches an existing customer; refusing to rebuild because we cannot assign that GUID without overwriting the existing one. User intent is ambiguous (rename? new entity? typo?) |
+| yes | found, id matches | (matches same record) | **update** fields |
+| yes | found, id mismatch | — | **error**: GUID resolves to customer with id=X but directive says id=Y; refusing to rename because Y may be in use by another record or referenced by invoices |
+
+The "error" rows are the safety net the user is asking for: any time the
+directive's claims don't line up with the book, halt before mutating anything.
+
+### 3. Export GUID alongside ID for every business object
+
+The plaintext export currently emits:
+
+```
+customer "C001"
+	name: "Acme"
+	currency: CAD
+```
+
+…with no GUID. This means a user editing the file cannot disambiguate two
+customers if duplicates somehow exist, and the plaintext format silently
+loses information that survives across GnuCash UI sessions.
+
+Add `guid:` as an optional field for `customer`, `vendor`, `taxtable`,
+`invoice`, `bill` — emitted on export, accepted on import, but not required
+in hand-written files:
+
+```
+customer "C001"
+	guid: 9f14a498cc894d50931f855a9a31d594
+	name: "Acme"
+	currency: CAD
+```
+
+When `guid:` is present and points to a customer that doesn't yet exist in
+the book (e.g. round-trip into a fresh book), we honour it via
+`qof_instance_set_guid` immediately after `Customer(book, id, currency)`.
+This keeps GUIDs stable across export → fresh-book → import cycles, the same
+property transactions already have.
+
+### 4. Cross-object references export both id and guid; import requires agreement
+
+Each business object block declares its own GUID via the universal `guid:`
+field (§3). On top of that, the two cross-object references in the
+business-object format — invoice → customer, bill → vendor — export **both**
+the referenced object's id and its guid:
+
+```
+invoice "INV-001"
+	customer_id: "C001"
+	customer_guid: 9f14a498cc894d50931f855a9a31d594
+	currency: CAD
+	date_opened: 2026-01-01
+	...
+```
+
+```
+bill "BILL-001"
+	vendor_id: "V001"
+	vendor_guid: f66df24e6e75424ba08c2b0a47ec292c
+	currency: CAD
+	...
+```
+
+**Import resolution rule** (parallels §2). For each cross-reference (writing
+generically as `<role>_id` / `<role>_guid` where `<role>` is `customer` or
+`vendor`):
+
+| `<role>_id` provided? | `<role>_guid` provided? | Action |
+|---|---|---|
+| yes | no | look up by id; error if not found or multiple matches (the latter only happens in legacy hand-written files; see §5) |
+| no | yes | look up by guid; error if not found |
+| yes | yes | look up by guid, then verify the matched record's id equals `<role>_id`; error on any mismatch (`customer_guid points to record with id "C002", but directive says customer_id "C001"`) |
+| no | no | error: invoice/bill missing required customer/vendor reference |
+
+The double-reference is for round-trip safety: the id keeps the file
+human-readable, the guid is the precise key the importer trusts, and the
+agreement check catches manual edits where one was changed but not the
+other.
+
+**Other cross-references stay unchanged.** Accounts in `entry: account:` /
+`posted: ar_account:` / `payment: bank_account:` / etc. are looked up by
+full name; tax tables in `entry: tax_table:` are looked up by name;
+commodities by `(namespace, mnemonic)`. These do not get guid pairs because
+GnuCash's structural rules already enforce uniqueness for them
+(parent-child enforced for accounts, name-keyed for tax tables, composite
+key for commodities). If a future test proves otherwise, that's a separate
+issue.
+
+### 5. Books with pre-existing duplicates surface at import time
+
+Plaintext-driven flows after this fix never create duplicates. A book that
+*already* contains duplicates (legacy import done before this fix, manual
+book edits, etc.) is caught by the "found (multiple matches)" row in §2's
+resolution table — the importer halts with a clear error and asks the user
+to resolve in the GnuCash GUI before re-running. No export-side warning
+needed.
+
+## Scope
+
+| Object type | Has unique-by-ID lookup? | Bug present? |
+|---|---|---|
+| Customer | `book.CustomerLookupByID()` exists, not used in import | Yes |
+| Vendor | `book.VendorLookupByID()` exists, not used in import | Yes |
+| Tax table | `gncTaxTableLookupByName()` exists | Likely (untested) |
+| Invoice | `book.InvoiceLookupByID()` used since Q-004 | No |
+| Bill | `book.InvoiceLookupByID()` used since Q-004 | No |
+
+## Files to change
+
+| File | Change |
+|---|---|
+| `services/gnucash_importer.py` | `import_customer`/`import_vendor`/`import_taxtable`: lookup by ID before create; on hit, update rather than create. Honour optional `guid:` directive field for precise lookup. |
+| `use_cases/export_business_objects.py` | Emit `guid:` field for every business object block. |
+| `tests/integration/test_business_objects.py` | Strengthen `test_business_objects_persisted_when_imported_into_existing_file` to assert exactly one block per ID. Add explicit re-import-creates-no-duplicate test. |
+| `tests/fixtures/business_objects_only.txt` | Add `guid:` lines after the regenerated export uses them. |
+| `README.md` | Document the new optional `guid:` field on customer/vendor/etc. blocks; mention re-import semantics (update fields, no duplicates). |
+
+## Out of scope
+
+- Backfilling fixes for books that already have pre-existing duplicates
+  (those need manual cleanup in the GnuCash GUI).
+- Customer/vendor *deletion* on re-import when a directive disappears from
+  the file — covered by F-011 archive/delete commands.
+- Employees and Jobs — not currently imported.
+
+## Open questions
+
+1. Should `customer_id:` references in invoices be validated against the
+   set of declared customer IDs at parse time? Probably yes, but a separate
+   issue from this one.
+2. Setting a fresh customer's GUID via `qof_instance_set_guid` requires
+   `BeginEdit/CommitEdit` semantics — needs verification on all platforms
+   (the same ctypes-vs-SWIG pitfalls that bit Q-004's
+   `xaccSplitSetAccount` likely apply here).
+
+---
+
+**Created**: 2026-05-06

--- a/infrastructure/gnucash/kvp.py
+++ b/infrastructure/gnucash/kvp.py
@@ -49,23 +49,24 @@ KNOWN_SPLIT_METADATA_KEYS = frozenset({
 
 # Customer metadata keys that have dedicated GnuCash setters.
 KNOWN_CUSTOMER_METADATA_KEYS = frozenset({
-    'name', 'currency', 'addr1', 'addr2', 'addr3', 'addr4', 'email', 'active',
+    'guid', 'name', 'currency', 'addr1', 'addr2', 'addr3', 'addr4', 'email', 'active',
 })
 
 # Vendor metadata keys that have dedicated GnuCash setters.
 KNOWN_VENDOR_METADATA_KEYS = frozenset({
-    'name', 'currency', 'active',
+    'guid', 'name', 'currency', 'active',
 })
 
 # Invoice metadata keys that have dedicated GnuCash setters.
 KNOWN_INVOICE_METADATA_KEYS = frozenset({
-    'customer_id', 'currency', 'date_opened', 'billing_id', 'notes',
-    'posted', 'payment',
+    'guid', 'customer_id', 'customer_guid', 'currency', 'date_opened',
+    'billing_id', 'notes', 'posted', 'payment',
 })
 
 # Bill metadata keys that have dedicated GnuCash setters.
 KNOWN_BILL_METADATA_KEYS = frozenset({
-    'vendor_id', 'currency', 'date_opened', 'posted', 'payment',
+    'guid', 'vendor_id', 'vendor_guid', 'currency', 'date_opened',
+    'posted', 'payment',
 })
 
 # Account metadata keys that have dedicated GnuCash setters.

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -8,7 +8,7 @@ Converts PlaintextDirective objects from the parser into GnuCash objects
 import ctypes
 import logging
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 import gnucash.gnucash_core_c as gc
 from gnucash import Account, Book, GncCommodity, GncNumeric, Split, Transaction
@@ -78,6 +78,242 @@ def _find_transaction_by_guid(book, guid: str):
     if raw is None:
         return None
     return Transaction(instance=raw)
+
+
+def _normalise_guid(guid) -> str:
+    """Normalise a user-supplied GUID to GnuCash's canonical 32-char lowercase hex.
+
+    Accepts:
+      - quoted hex string ("b2b3…b4")
+      - unquoted mixed hex (b2b3…b4) — the parser keeps it as a string
+      - UUID-with-hyphens
+    Rejects:
+      - int / float — these slip in when a user writes an unquoted all-digit
+        guid (e.g. `guid: 22222222222222222222222222222222`). The parser
+        auto-converts to int and the original digit count is lost (so
+        `0000…0022` would be indistinguishable from `22`). Force the user
+        to quote so we keep the literal hex digits.
+      - malformed strings ("hello") via `string_to_guid`
+    """
+    if isinstance(guid, (int, float, bool)):
+        raise ValueError(
+            f"guid must be a quoted string (got {type(guid).__name__} {guid!r}); "
+            f"unquoted all-digit values are auto-converted to a number and "
+            f"lose their digit count. Quote the guid: e.g. guid: \"{guid:032x}\""
+            if isinstance(guid, int) and 0 <= guid < 2**128
+            else f"guid must be a quoted string (got {type(guid).__name__} {guid!r})"
+        )
+
+    from gnucash.gnucash_core_c import GncGUID, string_to_guid
+    if not string_to_guid(guid, GncGUID()):
+        raise ValueError(f"Invalid GUID format: {guid!r}")
+    return guid.replace('-', '').lower()
+
+
+def _find_customers_by_id(book, id_: str):
+    """Return all Customer records with the given user-facing id."""
+    from gnucash import Query
+    from gnucash.gnucash_business import Customer
+    q = Query()
+    q.search_for('gncCustomer')
+    q.set_book(book)
+    out = [Customer(instance=r) for r in q.run() if Customer(instance=r).GetID() == id_]
+    q.destroy()
+    return out
+
+
+def _find_vendors_by_id(book, id_: str):
+    from gnucash import Query
+    from gnucash.gnucash_business import Vendor
+    q = Query()
+    q.search_for('gncVendor')
+    q.set_book(book)
+    out = [Vendor(instance=r) for r in q.run() if Vendor(instance=r).GetID() == id_]
+    q.destroy()
+    return out
+
+
+def _find_customer_by_guid(book, guid_norm: str):
+    from gnucash import Query
+    from gnucash.gnucash_business import Customer
+    q = Query()
+    q.search_for('gncCustomer')
+    q.set_book(book)
+    found = None
+    for r in q.run():
+        c = Customer(instance=r)
+        if c.GetGUID().to_string() == guid_norm:
+            found = c
+            break
+    q.destroy()
+    return found
+
+
+def _find_vendor_by_guid(book, guid_norm: str):
+    from gnucash import Query
+    from gnucash.gnucash_business import Vendor
+    q = Query()
+    q.search_for('gncVendor')
+    q.set_book(book)
+    found = None
+    for r in q.run():
+        v = Vendor(instance=r)
+        if v.GetGUID().to_string() == guid_norm:
+            found = v
+            break
+    q.destroy()
+    return found
+
+
+def _resolve_existing_or_none(kind: str, id_: str, guid_str: Optional[str],
+                              find_by_id, find_by_guid):
+    """Apply Q-006 §2 resolution rules. Returns (existing, must_set_guid_str).
+
+    `kind` is 'customer'/'vendor' for error messages.
+    `existing` is the matched record or None (caller creates new).
+    `must_set_guid_str` is the normalised guid to assign to a freshly-created
+    record (for round-trip into a fresh book), or None.
+
+    Raises ValueError on any contradiction the user must resolve manually.
+    """
+    matches_by_id = find_by_id(id_)
+    if len(matches_by_id) > 1:
+        raise ValueError(
+            f'{kind} "{id_}": book already has {len(matches_by_id)} records '
+            f'with this id; resolve in GnuCash GUI before re-importing'
+        )
+
+    if guid_str is None:
+        # No guid in the directive — match by id alone, update or create.
+        return (matches_by_id[0] if matches_by_id else None), None
+
+    guid_norm = _normalise_guid(guid_str)
+    by_guid = find_by_guid(guid_norm)
+
+    if by_guid is None and matches_by_id:
+        # GUID is unknown but id is taken — refuse to rebuild because we
+        # cannot assign that guid without overwriting the existing record.
+        existing = matches_by_id[0]
+        raise ValueError(
+            f'{kind} "{id_}": directive guid {guid_str!r} does not exist in '
+            f'the book, but a {kind} with this id already exists '
+            f'(guid {existing.GetGUID().to_string()}). Refusing to rebuild — '
+            f'either remove the guid: line to update the existing record, or '
+            f'change the id to create a new {kind}.'
+        )
+
+    if by_guid is not None:
+        if by_guid.GetID() != id_:
+            raise ValueError(
+                f'{kind} "{id_}": directive guid {guid_str!r} resolves to a '
+                f'{kind} with id {by_guid.GetID()!r} — refusing to rename. '
+                f'{kind} ids are immutable; fix the directive to match.'
+            )
+        return by_guid, None
+
+    # No id match, no guid match → fresh create with the requested guid.
+    return None, guid_norm
+
+
+def _resolve_cross_reference(kind: str, id_val: Optional[str], guid_val: Optional[str],
+                             find_by_id, find_by_guid):
+    """Resolve an invoice→customer or bill→vendor reference.
+
+    Q-006 §4 rules: id and guid (when both present) must resolve to the same
+    record. Single-field lookups are allowed for hand-written files.
+
+    Returns the resolved record. Raises ValueError on contradiction.
+    """
+    if id_val is None and guid_val is None:
+        raise ValueError(f"missing {kind} reference (need _id or _guid)")
+
+    by_guid = None
+    if guid_val is not None:
+        by_guid = find_by_guid(_normalise_guid(guid_val))
+        if by_guid is None:
+            raise ValueError(
+                f"{kind}_guid {guid_val!r} does not resolve to any record"
+            )
+        if id_val is not None and by_guid.GetID() != id_val:
+            raise ValueError(
+                f"{kind}_guid {guid_val!r} resolves to {kind} with id "
+                f"{by_guid.GetID()!r}, but {kind}_id says {id_val!r}"
+            )
+        return by_guid
+
+    matches = find_by_id(id_val)
+    if not matches:
+        raise ValueError(f"{kind}_id {id_val!r} not found")
+    if len(matches) > 1:
+        raise ValueError(
+            f"{kind}_id {id_val!r} matches {len(matches)} records — "
+            f"specify {kind}_guid to disambiguate, or fix duplicates in GnuCash GUI"
+        )
+    return matches[0]
+
+
+def _guid_in_use_anywhere(book, guid_norm: str) -> Optional[str]:
+    """Return the kind of entity that already uses guid_norm, or None if free.
+
+    GnuCash GUIDs are unique book-wide across every entity type. Before
+    forcing a freshly-created object's GUID via qof_instance_set_guid, callers
+    must ensure the target GUID is not already taken by another entity, or
+    the book becomes corrupted.
+    """
+    import ctypes
+    from gnucash.gnucash_core_c import GncGUID, string_to_guid, xaccTransLookup
+    g = GncGUID()
+    if not string_to_guid(guid_norm, g):
+        return None
+    if xaccTransLookup(g, book.instance) is not None:
+        return 'transaction'
+
+    lib = ctypes.CDLL(None)
+    lib.xaccAccountLookup.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    lib.xaccAccountLookup.restype = ctypes.c_void_p
+    lib.string_to_guid.argtypes = [ctypes.c_char_p, ctypes.c_void_p]
+    lib.string_to_guid.restype = ctypes.c_int
+
+    class QofGuid(ctypes.Structure):
+        _fields_ = [("data", ctypes.c_uint8 * 16)]
+    cguid = QofGuid()
+    for i in range(16):
+        cguid.data[i] = int(guid_norm[i*2:i*2+2], 16)
+    if lib.xaccAccountLookup(ctypes.byref(cguid), int(book.instance)):
+        return 'account'
+
+    if _find_customer_by_guid(book, guid_norm) is not None:
+        return 'customer'
+    if _find_vendor_by_guid(book, guid_norm) is not None:
+        return 'vendor'
+    return None
+
+
+def _set_object_guid(book, obj, kind: str, id_: str, guid_norm: str) -> None:
+    """Force a freshly-created business object's GUID to a specific value.
+
+    Errors if the requested GUID is already used by any other entity in the
+    book — GnuCash GUIDs are unique across all object types, and a collision
+    would corrupt the book.
+    """
+    in_use = _guid_in_use_anywhere(book, guid_norm)
+    if in_use is not None:
+        raise ValueError(
+            f'{kind} "{id_}": guid {guid_norm} is already used by an existing '
+            f'{in_use} in this book; pick a different guid or remove the guid: '
+            f'line to let GnuCash assign one'
+        )
+
+    import ctypes
+    class QofGuid(ctypes.Structure):
+        _fields_ = [("data", ctypes.c_uint8 * 16)]
+    lib = ctypes.CDLL(None)
+    lib.qof_instance_set_guid.argtypes = [ctypes.c_void_p, ctypes.POINTER(QofGuid)]
+    lib.qof_instance_set_guid.restype = None
+    g = QofGuid()
+    for i in range(16):
+        g.data[i] = int(guid_norm[i*2:i*2+2], 16)
+    lib.qof_instance_set_guid(int(obj.instance), ctypes.byref(g))
 
 
 def _retarget_counter_split_to_lot(lib, existing_tx, bank_acct_name: str,
@@ -567,42 +803,72 @@ class GnuCashImporter:
         if directive.type != DirectiveType.CUSTOMER:
             raise ValueError(f"Expected CUSTOMER but got {directive.type}")
 
-        customer = Customer(book, directive.props['id'], book.get_table().lookup("CURRENCY", directive.metadata['currency']))
+        cid = directive.props['id']
+        guid_str = directive.metadata.get('guid')
+        existing, must_set_guid = _resolve_existing_or_none(
+            'customer', cid, guid_str,
+            lambda i: _find_customers_by_id(book, i),
+            lambda g: _find_customer_by_guid(book, g),
+        )
+
+        currency = book.get_table().lookup("CURRENCY", directive.metadata['currency'])
+        if existing is None:
+            customer = Customer(book, cid, currency)
+            if must_set_guid is not None:
+                _set_object_guid(book, customer, 'customer', cid, must_set_guid)
+        else:
+            customer = existing
+
         customer.BeginEdit()
         customer.SetName(directive.metadata['name'])
-
         addr = customer.GetAddr()
         addr.SetAddr1(directive.metadata.get('addr1', ''))
         addr.SetAddr2(directive.metadata.get('addr2', ''))
         addr.SetAddr3(directive.metadata.get('addr3', ''))
         addr.SetAddr4(directive.metadata.get('addr4', ''))
         addr.SetEmail(directive.metadata.get('email', ''))
-
         customer.CommitEdit()
-        if _is_falsy(directive.metadata.get('active', 'true')):
-            customer.SetActive(False)
+
+        customer.SetActive(not _is_falsy(directive.metadata.get('active', 'true')))
+
         custom_meta = {k: v for k, v in directive.metadata.items()
                        if k not in KNOWN_CUSTOMER_METADATA_KEYS and v is not None}
         if custom_meta:
             set_custom_metadata(customer, custom_meta)
-        logging.debug(f"Created customer {directive.props['id']}")
+        logging.debug(f"{'Updated' if existing else 'Created'} customer {cid}")
 
     @staticmethod
     def import_vendor(directive: PlaintextDirective, book: Book):
         if directive.type != DirectiveType.VENDOR:
             raise ValueError(f"Expected VENDOR but got {directive.type}")
 
-        vendor = Vendor(book, directive.props['id'], book.get_table().lookup("CURRENCY", directive.metadata['currency']))
+        vid = directive.props['id']
+        guid_str = directive.metadata.get('guid')
+        existing, must_set_guid = _resolve_existing_or_none(
+            'vendor', vid, guid_str,
+            lambda i: _find_vendors_by_id(book, i),
+            lambda g: _find_vendor_by_guid(book, g),
+        )
+
+        currency = book.get_table().lookup("CURRENCY", directive.metadata['currency'])
+        if existing is None:
+            vendor = Vendor(book, vid, currency)
+            if must_set_guid is not None:
+                _set_object_guid(book, vendor, 'vendor', vid, must_set_guid)
+        else:
+            vendor = existing
+
         vendor.BeginEdit()
         vendor.SetName(directive.metadata['name'])
         vendor.CommitEdit()
-        if _is_falsy(directive.metadata.get('active', 'true')):
-            vendor.SetActive(False)
+
+        vendor.SetActive(not _is_falsy(directive.metadata.get('active', 'true')))
+
         custom_meta = {k: v for k, v in directive.metadata.items()
                        if k not in KNOWN_VENDOR_METADATA_KEYS and v is not None}
         if custom_meta:
             set_custom_metadata(vendor, custom_meta)
-        logging.debug(f"Created vendor {directive.props['id']}")
+        logging.debug(f"{'Updated' if existing else 'Created'} vendor {vid}")
 
     @staticmethod
     def import_taxtable(directive: PlaintextDirective, book: Book):
@@ -673,7 +939,17 @@ class GnuCashImporter:
         if has_posted_none and payment_children:
             raise ValueError(f'Invoice {inv_id}: cannot have payment: blocks on an unposted invoice (posted: none)')
 
-        invoice = Invoice(book, inv_id, book.get_table().lookup("CURRENCY", directive.metadata['currency']), book.CustomerLookupByID(directive.metadata['customer_id']))
+        customer = _resolve_cross_reference(
+            'customer',
+            directive.metadata.get('customer_id'),
+            directive.metadata.get('customer_guid'),
+            lambda i: _find_customers_by_id(book, i),
+            lambda g: _find_customer_by_guid(book, g),
+        )
+        invoice = Invoice(book, inv_id, book.get_table().lookup("CURRENCY", directive.metadata['currency']), customer)
+        if 'guid' in directive.metadata:
+            _set_object_guid(book, invoice, 'invoice', inv_id,
+                             _normalise_guid(directive.metadata['guid']))
         invoice.BeginEdit()
         invoice.SetDateOpened(datetime.strptime(directive.metadata['date_opened'], "%Y-%m-%d"))
 
@@ -799,7 +1075,17 @@ class GnuCashImporter:
             raise ValueError(f'Bill {bill_id}: cannot have payment: blocks on an unposted bill (posted: none)')
 
         # Bills are Invoice objects whose owner is a Vendor (no separate Bill class)
-        bill = Invoice(book, bill_id, book.get_table().lookup("CURRENCY", directive.metadata['currency']), book.VendorLookupByID(directive.metadata['vendor_id']))
+        vendor = _resolve_cross_reference(
+            'vendor',
+            directive.metadata.get('vendor_id'),
+            directive.metadata.get('vendor_guid'),
+            lambda i: _find_vendors_by_id(book, i),
+            lambda g: _find_vendor_by_guid(book, g),
+        )
+        bill = Invoice(book, bill_id, book.get_table().lookup("CURRENCY", directive.metadata['currency']), vendor)
+        if 'guid' in directive.metadata:
+            _set_object_guid(book, bill, 'bill', bill_id,
+                             _normalise_guid(directive.metadata['guid']))
         bill.BeginEdit()
         bill.SetDateOpened(datetime.strptime(directive.metadata['date_opened'], "%Y-%m-%d"))
 

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -261,6 +261,7 @@ def _guid_in_use_anywhere(book, guid_norm: str) -> Optional[str]:
     the book becomes corrupted.
     """
     import ctypes
+
     from gnucash.gnucash_core_c import GncGUID, string_to_guid, xaccTransLookup
     g = GncGUID()
     if not string_to_guid(guid_norm, g):

--- a/tests/fixtures/business_objects_with_guids.txt
+++ b/tests/fixtures/business_objects_with_guids.txt
@@ -1,0 +1,81 @@
+2026-01-01 open Assets
+	type: Asset
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Bank
+	type: Bank
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Accounts Receivable
+	type: Accounts Receivable
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities
+	type: Liability
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:Accounts Payable
+	type: Liability
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Income
+	type: Income
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Income:Sales
+	type: Income
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Expenses
+	type: Expense
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Expenses:Supplies
+	type: Expense
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+
+customer "C001"
+	guid: "aa11aa11aa11aa11aa11aa11aa11aa11"
+	name: "Acme Customer"
+	currency: CAD
+
+vendor "V001"
+	guid: "bb22bb22bb22bb22bb22bb22bb22bb22"
+	name: "Supply Vendor"
+	currency: CAD
+
+invoice "INV-001"
+	guid: "cc33cc33cc33cc33cc33cc33cc33cc33"
+	customer_id: "C001"
+	customer_guid: "aa11aa11aa11aa11aa11aa11aa11aa11"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted: none
+	payment: none
+
+bill "BILL-001"
+	guid: "dd44dd44dd44dd44dd44dd44dd44dd44"
+	vendor_id: "V001"
+	vendor_guid: "bb22bb22bb22bb22bb22bb22bb22bb22"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Supplies"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 50
+		taxable: true
+		tax_included: false
+	posted: none
+	payment: none

--- a/tests/integration/test_business_object_idempotent_reimport.py
+++ b/tests/integration/test_business_object_idempotent_reimport.py
@@ -1,0 +1,807 @@
+"""
+Q-006: Business-object IDs must be unique on re-import; GUIDs must round-trip.
+
+Tests in this file describe the desired behaviour of the importer/exporter
+once Q-006 is fixed. They are written first so we can confirm the gap before
+changing any implementation:
+
+  1. Re-import of a customer/vendor with the same id must NOT create a
+     duplicate record. Existing record fields update in place.
+  2. Each business-object block (customer, vendor, taxtable, invoice, bill)
+     exports its own GUID under a universal `guid:` field.
+  3. Invoice → customer and bill → vendor cross-references export both id
+     and guid (`customer_id:` + `customer_guid:`, `vendor_id:` + `vendor_guid:`).
+     If both are present on import, they must resolve to the same record;
+     mismatches are errors.
+  4. Re-import resolution honours `id` ⇔ `guid` agreement: any contradiction
+     between the directive and the existing book record is an error.
+
+These tests intentionally avoid depending on internal helpers; they drive
+everything through the CLI to mirror the user-level scenario reported by
+the external tester.
+"""
+
+import os
+import re
+import time
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+_GUID_RE = re.compile(r'^[0-9a-f]{32}$')
+
+
+ACCOUNTS = """
+2026-01-01 open Assets
+\ttype: Asset
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Assets:Bank
+\ttype: Bank
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Assets:Accounts Receivable
+\ttype: Accounts Receivable
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Liabilities
+\ttype: Liability
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:Accounts Payable
+\ttype: Accounts Payable
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Income
+\ttype: Income
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Income:Sales
+\ttype: Income
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Expenses
+\ttype: Expense
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Expenses:Supplies
+\ttype: Expense
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+"""
+
+
+def _write(path, text):
+    path.write_text(text)
+    return str(path)
+
+
+def _import_new(runner, gnc, fixture):
+    return runner.invoke(cli, ["import", "--new", str(gnc), fixture,
+                               "--include-business-objects"])
+
+
+def _import(runner, gnc, fixture):
+    return runner.invoke(cli, ["import", str(gnc), fixture,
+                               "--include-business-objects"])
+
+
+def _export(runner, gnc, out):
+    return runner.invoke(cli, ["export", str(gnc), str(out),
+                               "--include-business-objects"])
+
+
+def _count_blocks(text, header_prefix):
+    """Count business-object blocks whose header line starts with header_prefix.
+    e.g. _count_blocks(text, 'customer "C001"') counts customer blocks for C001."""
+    return sum(1 for line in text.splitlines() if line.startswith(header_prefix))
+
+
+def _all_blocks_for(text, header):
+    """Return a list of blocks (each a list of lines) whose header equals `header`."""
+    blocks = []
+    current = None
+    for line in text.splitlines():
+        if line == header:
+            if current is not None:
+                blocks.append(current)
+            current = [line]
+            continue
+        if current is not None:
+            if line == '' or line.startswith(' ') or line.startswith('\t'):
+                current.append(line)
+            else:
+                blocks.append(current)
+                current = None
+    if current is not None:
+        blocks.append(current)
+    return blocks
+
+
+def _block_for(text, header):
+    """Return the unique block whose header equals `header`.
+
+    Asserts that exactly one block exists. Returns 0 or >1 → AssertionError so
+    a duplicate (the very bug Q-006 is about) cannot silently pass a test that
+    only inspects fields.
+    """
+    blocks = _all_blocks_for(text, header)
+    assert len(blocks) == 1, (
+        f"Expected exactly 1 block matching {header!r}, got {len(blocks)}.\n"
+        f"This usually means the importer created duplicates."
+    )
+    return blocks[0]
+
+
+def _field_in_block(block_lines, key, *, strip_quotes=False):
+    """Return the value of a `\\tkey: value` field, or None.
+
+    If `strip_quotes` is True, surrounding double quotes are stripped from
+    the value. Use this when reading e.g. guid: "abcd…" → "abcd…".
+    """
+    for line in block_lines:
+        m = re.match(rf'^\t{re.escape(key)}:\s*(.*)$', line)
+        if m:
+            v = m.group(1).strip()
+            if strip_quotes and len(v) >= 2 and v[0] == '"' and v[-1] == '"':
+                v = v[1:-1]
+            return v
+    return None
+
+
+def _setup_book_with(runner, tmp_path, fixture_text):
+    """Create a fresh GnuCash file and import the given fixture text. Returns its path."""
+    gnc = tmp_path / "book.gnucash"
+    fix = _write(tmp_path / "in.txt", ACCOUNTS + "\n" + fixture_text)
+    r = _import_new(runner, gnc, fix)
+    assert r.exit_code == 0, f"Setup import failed:\n{r.output}"
+    time.sleep(1)  # GnuCash backup-timestamp safety
+    return gnc
+
+
+def _exported_biz_text(runner, tmp_path, gnc):
+    out = tmp_path / "exported.txt"
+    r = _export(runner, gnc, out)
+    assert r.exit_code == 0, f"Export failed:\n{r.output}"
+    return out.read_text()
+
+
+# ── 1. Re-import idempotency ─────────────────────────────────────────────────
+
+
+class TestReimportDoesNotDuplicate:
+    def test_customer_same_id_does_not_duplicate(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n')
+        # Re-import the same fixture with no changes.
+        again = _write(tmp_path / "again.txt",
+                       'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n')
+        r = _import(runner, gnc, again)
+        assert r.exit_code == 0, f"Re-import must succeed:\n{r.output}"
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        assert _count_blocks(text, 'customer "C001"') == 1, (
+            f"Expected exactly one customer 'C001' after re-import; got\n{text}"
+        )
+
+    def test_vendor_same_id_does_not_duplicate(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               'vendor "V001"\n\tname: "Supplier"\n\tcurrency: CAD\n')
+        again = _write(tmp_path / "again.txt",
+                       'vendor "V001"\n\tname: "Supplier"\n\tcurrency: CAD\n')
+        r = _import(runner, gnc, again)
+        assert r.exit_code == 0, f"Re-import must succeed:\n{r.output}"
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        assert _count_blocks(text, 'vendor "V001"') == 1, (
+            f"Expected exactly one vendor 'V001' after re-import; got\n{text}"
+        )
+
+    def test_customer_three_imports_one_record(self, tmp_path):
+        """Regression for the bug: N imports must NOT produce N records."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n')
+        for _ in range(2):
+            again = _write(tmp_path / "again.txt",
+                           'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n')
+            r = _import(runner, gnc, again)
+            assert r.exit_code == 0, f"Re-import must succeed:\n{r.output}"
+            time.sleep(1)
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        assert _count_blocks(text, 'customer "C001"') == 1
+
+
+# ── 2. Re-import updates fields rather than skipping ─────────────────────────
+
+
+class TestReimportUpdatesFields:
+    def test_customer_name_updates(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               'customer "C001"\n\tname: "Acme Original"\n\tcurrency: CAD\n')
+        renamed = _write(tmp_path / "renamed.txt",
+                         'customer "C001"\n\tname: "Acme Renamed"\n\tcurrency: CAD\n')
+        r = _import(runner, gnc, renamed)
+        assert r.exit_code == 0, f"Re-import must succeed:\n{r.output}"
+
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        assert _count_blocks(text, 'customer "C001"') == 1
+        block = _block_for(text, 'customer "C001"')
+        assert _field_in_block(block, 'name') == '"Acme Renamed"', (
+            "Expected updated name in re-imported customer; got block:\n" + "\n".join(block)
+        )
+
+    def test_customer_active_flag_updates_to_false(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n')
+        deact = _write(tmp_path / "deact.txt",
+                       'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n\tactive: false\n')
+        r = _import(runner, gnc, deact)
+        assert r.exit_code == 0, f"Re-import must succeed:\n{r.output}"
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        assert _count_blocks(text, 'customer "C001"') == 1, (
+            f"Re-import with active: false must update the existing record, not "
+            f"create a duplicate. Got:\n{text}"
+        )
+        block = _block_for(text, 'customer "C001"')
+        assert _field_in_block(block, 'active') == 'false', (
+            "Expected active: false after re-import; got block:\n" + "\n".join(block)
+        )
+
+
+# ── 3. Universal `guid:` field on each object's own block ────────────────────
+
+
+class TestExportEmitsObjectGuid:
+    @pytest.mark.parametrize("kind,header,fixture_text", [
+        ("customer", 'customer "C001"',
+         'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n'),
+        ("vendor", 'vendor "V001"',
+         'vendor "V001"\n\tname: "Supplier"\n\tcurrency: CAD\n'),
+        ("taxtable", 'taxtable "GST"',
+         'taxtable "GST"\n\tentry:\n\t\taccount: "Liabilities:Accounts Payable"\n\t\trate: 5.0%\n\t\ttype: PERCENT\n'),
+    ])
+    def test_object_block_has_guid_field(self, tmp_path, kind, header, fixture_text):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, fixture_text)
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        block = _block_for(text, header)
+        guid = _field_in_block(block, 'guid', strip_quotes=True)
+        assert guid is not None, f"{kind} block must export guid:\n" + "\n".join(block)
+        assert _GUID_RE.match(guid), f"{kind} guid must be 32-char hex; got {guid!r}"
+
+
+# ── 4. Cross-reference guid pairs ────────────────────────────────────────────
+
+
+_INVOICE = """
+customer "C001"
+\tname: "Acme"
+\tcurrency: CAD
+
+invoice "INV-001"
+\tcustomer_id: "C001"
+\tcurrency: CAD
+\tdate_opened: 2026-01-01
+\tentry:
+\t\tdate: 2026-01-01
+\t\tdescription: "Service"
+\t\taction: "Hours"
+\t\taccount: "Income:Sales"
+\t\tquantity: 1
+\t\tprice: 100
+\t\ttaxable: false
+\t\ttax_included: false
+"""
+
+
+_BILL = """
+vendor "V001"
+\tname: "Supplier"
+\tcurrency: CAD
+
+bill "BILL-001"
+\tvendor_id: "V001"
+\tcurrency: CAD
+\tdate_opened: 2026-01-01
+\tentry:
+\t\tdate: 2026-01-01
+\t\tdescription: "Supplies"
+\t\taccount: "Expenses:Supplies"
+\t\tquantity: 1
+\t\tprice: 50
+\t\ttaxable: false
+"""
+
+
+class TestCrossReferenceGuid:
+    def test_invoice_exports_customer_guid_matching_customer_block_guid(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _INVOICE)
+        text = _exported_biz_text(runner, tmp_path, gnc)
+
+        cust_block = _block_for(text, 'customer "C001"')
+        cust_guid = _field_in_block(cust_block, 'guid', strip_quotes=True)
+        assert cust_guid is not None and _GUID_RE.match(cust_guid)
+
+        inv_block = _block_for(text, 'invoice "INV-001"')
+        ref_guid = _field_in_block(inv_block, 'customer_guid', strip_quotes=True)
+        assert ref_guid == cust_guid, (
+            f"Invoice's customer_guid must equal the customer's guid.\n"
+            f"customer guid: {cust_guid}\ninvoice ref:  {ref_guid}\n"
+            f"invoice block:\n" + "\n".join(inv_block)
+        )
+
+    def test_bill_exports_vendor_guid_matching_vendor_block_guid(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _BILL)
+        text = _exported_biz_text(runner, tmp_path, gnc)
+
+        vend_block = _block_for(text, 'vendor "V001"')
+        vend_guid = _field_in_block(vend_block, 'guid', strip_quotes=True)
+        assert vend_guid is not None and _GUID_RE.match(vend_guid)
+
+        bill_block = _block_for(text, 'bill "BILL-001"')
+        ref_guid = _field_in_block(bill_block, 'vendor_guid', strip_quotes=True)
+        assert ref_guid == vend_guid, (
+            f"Bill's vendor_guid must equal the vendor's guid.\n"
+            f"vendor guid: {vend_guid}\nbill ref:    {ref_guid}\n"
+            f"bill block:\n" + "\n".join(bill_block)
+        )
+
+
+# ── 5. Conflict detection on the cross-reference ─────────────────────────────
+
+
+class TestCrossReferenceMismatchErrors:
+    def test_invoice_with_mismatched_customer_id_and_guid_errors(self, tmp_path):
+        """Invoice that names customer_id="C001" + customer_guid pointing at C002 → error."""
+        runner = CliRunner()
+        # Create a book with TWO customers so we have two valid GUIDs.
+        gnc = _setup_book_with(runner, tmp_path,
+            'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n'
+            '\ncustomer "C002"\n\tname: "Other"\n\tcurrency: CAD\n')
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        c1_block = _block_for(text, 'customer "C001"')
+        c2_block = _block_for(text, 'customer "C002"')
+        c1_guid = _field_in_block(c1_block, 'guid', strip_quotes=True)
+        c2_guid = _field_in_block(c2_block, 'guid', strip_quotes=True)
+        assert c1_guid and c2_guid
+
+        # New invoice file with customer_id=C001 but customer_guid=C002's guid → contradiction
+        bad = (
+            f'invoice "INV-001"\n'
+            f'\tcustomer_id: "C001"\n'
+            f'\tcustomer_guid: "{c2_guid}"\n'
+            f'\tcurrency: CAD\n'
+            f'\tdate_opened: 2026-01-01\n'
+            f'\tentry:\n'
+            f'\t\tdate: 2026-01-01\n'
+            f'\t\tdescription: "Service"\n'
+            f'\t\taction: "Hours"\n'
+            f'\t\taccount: "Income:Sales"\n'
+            f'\t\tquantity: 1\n'
+            f'\t\tprice: 100\n'
+            f'\t\ttaxable: false\n'
+            f'\t\ttax_included: false\n'
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt", bad))
+        assert r.exit_code != 0, "Mismatched customer_id/customer_guid must error"
+        out = r.output.lower()
+        assert "customer_id" in out or "customer_guid" in out or "mismatch" in out, (
+            f"Error must explain the conflict; got:\n{r.output}"
+        )
+
+
+# ── 6. Conflict detection on the object block itself ─────────────────────────
+
+
+class TestObjectBlockGuidIdConflictErrors:
+    def test_reimport_with_guid_match_but_id_mismatch_errors(self, tmp_path):
+        """guid: <X> already exists with id="C001"; directive says id="C999" → error.
+
+        We refuse to silently rename a customer because the old id may be
+        referenced by invoices, and renaming would break those references.
+        """
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n')
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        guid = _field_in_block(_block_for(text, 'customer "C001"'), 'guid', strip_quotes=True)
+        assert guid
+
+        bad = (
+            f'customer "C999"\n'
+            f'\tguid: "{guid}"\n'
+            f'\tname: "Renamed"\n'
+            f'\tcurrency: CAD\n'
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt", bad))
+        assert r.exit_code != 0, (
+            f"GUID-already-exists with mismatched id must error; got success:\n{r.output}"
+        )
+
+
+# ── 7. Pre-existing duplicates surface at next import ────────────────────────
+
+
+class TestCrossReferenceFailureModes:
+    """Negative cases for invoice→customer / bill→vendor cross-references.
+
+    Each row of the §4 resolution table that should error gets a test."""
+
+    def test_invoice_with_unknown_customer_id_only_errors(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+            'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n')
+        bad = (
+            'invoice "INV-001"\n'
+            '\tcustomer_id: "GHOST"\n'
+            '\tcurrency: CAD\n'
+            '\tdate_opened: 2026-01-01\n'
+            '\tentry:\n'
+            '\t\tdate: 2026-01-01\n'
+            '\t\tdescription: "Service"\n'
+            '\t\taction: "Hours"\n'
+            '\t\taccount: "Income:Sales"\n'
+            '\t\tquantity: 1\n'
+            '\t\tprice: 100\n'
+            '\t\ttaxable: false\n'
+            '\t\ttax_included: false\n'
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt", bad))
+        assert r.exit_code != 0, "Unknown customer_id must error"
+        assert "ghost" in r.output.lower() or "not found" in r.output.lower()
+
+    def test_invoice_with_unknown_customer_guid_only_errors(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+            'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n')
+        bad = (
+            'invoice "INV-001"\n'
+            '\tcustomer_guid: "deadbeefdeadbeefdeadbeefdeadbeef"\n'
+            '\tcurrency: CAD\n'
+            '\tdate_opened: 2026-01-01\n'
+            '\tentry:\n'
+            '\t\tdate: 2026-01-01\n'
+            '\t\tdescription: "Service"\n'
+            '\t\taction: "Hours"\n'
+            '\t\taccount: "Income:Sales"\n'
+            '\t\tquantity: 1\n'
+            '\t\tprice: 100\n'
+            '\t\ttaxable: false\n'
+            '\t\ttax_included: false\n'
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt", bad))
+        assert r.exit_code != 0, "Unknown customer_guid must error"
+
+    def test_invoice_with_no_customer_reference_errors(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, "")
+        bad = (
+            'invoice "INV-001"\n'
+            '\tcurrency: CAD\n'
+            '\tdate_opened: 2026-01-01\n'
+            '\tentry:\n'
+            '\t\tdate: 2026-01-01\n'
+            '\t\tdescription: "Service"\n'
+            '\t\taction: "Hours"\n'
+            '\t\taccount: "Income:Sales"\n'
+            '\t\tquantity: 1\n'
+            '\t\tprice: 100\n'
+            '\t\ttaxable: false\n'
+            '\t\ttax_included: false\n'
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt", bad))
+        assert r.exit_code != 0, (
+            f"Invoice missing both customer_id and customer_guid must error.\n"
+            f"Got:\n{r.output}"
+        )
+
+    def test_invoice_with_only_customer_guid_imports_ok(self, tmp_path):
+        """Hand-written invoice using customer_guid (no customer_id) is allowed.
+
+        Note: this only applies to the invoice→customer cross-reference field.
+        A `customer "..."` block itself always carries the customer number in
+        its directive header — there is no such thing as a guid-only customer
+        record.
+        """
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+            'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n')
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        c_guid = _field_in_block(_block_for(text, 'customer "C001"'), 'guid', strip_quotes=True)
+        assert c_guid
+
+        guid_only = (
+            f'invoice "INV-001"\n'
+            f'\tcustomer_guid: "{c_guid}"\n'
+            f'\tcurrency: CAD\n'
+            f'\tdate_opened: 2026-01-01\n'
+            f'\tentry:\n'
+            f'\t\tdate: 2026-01-01\n'
+            f'\t\tdescription: "Service"\n'
+            f'\t\taction: "Hours"\n'
+            f'\t\taccount: "Income:Sales"\n'
+            f'\t\tquantity: 1\n'
+            f'\t\tprice: 100\n'
+            f'\t\ttaxable: false\n'
+            f'\t\ttax_included: false\n'
+        )
+        r = _import(runner, gnc, _write(tmp_path / "ok.txt", guid_only))
+        assert r.exit_code == 0, f"customer_guid-only must succeed:\n{r.output}"
+
+
+class TestObjectBlockGuidValidation:
+    """Negative cases for the object's own `guid:` field."""
+
+    def test_unknown_guid_with_existing_id_errors(self, tmp_path):
+        """Directive guid is unknown; id is taken → refuse to rebuild."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+            'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n')
+        bad = (
+            'customer "C001"\n'
+            '\tguid: "deadbeefdeadbeefdeadbeefdeadbeef"\n'
+            '\tname: "Other"\n'
+            '\tcurrency: CAD\n'
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt", bad))
+        assert r.exit_code != 0, (
+            f"Unknown guid + existing id must error.\nGot:\n{r.output}"
+        )
+
+    def test_unquoted_mixed_hex_guid_works(self, tmp_path):
+        """Unquoted mixed-hex guids (e.g. b2b3...b4) must still parse as strings.
+
+        This is the friction-free hand-written form — users shouldn't be
+        forced to add quotes when the value is unambiguously hex.
+        """
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, "")
+        ok = (
+            'customer "C001"\n'
+            '\tguid: b2b3b2b3b2b3b2b3b2b3b2b3b2b3b2b4\n'
+            '\tname: "Acme"\n'
+            '\tcurrency: CAD\n'
+        )
+        r = _import(runner, gnc, _write(tmp_path / "ok.txt", ok))
+        assert r.exit_code == 0, (
+            f"Unquoted mixed-hex guid must be accepted:\n{r.output}"
+        )
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        guid = _field_in_block(_block_for(text, 'customer "C001"'), 'guid', strip_quotes=True)
+        assert guid == "b2b3b2b3b2b3b2b3b2b3b2b3b2b3b2b4"
+
+    def test_unquoted_all_digit_guid_errors_with_clear_message(self, tmp_path):
+        """Unquoted all-digit guids are lossy (parser converts to int) — must
+        be rejected with a message asking the user to quote."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, "")
+        bad = (
+            'customer "C001"\n'
+            '\tguid: 22222222222222222222222222222222\n'
+            '\tname: "Acme"\n'
+            '\tcurrency: CAD\n'
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt", bad))
+        assert r.exit_code != 0, "Unquoted all-digit guid must error"
+        out = r.output.lower()
+        assert "quote" in out or "string" in out, (
+            f"Error must hint at quoting; got:\n{r.output}"
+        )
+
+    def test_malformed_guid_errors(self, tmp_path):
+        """guid: 'hello' must surface as an invalid-format error."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, "")
+        bad = (
+            'customer "C001"\n'
+            '\tguid: "hello"\n'
+            '\tname: "Acme"\n'
+            '\tcurrency: CAD\n'
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt", bad))
+        assert r.exit_code != 0, "Malformed guid must error"
+        assert "invalid" in r.output.lower() or "guid" in r.output.lower()
+
+
+class TestRoundtripPreservesGuid:
+    """Round-trip: customer with explicit guid → import → export → same guid."""
+
+    def test_customer_guid_preserved_through_fresh_book(self, tmp_path):
+        runner = CliRunner()
+        original_guid = "abc123def456abc123def456abc12345"
+        fix = (
+            f'customer "C001"\n'
+            f'\tguid: "{original_guid}"\n'
+            f'\tname: "Acme"\n'
+            f'\tcurrency: CAD\n'
+        )
+        gnc = _setup_book_with(runner, tmp_path, fix)
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        guid = _field_in_block(_block_for(text, 'customer "C001"'), 'guid', strip_quotes=True)
+        assert guid == original_guid, (
+            f"Customer's explicit guid must round-trip; got {guid!r}, "
+            f"expected {original_guid!r}"
+        )
+
+    def test_full_fixture_with_guids_roundtrips_exactly(self, tmp_path):
+        """Fixture pre-populated with guids → import → export → identical biz blocks.
+
+        Complement to test_business_objects_roundtrip in test_business_objects.py:
+        that test imports a guid-less fixture and ignores guid lines on compare;
+        this one imports a fixture WITH explicit guids and demands exact match
+        (because the guids are deterministic on the input side, they should be
+        deterministic on the output side too).
+        """
+        from tests.integration.test_business_objects import extract_business_objects
+
+        runner = CliRunner()
+        gnc = tmp_path / "book.gnucash"
+        r = _import_new(runner, gnc, "tests/fixtures/business_objects_with_guids.txt")
+        assert r.exit_code == 0, f"Import failed:\n{r.output}"
+        time.sleep(1)
+
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        exported_biz = extract_business_objects(text)
+
+        with open("tests/fixtures/business_objects_with_guids.txt") as f:
+            reference_biz = extract_business_objects(f.read())
+
+        assert exported_biz == reference_biz, (
+            f"Business objects with explicit guids must round-trip exactly.\n"
+            f"--- reference ---\n{reference_biz}\n"
+            f"--- exported ---\n{exported_biz}"
+        )
+
+
+class TestGuidCollisionAcrossObjectTypes:
+    """GnuCash keeps GUIDs unique book-wide. A customer cannot share its GUID
+    with an account, transaction, vendor, or any other entity. Re-using a GUID
+    that already belongs to a different entity type must error."""
+
+    def _read_first_guid(self, gnc_path, qof_type: str) -> str:
+        """Open the gnucash file with bindings and return the GUID of the
+        first entity of the given QOF type ('Trans' or 'Account').
+
+        Note: Account(instance=raw_ptr) wrapping is unsafe per CLAUDE.md
+        ("SWIG may not wrap raw pointers safely"), so for accounts we walk
+        the parent→children tree via the proper SWIG API instead of using
+        the QofQuery results directly.
+        """
+        from gnucash import Query, Session, Transaction
+        s = Session(f"xml://{gnc_path}")
+        try:
+            book = s.book
+            if qof_type == 'Account':
+                root = book.get_root_account()
+
+                def first_descendant(acct):
+                    for child in acct.get_children():
+                        return child
+                    return None
+
+                first = first_descendant(root)
+                assert first is not None, (
+                    f"No accounts found in {gnc_path} — setup didn't populate."
+                )
+                return first.GetGUID().to_string()
+
+            q = Query()
+            q.search_for(qof_type)
+            q.set_book(book)
+            results = list(q.run())
+            q.destroy()
+            assert results, (
+                f"No {qof_type} found in {gnc_path} — setup import was silent "
+                f"about a malformed fixture. Check the fixture text."
+            )
+            return Transaction(instance=results[0]).GetGUID().to_string()
+        finally:
+            s.end()
+
+    def test_customer_guid_collides_with_existing_transaction_errors(self, tmp_path):
+        """Existing transaction has guid X; importing customer with guid: X must error."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, "")
+        # Setup: import a real transaction so the book has a transaction with a guid.
+        tx_fix = (
+            '2026-01-15 * "Test transaction"\n'
+            '\tAssets:Bank          100.00 CAD\n'
+            '\tIncome:Sales        -100.00 CAD\n'
+        )
+        r = _import(runner, gnc, _write(tmp_path / "tx.txt", tx_fix))
+        assert r.exit_code == 0, f"Setup tx import failed:\n{r.output}"
+        time.sleep(1)
+
+        # Read the transaction's actual guid via gnucash bindings.
+        tx_guid = self._read_first_guid(gnc, 'Trans')
+
+        bad = (
+            f'customer "C001"\n'
+            f'\tguid: "{tx_guid}"\n'
+            f'\tname: "Acme"\n'
+            f'\tcurrency: CAD\n'
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt", bad))
+        assert r.exit_code != 0, (
+            f"Customer with guid already used by a transaction must error.\n"
+            f"Got success:\n{r.output}"
+        )
+
+    def test_customer_guid_collides_with_existing_account_errors(self, tmp_path):
+        """The Assets account has a guid; reusing it for a customer must error."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, "")
+        # Read an existing account's guid via gnucash bindings (the plaintext
+        # exporter doesn't emit account guids, so we go to the source).
+        acct_guid = self._read_first_guid(gnc, 'Account')
+
+        bad = (
+            f'customer "C001"\n'
+            f'\tguid: "{acct_guid}"\n'
+            f'\tname: "Acme"\n'
+            f'\tcurrency: CAD\n'
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt", bad))
+        assert r.exit_code != 0, (
+            f"Customer with guid already used by an account must error.\n"
+            f"Got success:\n{r.output}"
+        )
+
+    def test_vendor_guid_collides_with_existing_customer_errors(self, tmp_path):
+        """Vendor and customer cannot share a GUID even though they're different types."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+            'customer "C001"\n\tguid: "22222222222222222222222222222222"\n\tname: "Acme"\n\tcurrency: CAD\n')
+
+        bad = (
+            'vendor "V001"\n'
+            '\tguid: "22222222222222222222222222222222"\n'
+            '\tname: "Supplier"\n'
+            '\tcurrency: CAD\n'
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt", bad))
+        assert r.exit_code != 0, (
+            f"Vendor with guid already used by a customer must error.\n"
+            f"Got success:\n{r.output}"
+        )
+
+
+class TestPreexistingDuplicates:
+    def test_reimport_into_book_with_duplicate_customers_errors(self, tmp_path):
+        """If the book already has two customers sharing id, next re-import errors.
+
+        We can't easily *create* such a state with the post-fix importer, so
+        we exercise this path by constructing a book the legacy way (two
+        sequential `customer "C001"` directives in a single file) and rely on
+        the fact that the importer must either:
+        - Error during the bad import itself (multiple-match on the second), or
+        - Error on a subsequent re-import when the now-duplicated state is hit
+        """
+        runner = CliRunner()
+        # Two customer "C001" blocks in one fixture — under the post-fix
+        # importer this should already error or update; either way the book
+        # should not end up with two C001 records.
+        fixture = (
+            'customer "C001"\n\tname: "First"\n\tcurrency: CAD\n'
+            '\ncustomer "C001"\n\tname: "Second"\n\tcurrency: CAD\n'
+        )
+        gnc = tmp_path / "book.gnucash"
+        fix = _write(tmp_path / "dup.txt", ACCOUNTS + "\n" + fixture)
+        r = _import_new(runner, gnc, fix)
+        # Either the import errors (preferred), or the export shows exactly 1.
+        if r.exit_code == 0:
+            text = _exported_biz_text(runner, tmp_path, gnc)
+            assert _count_blocks(text, 'customer "C001"') == 1, (
+                f"Two same-id directives in one file must not produce two records.\n"
+                f"Export:\n{text}"
+            )

--- a/tests/integration/test_business_objects.py
+++ b/tests/integration/test_business_objects.py
@@ -76,14 +76,26 @@ def test_business_objects_roundtrip(tmp_path):
     duplicates = [name for name in set(open_names) if open_names.count(name) > 1]
     assert not duplicates, f"Duplicate account declarations found: {duplicates}"
 
-    # Extract only the business objects from the output and compare with the reference
-    exported_biz = extract_business_objects(exported_text)
+    # Extract only the business objects from the output and compare with the reference.
+    # GUID-bearing lines (`guid:`, `customer_guid:`, `vendor_guid:`) are stripped
+    # because GUIDs are random per import; their round-trip behaviour is covered
+    # in test_business_object_idempotent_reimport.py.
+    def _strip_guid_lines(text):
+        keep = []
+        for line in text.splitlines():
+            stripped = line.lstrip(' \t')
+            if stripped.startswith(('guid:', 'customer_guid:', 'vendor_guid:')):
+                continue
+            keep.append(line)
+        return '\n'.join(keep)
+
+    exported_biz = _strip_guid_lines(extract_business_objects(exported_text))
 
     with open("tests/fixtures/business_objects_only.txt") as f:
-        reference_biz = extract_business_objects(f.read())
+        reference_biz = _strip_guid_lines(extract_business_objects(f.read()))
 
     assert exported_biz == reference_biz, (
-        f"Business objects mismatch.\n"
+        f"Business objects mismatch (ignoring guid lines).\n"
         f"--- reference ---\n{reference_biz}\n"
         f"--- exported ---\n{exported_biz}"
     )

--- a/use_cases/export_business_objects.py
+++ b/use_cases/export_business_objects.py
@@ -35,6 +35,29 @@ class ExportBusinessObjectsUseCase:
         self.book = book
         self._lib = load_gnc_engine()
 
+    def _guid_for_ptr_factory(self):
+        """Return a function (qof_ptr -> 32-char hex guid) for use with ctypes pointers.
+
+        Used for Invoices/Bills (SWIG `Invoice` does not expose GetGUID on
+        all platforms) and tax tables (only available via ctypes).
+        """
+        import ctypes
+        lib = self._lib
+        lib.qof_instance_get_guid.argtypes = [ctypes.c_void_p]
+        lib.qof_instance_get_guid.restype = ctypes.c_void_p
+        lib.guid_to_string_buff.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+        lib.guid_to_string_buff.restype = ctypes.c_char_p
+
+        def guid_for_ptr(qof_ptr):
+            buf = ctypes.create_string_buffer(40)
+            guid_ptr = lib.qof_instance_get_guid(qof_ptr)
+            if not guid_ptr:
+                return ''
+            lib.guid_to_string_buff(guid_ptr, buf)
+            return buf.value.decode('ascii')
+
+        return guid_for_ptr
+
     def _account_full_name(self, acct_ptr: int) -> str:
         """
         Build colon-separated account full name via ctypes (avoids SWIG const-type bug).
@@ -90,6 +113,7 @@ class ExportBusinessObjectsUseCase:
             addr  = cust.GetAddr()
             lines = [
                 f'customer "{cust.GetID()}"',
+                f'\tguid: "{cust.GetGUID().to_string()}"',
                 f'\tname: "{cust.GetName()}"',
                 f'\tcurrency: {cust.GetCurrency().get_mnemonic()}',
             ]
@@ -124,6 +148,7 @@ class ExportBusinessObjectsUseCase:
         for v in vendors:
             lines = [
                 f'vendor "{v.GetID()}"',
+                f'\tguid: "{v.GetGUID().to_string()}"',
                 f'	name: "{v.GetName()}"',
                 f'	currency: {v.GetCurrency().get_mnemonic()}',
             ]
@@ -147,10 +172,15 @@ class ExportBusinessObjectsUseCase:
         # gncTaxTableGetTables returns a GList* of GncTaxTable* pointers
         glist_ptr = lib.gncTaxTableGetTables(int(self.book.instance))
 
+        guid_for_ptr = self._guid_for_ptr_factory()
+
         def process_tax_table(lib, tt_ptr):
             """Process single tax table pointer to plaintext lines."""
             tt_name = safe_ctypes_string(lib.gncTaxTableGetName, tt_ptr)
-            lines = [f'taxtable "{tt_name}"']
+            lines = [
+                f'taxtable "{tt_name}"',
+                f'\tguid: "{guid_for_ptr(tt_ptr)}"',
+            ]
 
             # Process entries using iterate_glist
             entries_ptr = lib.gncTaxTableGetEntries(tt_ptr)
@@ -181,6 +211,7 @@ class ExportBusinessObjectsUseCase:
 
     def _export_invoices(self) -> str:
         lib = self._lib
+        guid_for_ptr = self._guid_for_ptr_factory()
 
         q = Query()
         q.search_for('gncInvoice')
@@ -202,7 +233,9 @@ class ExportBusinessObjectsUseCase:
         for inv, cust in invoices:
             lines = [
                 f'invoice "{inv.GetID()}"',
+                f'\tguid: "{guid_for_ptr(int(inv.instance))}"',
                 f'	customer_id: "{cust.GetID()}"',
+                f'\tcustomer_guid: "{cust.GetGUID().to_string()}"',
                 f'	currency: {inv.GetCurrency().get_mnemonic()}',
                 f'	date_opened: {inv.GetDateOpened().strftime("%Y-%m-%d")}',
             ]
@@ -389,11 +422,14 @@ class ExportBusinessObjectsUseCase:
             except Exception:
                 pass
 
+        guid_for_ptr = self._guid_for_ptr_factory()
         bill_strings = []
         for inv, vendor in bills:
             lines = [
                 f'bill "{inv.GetID()}"',
+                f'\tguid: "{guid_for_ptr(int(inv.instance))}"',
                 f'	vendor_id: "{vendor.GetID()}"',
+                f'\tvendor_guid: "{vendor.GetGUID().to_string()}"',
                 f'	currency: {inv.GetCurrency().get_mnemonic()}',
                 f'	date_opened: {inv.GetDateOpened().strftime("%Y-%m-%d")}',
             ]


### PR DESCRIPTION

A user-reported bug: re-importing a plaintext file containing customers / vendors creates a *duplicate* record every time. After N imports of the same `customer "C001"` directive, the book ends up with N customers all sharing id "C001" but with different GUIDs. The same applies to vendors. Invoices and bills were already protected via `book.InvoiceLookupByID` (added in Q-004 work).

Confirmed via direct CLI exploration before any implementation change:

  After 1st import: count=1
  After 2nd import: count=2
  After 3rd import: count=3

The duplicates were also persisted to disk and round-tripped through export — `gnucash-plaintext export` faithfully emitted three `customer "C001"` blocks for the three colliding records.

## Why our existing tests missed it

`test_business_objects_persisted_when_imported_into_existing_file` did re-import the same customer twice into one book, but the assertion only checked for *presence* (`'customer "1"' in exported_biz`), never count. KVP-related tests used distinct ids (`CUST-010`, `CUST-011`, …) and therefore never exercised the duplicate path.

## What this commit changes

### 1. Re-import is idempotent and updates fields in place

`Customer(book, id, currency)` in the GnuCash bindings always creates a new entity with no uniqueness check. Replaced the importer's direct construction with a resolver (`_resolve_existing_or_none`) that:

- looks up by guid first (when the directive provides `guid:`)
- falls back to lookup by id
- returns the existing record (so the caller updates fields) or None (so the caller creates a fresh entity)

Mutable fields (name, address, active flag, custom KVP) are updated on the existing record. This matches the user's "edit the text and re-import" mental model. `import_customer` and `import_vendor` use this path.

### 2. id ⇔ guid agreement is enforced; mismatches are errors

GnuCash GUIDs are immutable internal keys; ids are the user-facing handle. Once both are committed to the book, neither can be silently overwritten without breaking invoices that reference them. The resolver implements the §2 resolution table from docs/issues/Q-006-…:

  | guid? | id lookup | guid lookup | action |
  | no    | not found | —           | create |
  | no    | one match | —           | update |
  | no    | multiple  | —           | error  |
  | yes   | —         | not found, id taken | error |
  | yes   | id matches resolved record | (same record) | update |
  | yes   | id mismatches resolved record | — | error |

### 3. Universal `guid:` field on every business-object block

Customer, vendor, taxtable, invoice, and bill blocks now export a `guid:` field carrying the entity's GnuCash GUID. Importers honour this field via `qof_instance_set_guid` (ctypes), so a round-trip into a fresh book reproduces the same GUID. Tax tables and invoices / bills require the ctypes path because SWIG's `Invoice` doesn't expose `GetGUID` on all platforms, and tax tables are only reachable via `gncTaxTableGetTables` to begin with.

### 4. Cross-reference fields export both id and guid

Invoice → customer references export `customer_id:` *and* `customer_guid:`. Bill → vendor references export `vendor_id:` *and* `vendor_guid:`. On import, when both are present they must resolve to the same record (`_resolve_cross_reference`), otherwise the importer errors with the conflict spelled out:

  customer_guid 'aa11…' resolves to customer with id "C002",
  but customer_id says "C001"

This catches manual-edit inconsistencies that would otherwise silently produce a bill against the wrong vendor.

### 5. Cross-type guid uniqueness is enforced

GnuCash GUIDs are unique book-wide across every entity type, but `qof_instance_set_guid` does not refuse a guid that's already in use by a different type — it would silently corrupt the book. Added `_guid_in_use_anywhere` which checks transactions
(`xaccTransLookup`), accounts (`xaccAccountLookup`), customers, and vendors before letting `_set_object_guid` write a custom guid.

### 6. Unquoted all-digit guid → clear error

The plaintext parser auto-converts all-digit values (e.g. `guid: 22222222222222222222222222222222`) to a Python int, losing the original digit count (`0000…0022` and `22` would both decode to `22`). `_normalise_guid` now rejects non-string inputs with a message asking the user to quote the value:

  guid must be a quoted string (got int 22…22); unquoted all-digit
  values are auto-converted to a number and lose their digit count.
  Quote the guid: e.g. guid: "00000000000000000000000000000022"

Mixed-hex unquoted forms (e.g. `b2b3…b4`) continue to work because the parser keeps them as strings.

### 7. Quoted guid emission

Export emits `guid: "<hex>"` (quoted) rather than `guid: <hex>` (unquoted). Quoted is the canonical form because the parser preserves strings unconditionally; unquoted is supported for hand-written files but not what the exporter produces. `tests/integration/test_business_objects.py` strips guid lines before its exact-text comparison (because the GUIDs are random per import), and a new
`test_full_fixture_with_guids_roundtrips_exactly` proves the fixture-with-explicit-guids round-trip is byte-exact.

## Test coverage

Added 26 tests in
`tests/integration/test_business_object_idempotent_reimport.py`:

- Re-import idempotency (3): customer, vendor, three-imports-one-record
- Update on re-import (2): name, active flag
- Object-block `guid:` export (3 parametrised: customer/vendor/taxtable)
- Cross-reference guid export (2): customer_guid, vendor_guid
- Cross-reference mismatch error (1)
- Cross-reference failure modes (4): unknown id, unknown guid, missing ref, guid-only happy path
- Object-block guid validation (3): unknown-guid-with-existing-id, malformed guid, unquoted mixed hex works, unquoted all-digit errors
- Round-trip with explicit guids (2): single-customer through fresh book, full fixture exactly
- Cross-type guid collision (3): customer↔transaction, customer↔account, vendor↔customer
- Pre-existing duplicates (1)

All 829 tests pass on Debian 13 and Ubuntu 20.04 (Python 3.8 and 3.13). No regressions in the other 803 tests.

## Files changed

- docs/issues/Q-006-business-object-id-uniqueness-and-guid-export.md (new)
- infrastructure/gnucash/kvp.py: add `guid`, `customer_guid`, `vendor_guid` to KNOWN_*_METADATA_KEYS
- services/gnucash_importer.py: resolver, `_set_object_guid`, `_normalise_guid`, `_guid_in_use_anywhere`, lookups by id/guid, customer/vendor/invoice/bill import paths. Type annotations use Optional[str] (not str | None) for Python 3.8 compatibility on Ubuntu 20.04.
- use_cases/export_business_objects.py: `_guid_for_ptr_factory`, guid emission for every business-object block, customer_guid / vendor_guid emission, all guid values quoted
- tests/fixtures/business_objects_with_guids.txt (new)
- tests/integration/test_business_object_idempotent_reimport.py (new, 808 lines)
- tests/integration/test_business_objects.py: strip guid lines before exact-text comparison (guids are random per import)