### PR TITLE
feat(Q-007): accept --by-guid in delete/archive customer & vendor commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,14 +942,18 @@ gnucash-plaintext archive-customers mybook.gnucash CUST-001 CUST-002
 gnucash-plaintext archive-vendors mybook.gnucash VEND-001
 ```
 
-Per-ID status is printed for every ID requested:
+Per-ID status is printed for every ID requested. Each line shows both
+the user-facing id and the matched record's GUID so you can correlate the
+output with whatever you have on hand:
 
 ```
-CUST-001: archived
-CUST-002: archived — 5 invoice(s) linked
-CUST-003: already archived
+CUST-001 (9f14a498cc894d50931f855a9a31d594): archived
+CUST-002 (b02d3aa7df3a4f0a8e7c1cda5e88a3a1): archived — 5 invoice(s) linked
+CUST-003 (47b9c5e0b7e44b53b4d9f2c8e1e8a3b1): already archived
 CUST-004: not found
 ```
+
+The "not found" line has no GUID because no record was matched.
 
 The linked invoice/bill count is informational — archiving always succeeds for
 a found, currently-active entity. Exit code 1 if any ID was not found or
@@ -959,8 +963,8 @@ already archived.
 
 Both `archive-customers` and `archive-vendors` accept a `--by-guid` flag.
 With it set, positional args are interpreted as GUIDs (32-char hex, with or
-without UUID hyphens) instead of customer/vendor numbers. Output still shows
-the user-facing id of the matched record:
+without UUID hyphens) instead of customer/vendor numbers. The output format
+is the same `<id> (<guid>)` regardless of which form you used as input:
 
 ```bash
 gnucash-plaintext archive-customers mybook.gnucash --by-guid \
@@ -968,7 +972,7 @@ gnucash-plaintext archive-customers mybook.gnucash --by-guid \
 ```
 
 ```
-CUST-001: archived
+CUST-001 (9f14a498cc894d50931f855a9a31d594): archived
 ```
 
 Use this when you have an entity's GUID (e.g. parsed from an exported
@@ -993,8 +997,8 @@ gnucash-plaintext delete-customers mybook.gnucash CUST-001 CUST-002
 ```
 
 ```
-CUST-001: deleted
-CUST-002: failed — cannot delete, 3 invoice(s) linked
+CUST-001 (9f14a498cc894d50931f855a9a31d594): deleted
+CUST-002 (b02d3aa7df3a4f0a8e7c1cda5e88a3a1): failed — cannot delete, 3 invoice(s) linked
 CUST-003: not found
 ```
 

--- a/README.md
+++ b/README.md
@@ -955,6 +955,29 @@ The linked invoice/bill count is informational — archiving always succeeds for
 a found, currently-active entity. Exit code 1 if any ID was not found or
 already archived.
 
+#### Addressing by GUID instead of customer/vendor number
+
+Both `archive-customers` and `archive-vendors` accept a `--by-guid` flag.
+With it set, positional args are interpreted as GUIDs (32-char hex, with or
+without UUID hyphens) instead of customer/vendor numbers. Output still shows
+the user-facing id of the matched record:
+
+```bash
+gnucash-plaintext archive-customers mybook.gnucash --by-guid \
+    9f14a498cc894d50931f855a9a31d594
+```
+
+```
+CUST-001: archived
+```
+
+Use this when you have an entity's GUID (e.g. parsed from an exported
+plaintext file) and don't want the extra ID-lookup step. Mixing GUIDs and
+numbers in one invocation isn't supported — pick one form per call.
+
+A malformed GUID (e.g. wrong length, not hex) is rejected up-front with a
+clear error rather than producing a confusing "not found".
+
 ### Deleting customers permanently
 
 `delete-customers` hard-deletes a customer from the book. This is irreversible.
@@ -976,6 +999,14 @@ CUST-003: not found
 ```
 
 Exit code 1 if any ID failed or was not found.
+
+`delete-customers` also accepts `--by-guid` to address records by GUID
+(same semantics as `archive-customers --by-guid` above):
+
+```bash
+gnucash-plaintext delete-customers mybook.gnucash --by-guid \
+    9f14a498cc894d50931f855a9a31d594
+```
 
 > **Note:** Vendor deletion is not supported. GnuCash's vendor entity does not
 > persist correctly through the XML backend when `Destroy()` is called — the

--- a/cli/delete_cmd.py
+++ b/cli/delete_cmd.py
@@ -59,7 +59,7 @@ def _run_delete(gnucash_file, ids, use_case_cls, by_guid=False):
 
         all_ok = True
         for r in results:
-            click.echo(f'{r.id}: {r.message()}')
+            click.echo(f'{r.label()}: {r.message()}')
             if r.status != DeleteStatus.DELETED:
                 all_ok = False
 
@@ -94,7 +94,7 @@ def _run_archive(gnucash_file, ids, use_case_cls, by_guid=False):
 
         all_ok = True
         for r in results:
-            click.echo(f'{r.id}: {r.message()}')
+            click.echo(f'{r.label()}: {r.message()}')
             if r.status != ArchiveStatus.ARCHIVED:
                 all_ok = False
 

--- a/cli/delete_cmd.py
+++ b/cli/delete_cmd.py
@@ -25,6 +25,7 @@ import sys
 
 import click
 
+from infrastructure.gnucash.guid_lookup import normalise_guid
 from repositories.gnucash_repository import GnuCashRepository, SessionMode
 from use_cases.delete_business_objects import (
     ArchiveCustomersUseCase,
@@ -35,12 +36,26 @@ from use_cases.delete_business_objects import (
 )
 
 
-def _run_delete(gnucash_file, ids, use_case_cls):
+def _normalise_guids(guids):
+    """Validate format and canonicalise each guid (lowercase, strip hyphens).
+    Format errors surface as ClickException so the user sees a clean message
+    rather than a traceback."""
+    out = []
+    for g in guids:
+        try:
+            out.append(normalise_guid(g))
+        except ValueError as e:
+            raise click.ClickException(str(e)) from e
+    return out
+
+
+def _run_delete(gnucash_file, ids, use_case_cls, by_guid=False):
+    ids = _normalise_guids(ids) if by_guid else list(ids)
     repo = GnuCashRepository(gnucash_file)
     repo.open(mode=SessionMode.NORMAL)
     try:
         use_case = use_case_cls(repo.book)
-        results = use_case.execute(list(ids))
+        results = use_case.execute(ids, by_guid=by_guid)
 
         all_ok = True
         for r in results:
@@ -69,12 +84,13 @@ def _run_delete(gnucash_file, ids, use_case_cls):
         repo.close()
 
 
-def _run_archive(gnucash_file, ids, use_case_cls):
+def _run_archive(gnucash_file, ids, use_case_cls, by_guid=False):
+    ids = _normalise_guids(ids) if by_guid else list(ids)
     repo = GnuCashRepository(gnucash_file)
     repo.open(mode=SessionMode.NORMAL)
     try:
         use_case = use_case_cls(repo.book)
-        results = use_case.execute(list(ids))
+        results = use_case.execute(ids, by_guid=by_guid)
 
         all_ok = True
         for r in results:
@@ -98,58 +114,67 @@ def _run_archive(gnucash_file, ids, use_case_cls):
 @click.command('delete-customers')
 @click.argument('gnucash_file', type=click.Path(exists=True))
 @click.argument('ids', nargs=-1, required=True)
-def delete_customers(gnucash_file, ids):
+@click.option('--by-guid', is_flag=True, default=False,
+              help='Treat positional args as customer GUIDs instead of customer numbers.')
+def delete_customers(gnucash_file, ids, by_guid):
     """
-    Hard-delete one or more customers by ID.
+    Hard-delete one or more customers by ID (or GUID with --by-guid).
 
     Deletion is blocked if the customer has any linked invoices (paid or
     unpaid). Use archive-customers to soft-hide instead.
 
-    Exit code 1 if any ID was not deleted.
+    Exit code 1 if any record was not deleted.
 
     \b
     Examples:
       gnucash-plaintext delete-customers ledger.gnucash CUST001
       gnucash-plaintext delete-customers ledger.gnucash CUST001 CUST002 CUST003
+      gnucash-plaintext delete-customers ledger.gnucash --by-guid 9f14a498cc894d50931f855a9a31d594
     """
-    _run_delete(gnucash_file, ids, DeleteCustomersUseCase)
+    _run_delete(gnucash_file, ids, DeleteCustomersUseCase, by_guid=by_guid)
 
 
 @click.command('archive-customers')
 @click.argument('gnucash_file', type=click.Path(exists=True))
 @click.argument('ids', nargs=-1, required=True)
-def archive_customers(gnucash_file, ids):
+@click.option('--by-guid', is_flag=True, default=False,
+              help='Treat positional args as customer GUIDs instead of customer numbers.')
+def archive_customers(gnucash_file, ids, by_guid):
     """
     Archive (hide) one or more customers by setting them inactive.
 
     Linked invoices are unaffected. The invoice count is shown as
     informational context when records exist.
 
-    Exit code 1 if any ID was not found or already archived.
+    Exit code 1 if any record was not found or already archived.
 
     \b
     Examples:
       gnucash-plaintext archive-customers ledger.gnucash CUST001
       gnucash-plaintext archive-customers ledger.gnucash CUST001 CUST002
+      gnucash-plaintext archive-customers ledger.gnucash --by-guid 9f14a498cc894d50931f855a9a31d594
     """
-    _run_archive(gnucash_file, ids, ArchiveCustomersUseCase)
+    _run_archive(gnucash_file, ids, ArchiveCustomersUseCase, by_guid=by_guid)
 
 
 @click.command('archive-vendors')
 @click.argument('gnucash_file', type=click.Path(exists=True))
 @click.argument('ids', nargs=-1, required=True)
-def archive_vendors(gnucash_file, ids):
+@click.option('--by-guid', is_flag=True, default=False,
+              help='Treat positional args as vendor GUIDs instead of vendor numbers.')
+def archive_vendors(gnucash_file, ids, by_guid):
     """
     Archive (hide) one or more vendors by setting them inactive.
 
     Linked bills are unaffected. The bill count is shown as informational
     context when records exist.
 
-    Exit code 1 if any ID was not found or already archived.
+    Exit code 1 if any record was not found or already archived.
 
     \b
     Examples:
       gnucash-plaintext archive-vendors ledger.gnucash VEND001
       gnucash-plaintext archive-vendors ledger.gnucash VEND001 VEND002
+      gnucash-plaintext archive-vendors ledger.gnucash --by-guid f66df24e6e75424ba08c2b0a47ec292c
     """
-    _run_archive(gnucash_file, ids, ArchiveVendorsUseCase)
+    _run_archive(gnucash_file, ids, ArchiveVendorsUseCase, by_guid=by_guid)

--- a/docs/DEBUGGING_GNUCASH_BINDINGS.md
+++ b/docs/DEBUGGING_GNUCASH_BINDINGS.md
@@ -333,6 +333,48 @@ strings.
 `_normalise_guid` rejects non-string inputs with a message asking the
 user to quote.
 
+### 6. `book.InvoiceLookupByID(id)` does NOT find vendor bills (Q-007, 2026-05-07)
+
+GnuCash's customer invoices and vendor bills are both stored in the
+`gncInvoice` collection, distinguished only by their owner-type field
+(2 = Customer, 4 = Vendor). One might assume `book.InvoiceLookupByID(id)`
+queries the entire collection. It does not — it returns only customer
+invoices and silently returns `None` for bills, even when a bill with
+that exact id exists in the book.
+
+**Symptom**: an idempotency check like
+
+```python
+if book.InvoiceLookupByID(bill_id) is not None:
+    return  # skip; already imported
+```
+
+…is a no-op for bills. Re-importing the same bill fixture creates a
+fresh duplicate every time, accumulating bills with the same id and
+different GUIDs. The pre-Q-007 importer hit exactly this bug and
+nobody noticed because the existing tests only checked presence
+(`'bill "BILL-001"' in exported`), never count.
+
+**Fix**: drop `InvoiceLookupByID` for bills entirely; use a `Query` over
+`gncInvoice` filtered to owner-type 4. (Q-007's
+`_find_bills_by_id` / `_find_bill_by_guid` in
+`services/gnucash_importer.py`.)
+
+**Verified**:
+
+```
+>>> b.InvoiceLookupByID('BILL-001')
+None
+>>> # …yet a Query over gncInvoice returns:
+>>>   id='BILL-001'  owner_type=4
+```
+
+It's worth running the same Query-based replacement for customer
+invoices too, even though `InvoiceLookupByID` does work there — having
+both code paths use the same lookup shape avoids future surprises if
+the SWIG behaviour changes or if a query needs to detect legacy
+duplicates (multiple invoices with the same id, returned as a list).
+
 ## Summary
 
 1. **No prediction possible** - test to discover failures
@@ -346,5 +388,6 @@ user to quote.
 9. **GUIDs are unique book-wide** - check across all entity types before forcing
 10. **`Account(instance=raw_ptr)` from a Query result is unsafe** - walk the tree instead
 11. **All-digit GUID values need quoting** - parser auto-converts to int
+12. **`book.InvoiceLookupByID` does not find bills** - use a Query filtered by owner-type
 
 This approach has proven necessary for maximum compatibility across Ubuntu 20/22/24 and Debian 11/12/13.

--- a/docs/issues/Q-007-delete-archive-by-guid.md
+++ b/docs/issues/Q-007-delete-archive-by-guid.md
@@ -55,19 +55,31 @@ GUID values follow the same rules as Q-006:
 - UUID-with-hyphens accepted (normalised via `string_to_guid`)
 - Any other format is an immediate `Invalid GUID format` error
 
-## Per-id output stays the same
+## Per-record output always shows both id and guid
 
-The existing per-id summary lines (`CUST-001: deleted`,
-`CUST-002: failed — cannot delete, 3 invoice(s) linked`, etc.) keep
-showing the user-facing id of the matched record, regardless of which
-form was used to look it up. So:
+When a record is matched, the per-record summary line includes **both**
+the user-facing id and the GUID, regardless of which form the user typed
+on the command line:
 
 ```bash
+$ gnucash-plaintext delete-customers FILE CUST-001
+CUST-001 (9f14a498cc894d50931f855a9a31d594): deleted
+
 $ gnucash-plaintext delete-customers FILE --by-guid 9f14a498cc894d50931f855a9a31d594
-CUST-001: deleted
+CUST-001 (9f14a498cc894d50931f855a9a31d594): deleted
 ```
 
-This keeps logs readable when the GUID-form is used.
+This is also a small UX improvement on the existing id-only path: a
+maintainer reading a deletion log can confirm exactly which record was
+removed without having to cross-reference an export.
+
+On a miss (record not found) only the typed input is shown — there's no
+matched record to read a guid from:
+
+```
+DOES-NOT-EXIST: not found
+deadbeefdeadbeefdeadbeefdeadbeef: not found
+```
 
 ## Files to change
 

--- a/docs/issues/Q-007-delete-archive-by-guid.md
+++ b/docs/issues/Q-007-delete-archive-by-guid.md
@@ -1,0 +1,95 @@
+---
+id: Q-007
+title: delete-customers / archive-customers / archive-vendors must accept GUID, not just user-facing id
+category: quality
+severity: medium
+status: open
+---
+
+## Problem
+
+After Q-006 the importer/exporter treat GUID as a first-class identifier
+for customers, vendors, taxtables, invoices, and bills. The
+delete/archive CLI commands still only accept the user-facing id
+(customer number / vendor number) as the addressable handle:
+
+```bash
+gnucash-plaintext delete-customers   FILE CUST-001 CUST-002
+gnucash-plaintext archive-customers  FILE CUST-001
+gnucash-plaintext archive-vendors    FILE VEND-001
+```
+
+If two customers share an id (legacy data from before Q-006) the lookup
+returns a non-deterministic match — the user has no way to address a
+specific record. Also, scripts that already have a customer's GUID
+(e.g. parsed out of an exported plaintext file) must do an extra
+ID-lookup step before they can call delete/archive.
+
+## Why auto-detect is wrong
+
+We considered routing each arg through "looks like a 32-char hex →
+treat as GUID, else treat as id". Rejected: nothing prevents a user
+from naming a customer `9f14a498cc894d50931f855a9a31d594` (any non-empty
+string is a legal customer number). Auto-detection would silently
+misroute that arg.
+
+## Proposed fix
+
+Add an explicit `--by-guid` flag to each command:
+
+```bash
+gnucash-plaintext delete-customers   FILE [--by-guid] ID|GUID...
+gnucash-plaintext archive-customers  FILE [--by-guid] ID|GUID...
+gnucash-plaintext archive-vendors    FILE [--by-guid] ID|GUID...
+```
+
+Default behaviour (no flag) is unchanged: positional args are
+customer/vendor numbers. With `--by-guid` they are GUIDs. Mixed forms
+in one invocation are not supported — keeps the per-arg semantics
+unambiguous and matches the "I'm operating on a list of one kind of
+identifier" mental model.
+
+GUID values follow the same rules as Q-006:
+
+- 32-char lowercase hex
+- UUID-with-hyphens accepted (normalised via `string_to_guid`)
+- Any other format is an immediate `Invalid GUID format` error
+
+## Per-id output stays the same
+
+The existing per-id summary lines (`CUST-001: deleted`,
+`CUST-002: failed — cannot delete, 3 invoice(s) linked`, etc.) keep
+showing the user-facing id of the matched record, regardless of which
+form was used to look it up. So:
+
+```bash
+$ gnucash-plaintext delete-customers FILE --by-guid 9f14a498cc894d50931f855a9a31d594
+CUST-001: deleted
+```
+
+This keeps logs readable when the GUID-form is used.
+
+## Files to change
+
+| File | Change |
+|---|---|
+| `cli/delete_cmd.py` | Add `--by-guid` flag to all three commands; in the dispatcher, route to a new `*_by_guid` use case when set. |
+| `use_cases/delete_business_objects.py` | New `*ByGuidUseCase` variants (or a `lookup_mode` parameter on the existing ones) that resolve via a guid lookup instead of `book.CustomerLookupByID`. The resolver normalises via `_normalise_guid` so `string_to_guid` validates the format up-front. |
+| `services/gnucash_importer.py` | Re-export `_normalise_guid`, `_find_customer_by_guid`, `_find_vendor_by_guid` to the use case layer (they're currently module-private to `gnucash_importer`). Or move them to a shared helper module. |
+| `tests/integration/test_delete_business_objects.py` | New tests for `--by-guid`: happy path, unknown-guid not-found, malformed guid format error. |
+| `README.md` | Document the new flag for delete-customers, archive-customers, archive-vendors. |
+
+## Open questions
+
+1. Should we also add `--by-guid` to a hypothetical future `delete-vendors`
+   command? Not in scope here — `delete-vendors` is intentionally not
+   implemented (vendor `Destroy()` is broken in the GnuCash XML backend
+   per F-011 findings). If/when that's ever revisited, follow this
+   pattern.
+2. The existing `find-transactions` command takes a `--account` and
+   filters; it doesn't take a transaction id at all, so no symmetry
+   change needed there.
+
+---
+
+**Created**: 2026-05-07

--- a/docs/issues/Q-007-delete-archive-by-guid.md
+++ b/docs/issues/Q-007-delete-archive-by-guid.md
@@ -1,6 +1,6 @@
 ---
 id: Q-007
-title: delete-customers / archive-customers / archive-vendors must accept GUID, not just user-facing id
+title: delete/archive accept GUIDs; invoice/bill identity enforced on import
 category: quality
 severity: medium
 status: open
@@ -90,6 +90,42 @@ deadbeefdeadbeefdeadbeefdeadbeef: not found
 | `services/gnucash_importer.py` | Re-export `_normalise_guid`, `_find_customer_by_guid`, `_find_vendor_by_guid` to the use case layer (they're currently module-private to `gnucash_importer`). Or move them to a shared helper module. |
 | `tests/integration/test_delete_business_objects.py` | New tests for `--by-guid`: happy path, unknown-guid not-found, malformed guid format error. |
 | `README.md` | Document the new flag for delete-customers, archive-customers, archive-vendors. |
+
+## Scope extension: invoice/bill identity enforcement on import
+
+Originally Q-007 was just about the CLI delete/archive flag. Two
+related importer issues surfaced during review and were rolled in:
+
+### Bills were silently duplicating on re-import
+
+`book.InvoiceLookupByID(bill_id)` returns `None` for vendor bills (it
+only finds customer invoices). The pre-Q-007 idempotency check in
+`import_bill` was therefore a no-op — re-importing the same bill
+fixture would create a fresh duplicate every time, accumulating bills
+with the same id and different GUIDs.
+
+Fixed by replacing `book.InvoiceLookupByID(bill_id)` with a Query that
+filters `gncInvoice` to owner-type 4 (vendor). New helpers
+`_find_bills_by_id` and `_find_bill_by_guid` live alongside
+`_find_invoices_by_id` and `_find_invoice_by_guid` in
+`services/gnucash_importer.py`.
+
+### Invoices/bills lacked Q-006-style id ⇔ guid enforcement
+
+Customers and vendors got the §2 resolution table in Q-006: directive
+guid ⇔ existing id must agree, multiple-match in book is an error.
+Invoices and bills had a simpler (and weaker) "skip on id match,
+ignore guid entirely" model.
+
+Now invoices and bills go through the same `_resolve_existing_or_none`
+helper, with one twist: on a hit they SKIP rather than UPDATE because
+posted invoices have AR/AP lots wired into a real transaction and
+mutating their fields would corrupt accounting state. Detection of
+inconsistency is orthogonal to update-vs-skip and applies equally.
+
+The resolver gained an optional `get_guid_str` callback because SWIG
+`Invoice.GetGUID()` is missing on some platforms — invoices/bills pass
+a ctypes-based reader (`_swig_invoice_guid_str`).
 
 ## Open questions
 

--- a/infrastructure/gnucash/guid_lookup.py
+++ b/infrastructure/gnucash/guid_lookup.py
@@ -1,0 +1,74 @@
+"""
+Shared helpers for resolving customers/vendors by GUID.
+
+Used by both the importer (`services/gnucash_importer.py`) and the
+delete/archive use cases (`use_cases/delete_business_objects.py`) — kept
+here so neither has to depend on the other's internals.
+"""
+
+from typing import Optional
+
+import gnucash.gnucash_business as gb
+from gnucash import Book, Query
+from gnucash.gnucash_core_c import GncGUID, string_to_guid
+
+
+def normalise_guid(guid) -> str:
+    """Validate and canonicalise a user-supplied GUID string.
+
+    Accepts:
+      - 32-char lowercase hex
+      - UUID-with-hyphens (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`)
+      - mixed-case hex (lowercased on the way out)
+
+    Rejects:
+      - int/float/bool — these come from unquoted all-digit guid values in
+        plaintext where the parser auto-converts to int and silently loses
+        the digit count. Force the caller to quote.
+      - any string that `string_to_guid` cannot parse.
+    """
+    if isinstance(guid, (int, float, bool)):
+        raise ValueError(
+            f"guid must be a quoted string (got {type(guid).__name__} {guid!r}); "
+            f"unquoted all-digit values are auto-converted to a number and "
+            f"lose their digit count. Quote the guid: e.g. \"{guid:032x}\""
+            if isinstance(guid, int) and 0 <= guid < 2**128
+            else f"guid must be a quoted string (got {type(guid).__name__} {guid!r})"
+        )
+    if not string_to_guid(guid, GncGUID()):
+        raise ValueError(f"Invalid GUID format: {guid!r}")
+    return guid.replace('-', '').lower()
+
+
+def find_customer_by_guid(book: Book, guid_norm: str) -> Optional[gb.Customer]:
+    """Return the Customer whose GUID matches `guid_norm`, or None.
+
+    `guid_norm` must already be normalised (32-char lowercase hex) — call
+    `normalise_guid()` first if dealing with raw user input.
+    """
+    q = Query()
+    q.search_for('gncCustomer')
+    q.set_book(book)
+    found = None
+    for r in q.run():
+        c = gb.Customer(instance=r)
+        if c.GetGUID().to_string() == guid_norm:
+            found = c
+            break
+    q.destroy()
+    return found
+
+
+def find_vendor_by_guid(book: Book, guid_norm: str) -> Optional[gb.Vendor]:
+    """Return the Vendor whose GUID matches `guid_norm`, or None."""
+    q = Query()
+    q.search_for('gncVendor')
+    q.set_book(book)
+    found = None
+    for r in q.run():
+        v = gb.Vendor(instance=r)
+        if v.GetGUID().to_string() == guid_norm:
+            found = v
+            break
+    q.destroy()
+    return found

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -165,14 +165,151 @@ def _find_vendor_by_guid(book, guid_norm: str):
     return found
 
 
+# GnuCash's owner-type constants for gncInvoice. Customer invoices and
+# vendor bills both live in the gncInvoice collection, distinguished by
+# the owner type — 2 = Customer, 4 = Vendor.
+_GNC_OWNER_CUSTOMER = 2
+_GNC_OWNER_VENDOR = 4
+
+
+def _find_invoices_by_id(book, id_: str):
+    """All customer invoices with the given id.
+
+    `book.InvoiceLookupByID` is unsuitable: it returns at most one record
+    and (per Q-007 testing) does not return vendor bills at all. We use
+    Query so we can detect legacy duplicates and so the bill side has the
+    same lookup shape.
+    """
+    from gnucash import Query
+    from gnucash.gnucash_business import Invoice
+    q = Query()
+    q.search_for('gncInvoice')
+    q.set_book(book)
+    out = []
+    for r in q.run():
+        inv = Invoice(instance=r)
+        if inv.GetOwnerType() == _GNC_OWNER_CUSTOMER and inv.GetID() == id_:
+            out.append(inv)
+    q.destroy()
+    return out
+
+
+def _find_bills_by_id(book, id_: str):
+    """All vendor bills with the given id."""
+    from gnucash import Query
+    from gnucash.gnucash_business import Invoice
+    q = Query()
+    q.search_for('gncInvoice')
+    q.set_book(book)
+    out = []
+    for r in q.run():
+        inv = Invoice(instance=r)
+        if inv.GetOwnerType() == _GNC_OWNER_VENDOR and inv.GetID() == id_:
+            out.append(inv)
+    q.destroy()
+    return out
+
+
+def _find_invoice_by_guid(book, guid_norm: str):
+    """Customer invoice with the given GUID, or None.
+
+    SWIG `Invoice.GetGUID()` is missing on some platforms; use ctypes via
+    qof_instance_get_guid + guid_to_string_buff (same pattern as the
+    exporter's _guid_for_ptr_factory).
+    """
+    import ctypes
+
+    from gnucash import Query
+    from gnucash.gnucash_business import Invoice
+    lib = ctypes.CDLL(None)
+    lib.qof_instance_get_guid.argtypes = [ctypes.c_void_p]
+    lib.qof_instance_get_guid.restype = ctypes.c_void_p
+    lib.guid_to_string_buff.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    lib.guid_to_string_buff.restype = ctypes.c_char_p
+    buf = ctypes.create_string_buffer(40)
+
+    q = Query()
+    q.search_for('gncInvoice')
+    q.set_book(book)
+    found = None
+    for r in q.run():
+        inv = Invoice(instance=r)
+        if inv.GetOwnerType() != _GNC_OWNER_CUSTOMER:
+            continue
+        guid_ptr = lib.qof_instance_get_guid(int(inv.instance))
+        if not guid_ptr:
+            continue
+        lib.guid_to_string_buff(guid_ptr, buf)
+        if buf.value.decode('ascii') == guid_norm:
+            found = inv
+            break
+    q.destroy()
+    return found
+
+
+def _find_bill_by_guid(book, guid_norm: str):
+    """Vendor bill with the given GUID, or None."""
+    import ctypes
+
+    from gnucash import Query
+    from gnucash.gnucash_business import Invoice
+    lib = ctypes.CDLL(None)
+    lib.qof_instance_get_guid.argtypes = [ctypes.c_void_p]
+    lib.qof_instance_get_guid.restype = ctypes.c_void_p
+    lib.guid_to_string_buff.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    lib.guid_to_string_buff.restype = ctypes.c_char_p
+    buf = ctypes.create_string_buffer(40)
+
+    q = Query()
+    q.search_for('gncInvoice')
+    q.set_book(book)
+    found = None
+    for r in q.run():
+        inv = Invoice(instance=r)
+        if inv.GetOwnerType() != _GNC_OWNER_VENDOR:
+            continue
+        guid_ptr = lib.qof_instance_get_guid(int(inv.instance))
+        if not guid_ptr:
+            continue
+        lib.guid_to_string_buff(guid_ptr, buf)
+        if buf.value.decode('ascii') == guid_norm:
+            found = inv
+            break
+    q.destroy()
+    return found
+
+
+def _swig_invoice_guid_str(invoice) -> str:
+    """Read an Invoice's GUID via ctypes (qof_instance_get_guid + guid_to_string_buff).
+    SWIG `Invoice.GetGUID()` is missing on some platforms; this works everywhere
+    the invoice has been committed to the book."""
+    import ctypes
+    lib = ctypes.CDLL(None)
+    lib.qof_instance_get_guid.argtypes = [ctypes.c_void_p]
+    lib.qof_instance_get_guid.restype = ctypes.c_void_p
+    lib.guid_to_string_buff.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    lib.guid_to_string_buff.restype = ctypes.c_char_p
+    buf = ctypes.create_string_buffer(40)
+    guid_ptr = lib.qof_instance_get_guid(int(invoice.instance))
+    if not guid_ptr:
+        return ''
+    lib.guid_to_string_buff(guid_ptr, buf)
+    return buf.value.decode('ascii')
+
+
 def _resolve_existing_or_none(kind: str, id_: str, guid_str: Optional[str],
-                              find_by_id, find_by_guid):
+                              find_by_id, find_by_guid,
+                              get_guid_str=lambda r: r.GetGUID().to_string()):
     """Apply Q-006 §2 resolution rules. Returns (existing, must_set_guid_str).
 
-    `kind` is 'customer'/'vendor' for error messages.
+    `kind` is 'customer'/'vendor'/'invoice'/'bill' for error messages.
     `existing` is the matched record or None (caller creates new).
     `must_set_guid_str` is the normalised guid to assign to a freshly-created
     record (for round-trip into a fresh book), or None.
+    `get_guid_str(record) -> str` reads the guid from a matched record for
+    error reporting. Defaults to SWIG `record.GetGUID().to_string()`, which
+    works for Customer/Vendor; pass a ctypes-based callback for Invoice/Bill
+    where SWIG's `GetGUID` is missing on some platforms.
 
     Raises ValueError on any contradiction the user must resolve manually.
     """
@@ -197,7 +334,7 @@ def _resolve_existing_or_none(kind: str, id_: str, guid_str: Optional[str],
         raise ValueError(
             f'{kind} "{id_}": directive guid {guid_str!r} does not exist in '
             f'the book, but a {kind} with this id already exists '
-            f'(guid {existing.GetGUID().to_string()}). Refusing to rebuild — '
+            f'(guid {get_guid_str(existing)}). Refusing to rebuild — '
             f'either remove the guid: line to update the existing record, or '
             f'change the id to create a new {kind}.'
         )
@@ -916,10 +1053,17 @@ class GnuCashImporter:
 
         inv_id = directive.props['id']
 
-        # Idempotency: skip if this invoice already exists in the book.
-        # Re-importing the same file would otherwise create a duplicate invoice
-        # and a duplicate payment transaction for each payment: block.
-        if book.InvoiceLookupByID(inv_id) is not None:
+        # Resolve identity (Q-007): apply id ⇔ guid agreement rules and
+        # detect pre-existing duplicates. On a hit we SKIP rather than
+        # update — invoices have AR lots wired into a real transaction and
+        # mutating their fields after posting would corrupt accounting state.
+        existing, must_set_guid = _resolve_existing_or_none(
+            'invoice', inv_id, directive.metadata.get('guid'),
+            lambda i: _find_invoices_by_id(book, i),
+            lambda g: _find_invoice_by_guid(book, g),
+            get_guid_str=_swig_invoice_guid_str,
+        )
+        if existing is not None:
             logging.debug(f"Invoice {inv_id} already exists, skipping")
             return
 
@@ -948,9 +1092,8 @@ class GnuCashImporter:
             lambda g: _find_customer_by_guid(book, g),
         )
         invoice = Invoice(book, inv_id, book.get_table().lookup("CURRENCY", directive.metadata['currency']), customer)
-        if 'guid' in directive.metadata:
-            _set_object_guid(book, invoice, 'invoice', inv_id,
-                             _normalise_guid(directive.metadata['guid']))
+        if must_set_guid is not None:
+            _set_object_guid(book, invoice, 'invoice', inv_id, must_set_guid)
         invoice.BeginEdit()
         invoice.SetDateOpened(datetime.strptime(directive.metadata['date_opened'], "%Y-%m-%d"))
 
@@ -1053,8 +1196,20 @@ class GnuCashImporter:
 
         bill_id = directive.props['id']
 
-        # Idempotency: skip if this bill already exists in the book.
-        if book.InvoiceLookupByID(bill_id) is not None:
+        # Resolve identity (Q-007): apply id ⇔ guid agreement rules and
+        # detect pre-existing duplicates. On a hit we SKIP rather than
+        # update — bills have AP lots wired into a real transaction.
+        # `book.InvoiceLookupByID` is unsuitable here: it returns None for
+        # vendor bills (only customer invoices), so the pre-Q-007 skip
+        # logic was silently broken — re-importing the same bill file
+        # would create a duplicate every time.
+        existing, must_set_guid = _resolve_existing_or_none(
+            'bill', bill_id, directive.metadata.get('guid'),
+            lambda i: _find_bills_by_id(book, i),
+            lambda g: _find_bill_by_guid(book, g),
+            get_guid_str=_swig_invoice_guid_str,
+        )
+        if existing is not None:
             logging.debug(f"Bill {bill_id} already exists, skipping")
             return
 
@@ -1084,9 +1239,8 @@ class GnuCashImporter:
             lambda g: _find_vendor_by_guid(book, g),
         )
         bill = Invoice(book, bill_id, book.get_table().lookup("CURRENCY", directive.metadata['currency']), vendor)
-        if 'guid' in directive.metadata:
-            _set_object_guid(book, bill, 'bill', bill_id,
-                             _normalise_guid(directive.metadata['guid']))
+        if must_set_guid is not None:
+            _set_object_guid(book, bill, 'bill', bill_id, must_set_guid)
         bill.BeginEdit()
         bill.SetDateOpened(datetime.strptime(directive.metadata['date_opened'], "%Y-%m-%d"))
 

--- a/tests/integration/test_business_object_idempotent_reimport.py
+++ b/tests/integration/test_business_object_idempotent_reimport.py
@@ -805,3 +805,183 @@ class TestPreexistingDuplicates:
                 f"Two same-id directives in one file must not produce two records.\n"
                 f"Export:\n{text}"
             )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Invoice / bill identity enforcement (Q-007 follow-up)
+#
+# Q-006 added id ⇔ guid conflict detection for customers and vendors.
+# Invoices and bills had a weaker idempotency model (skip on id match, no
+# guid check). These tests describe the desired behaviour after extending
+# the conflict detection to invoices/bills:
+#
+#   - skip-on-existing stays the same (invoices have AR/AP lots, can't
+#     update mutable fields safely mid-flight)
+#   - but BEFORE skipping, verify identity is consistent: directive's
+#     `guid:` must match the existing invoice's GUID, else error
+#   - if directive's guid resolves to a DIFFERENT invoice's id, error
+#   - same rules apply to bills
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_INVOICE_BASE = """
+customer "C001"
+\tname: "Acme"
+\tcurrency: CAD
+
+invoice "INV-001"
+\tcustomer_id: "C001"
+\tcurrency: CAD
+\tdate_opened: 2026-01-01
+\tentry:
+\t\tdate: 2026-01-01
+\t\tdescription: "Service"
+\t\taction: "Hours"
+\t\taccount: "Income:Sales"
+\t\tquantity: 1
+\t\tprice: 100
+\t\ttaxable: false
+\t\ttax_included: false
+\tposted: none
+\tpayment: none
+"""
+
+
+_BILL_BASE = """
+vendor "V001"
+\tname: "Supplier"
+\tcurrency: CAD
+
+bill "BILL-001"
+\tvendor_id: "V001"
+\tcurrency: CAD
+\tdate_opened: 2026-01-01
+\tentry:
+\t\tdate: 2026-01-01
+\t\tdescription: "Supplies"
+\t\taccount: "Expenses:Supplies"
+\t\tquantity: 1
+\t\tprice: 50
+\t\ttaxable: true
+\t\ttax_included: false
+\tposted: none
+\tpayment: none
+"""
+
+
+class TestInvoiceBillIdentityEnforcement:
+    """Invoice/bill identity must be consistent on re-import."""
+
+    def test_reimport_same_invoice_is_idempotent(self, tmp_path):
+        """Existing baseline: re-importing identical invoice file is a no-op."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _INVOICE_BASE)
+        r = _import(runner, gnc, _write(tmp_path / "again.txt",
+                                        ACCOUNTS + "\n" + _INVOICE_BASE))
+        assert r.exit_code == 0, f"Re-import should be idempotent:\n{r.output}"
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        assert _count_blocks(text, 'invoice "INV-001"') == 1
+
+    def test_reimport_invoice_with_matching_guid_is_idempotent(self, tmp_path):
+        """Directive carries `guid:` matching the existing invoice → skip cleanly."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _INVOICE_BASE)
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        guid = _field_in_block(_block_for(text, 'invoice "INV-001"'),
+                               'guid', strip_quotes=True)
+        assert guid
+
+        with_guid = _INVOICE_BASE.replace(
+            'invoice "INV-001"\n',
+            f'invoice "INV-001"\n\tguid: "{guid}"\n',
+        )
+        r = _import(runner, gnc, _write(tmp_path / "again.txt",
+                                        ACCOUNTS + "\n" + with_guid))
+        assert r.exit_code == 0, f"Re-import with matching guid must succeed:\n{r.output}"
+        text2 = _exported_biz_text(runner, tmp_path, gnc)
+        assert _count_blocks(text2, 'invoice "INV-001"') == 1
+
+    def test_reimport_invoice_with_mismatched_guid_errors(self, tmp_path):
+        """Directive's `guid:` doesn't match the existing INV-001's guid → error.
+
+        Refuses to silently skip when the directive is claiming a different
+        identity for an existing id.
+        """
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _INVOICE_BASE)
+
+        bad = _INVOICE_BASE.replace(
+            'invoice "INV-001"\n',
+            'invoice "INV-001"\n\tguid: "deadbeefdeadbeefdeadbeefdeadbeef"\n',
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt",
+                                        ACCOUNTS + "\n" + bad))
+        assert r.exit_code != 0, (
+            f"Mismatched guid on existing invoice id must error:\n{r.output}"
+        )
+
+    def test_reimport_invoice_guid_resolves_to_different_id_errors(self, tmp_path):
+        """Directive says `INV-002` + guid of INV-001 → error.
+
+        We must not let the user file a new invoice claiming an existing
+        invoice's GUID.
+        """
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _INVOICE_BASE)
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        inv1_guid = _field_in_block(_block_for(text, 'invoice "INV-001"'),
+                                    'guid', strip_quotes=True)
+        assert inv1_guid
+
+        # Replace only the header line (first occurrence) and add a guid line.
+        bad = _INVOICE_BASE.replace(
+            'invoice "INV-001"',
+            f'invoice "INV-002"\n\tguid: "{inv1_guid}"',
+            1,
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt",
+                                        ACCOUNTS + "\n" + bad))
+        assert r.exit_code != 0, (
+            f"Reusing INV-001's guid for new INV-002 must error:\n{r.output}"
+        )
+
+    # ─── Same suite for bills ───────────────────────────────────────────────
+
+    def test_reimport_same_bill_is_idempotent(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _BILL_BASE)
+        r = _import(runner, gnc, _write(tmp_path / "again.txt",
+                                        ACCOUNTS + "\n" + _BILL_BASE))
+        assert r.exit_code == 0, f"Re-import should be idempotent:\n{r.output}"
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        assert _count_blocks(text, 'bill "BILL-001"') == 1
+
+    def test_reimport_bill_with_matching_guid_is_idempotent(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _BILL_BASE)
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        guid = _field_in_block(_block_for(text, 'bill "BILL-001"'),
+                               'guid', strip_quotes=True)
+        assert guid
+
+        with_guid = _BILL_BASE.replace(
+            'bill "BILL-001"\n',
+            f'bill "BILL-001"\n\tguid: "{guid}"\n',
+        )
+        r = _import(runner, gnc, _write(tmp_path / "again.txt",
+                                        ACCOUNTS + "\n" + with_guid))
+        assert r.exit_code == 0, f"Re-import with matching guid must succeed:\n{r.output}"
+
+    def test_reimport_bill_with_mismatched_guid_errors(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _BILL_BASE)
+
+        bad = _BILL_BASE.replace(
+            'bill "BILL-001"\n',
+            'bill "BILL-001"\n\tguid: "deadbeefdeadbeefdeadbeefdeadbeef"\n',
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt",
+                                        ACCOUNTS + "\n" + bad))
+        assert r.exit_code != 0, (
+            f"Mismatched guid on existing bill id must error:\n{r.output}"
+        )

--- a/tests/integration/test_delete_business_objects.py
+++ b/tests/integration/test_delete_business_objects.py
@@ -341,3 +341,177 @@ def test_archive_vendors_batch_mixed(tmp_path):
     assert result.exit_code == 1
     assert "V001: archived" in result.output
     assert "V002: already archived" in result.output
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E. --by-guid flag (Q-007)
+#
+# delete-customers / archive-customers / archive-vendors must accept GUIDs as
+# well as user-facing ids. The flag is opt-in (default behaviour stays
+# id-based) because nothing prevents a customer's id from happening to be a
+# 32-char hex string — auto-detection would silently misroute.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _customer_guid_for_id(gnc_path, cust_id):
+    """Read a customer's GUID from the saved gnucash file via the bindings."""
+    from gnucash import Session
+    s = Session(f"xml://{gnc_path}")
+    try:
+        cust = s.book.CustomerLookupByID(cust_id)
+        assert cust is not None, f"Setup fixture missing customer {cust_id!r}"
+        return cust.GetGUID().to_string()
+    finally:
+        s.end()
+
+
+def _vendor_guid_for_id(gnc_path, vend_id):
+    from gnucash import Session
+    s = Session(f"xml://{gnc_path}")
+    try:
+        v = s.book.VendorLookupByID(vend_id)
+        assert v is not None, f"Setup fixture missing vendor {vend_id!r}"
+        return v.GetGUID().to_string()
+    finally:
+        s.end()
+
+
+def test_delete_customer_by_guid_no_invoices(tmp_path):
+    """delete-customers --by-guid <guid> deletes the matching customer."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+    guid = _customer_guid_for_id(gf, "2")
+
+    result = runner.invoke(cli, ["delete-customers", str(gf), "--by-guid", guid])
+    assert result.exit_code == 0, result.output
+    # Output keeps the user-facing id for readability
+    assert "2: deleted" in result.output
+    exported = export_biz(runner, gf)
+    assert 'customer "2"' not in exported
+
+
+def test_delete_customer_by_guid_with_invoices_blocked(tmp_path):
+    """--by-guid still blocks when invoices are linked, exit 1."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+    guid = _customer_guid_for_id(gf, "1")  # Customer "1" has invoices in fixture
+
+    result = runner.invoke(cli, ["delete-customers", str(gf), "--by-guid", guid])
+    assert result.exit_code == 1
+    assert "1: failed" in result.output
+    assert "cannot delete" in result.output
+
+
+def test_delete_customer_by_guid_not_found(tmp_path):
+    """--by-guid with a valid-format guid that doesn't match → not found, exit 1."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    bogus = "deadbeefdeadbeefdeadbeefdeadbeef"
+    result = runner.invoke(cli, ["delete-customers", str(gf), "--by-guid", bogus])
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower()
+
+
+def test_delete_customer_by_guid_invalid_format(tmp_path):
+    """--by-guid with a malformed guid surfaces an Invalid GUID error, exit 1."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    result = runner.invoke(cli, ["delete-customers", str(gf), "--by-guid", "hello"])
+    assert result.exit_code != 0
+    assert "invalid guid" in result.output.lower()
+
+
+def test_delete_customers_by_guid_batch(tmp_path):
+    """Batch of two GUIDs: one with invoices (blocked), one without (deleted)."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+    g1 = _customer_guid_for_id(gf, "1")
+    g2 = _customer_guid_for_id(gf, "2")
+
+    result = runner.invoke(cli, ["delete-customers", str(gf), "--by-guid", g1, g2])
+    assert result.exit_code == 1  # 1 failed, 2 ok → overall failure
+    assert "1: failed" in result.output
+    assert "2: deleted" in result.output
+
+
+def test_archive_customer_by_guid_active(tmp_path):
+    """archive-customers --by-guid soft-hides an active customer."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+    guid = _customer_guid_for_id(gf, "1")
+
+    result = runner.invoke(cli, ["archive-customers", str(gf), "--by-guid", guid])
+    assert result.exit_code == 0, result.output
+    assert "1: archived" in result.output
+    exported = export_biz(runner, gf)
+    # Customer "1" still present, just inactive
+    assert 'customer "1"' in exported
+    assert "active: false" in exported
+
+
+def test_archive_customer_by_guid_not_found(tmp_path):
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    result = runner.invoke(cli, ["archive-customers", str(gf),
+                                 "--by-guid", "deadbeefdeadbeefdeadbeefdeadbeef"])
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower()
+
+
+def test_archive_vendor_by_guid_active(tmp_path):
+    """archive-vendors --by-guid soft-hides an active vendor."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+    guid = _vendor_guid_for_id(gf, "V001")
+
+    result = runner.invoke(cli, ["archive-vendors", str(gf), "--by-guid", guid])
+    assert result.exit_code == 0, result.output
+    assert "V001: archived" in result.output
+
+
+def test_archive_vendor_by_guid_already_archived(tmp_path):
+    """V002 is inactive in the fixture — by-guid path must report that too."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+    guid = _vendor_guid_for_id(gf, "V002")
+
+    result = runner.invoke(cli, ["archive-vendors", str(gf), "--by-guid", guid])
+    assert result.exit_code == 1
+    assert "V002: already archived" in result.output
+
+
+def test_archive_vendor_by_guid_not_found(tmp_path):
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+
+    result = runner.invoke(cli, ["archive-vendors", str(gf),
+                                 "--by-guid", "deadbeefdeadbeefdeadbeefdeadbeef"])
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower()
+
+
+def test_by_guid_accepts_uuid_with_hyphens(tmp_path):
+    """UUID-with-hyphens form is normalised the same way --txn_guid is."""
+    runner = CliRunner()
+    gf = tmp_path / "test.gnucash"
+    import_fixture(runner, gf)
+    guid = _customer_guid_for_id(gf, "2")
+    uuid_form = f"{guid[0:8]}-{guid[8:12]}-{guid[12:16]}-{guid[16:20]}-{guid[20:32]}"
+
+    result = runner.invoke(cli, ["delete-customers", str(gf),
+                                 "--by-guid", uuid_form])
+    assert result.exit_code == 0, result.output
+    assert "2: deleted" in result.output

--- a/tests/integration/test_delete_business_objects.py
+++ b/tests/integration/test_delete_business_objects.py
@@ -16,12 +16,37 @@ Covers:
   - archive: mixed batch
 """
 
+import re
+
 import pytest
 from click.testing import CliRunner
 
 from cli.main import cli
 
 FIXTURE = "tests/fixtures/business_objects.txt"
+
+
+def _has_status_line(output, id_, status_substring):
+    """Match a '<id> (<32-hex-guid>): <status...>' line in `output`.
+
+    The CLI always prints the matched record's GUID alongside the id, so
+    a successful hit looks like `2 (9f14a4…): deleted`. Use this helper
+    instead of plain substring checks so tests are explicit about the
+    format and don't accidentally match on substrings that would survive
+    a regression to id-only output.
+    """
+    pat = rf'(?m)^{re.escape(id_)} \([0-9a-f]{{32}}\): {re.escape(status_substring)}'
+    assert re.search(pat, output), (
+        f"Expected line matching {pat!r}\nGot:\n{output}"
+    )
+
+
+def _has_not_found_line(output, input_str):
+    """Match the miss line: '<input>: not found' (no guid since lookup failed)."""
+    pat = rf'(?m)^{re.escape(input_str)}: not found\s*$'
+    assert re.search(pat, output), (
+        f"Expected line matching {pat!r}\nGot:\n{output}"
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -129,7 +154,7 @@ def test_delete_customer_no_invoices(tmp_path):
 
     result = runner.invoke(cli, ["delete-customers", str(gf), "2"])
     assert result.exit_code == 0, result.output
-    assert "2: deleted" in result.output
+    _has_status_line(result.output, "2", "deleted")
 
     # Customer "2" must be gone from subsequent export
     exported = export_biz(runner, gf)
@@ -145,7 +170,7 @@ def test_delete_customer_with_invoices_blocked(tmp_path):
     # Customer "1" has invoices in the fixture
     result = runner.invoke(cli, ["delete-customers", str(gf), "1"])
     assert result.exit_code == 1
-    assert "1: failed" in result.output
+    _has_status_line(result.output, "1", "failed")
     assert "cannot delete" in result.output
     assert "invoice" in result.output
 
@@ -162,7 +187,7 @@ def test_delete_customer_not_found(tmp_path):
 
     result = runner.invoke(cli, ["delete-customers", str(gf), "DOES-NOT-EXIST"])
     assert result.exit_code == 1
-    assert "DOES-NOT-EXIST: not found" in result.output
+    _has_not_found_line(result.output, "DOES-NOT-EXIST")
 
 
 def test_delete_customers_batch_mixed(tmp_path):
@@ -173,8 +198,8 @@ def test_delete_customers_batch_mixed(tmp_path):
 
     result = runner.invoke(cli, ["delete-customers", str(gf), "2", "1"])
     assert result.exit_code == 1
-    assert "2: deleted" in result.output
-    assert "1: failed" in result.output
+    _has_status_line(result.output, "2", "deleted")
+    _has_status_line(result.output, "1", "failed")
 
     exported = export_biz(runner, gf)
     assert 'customer "2"' not in exported   # successfully deleted
@@ -190,7 +215,7 @@ def test_delete_customer_inactive_no_invoices(tmp_path):
     # "2" is inactive and has no invoices
     result = runner.invoke(cli, ["delete-customers", str(gf), "2"])
     assert result.exit_code == 0
-    assert "2: deleted" in result.output
+    _has_status_line(result.output, "2", "deleted")
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -212,7 +237,7 @@ def test_archive_customer_active_no_invoices(tmp_path):
 
     result = runner.invoke(cli, ["archive-customers", str(gf), "1"])
     assert result.exit_code == 0, result.output
-    assert "1: archived" in result.output
+    _has_status_line(result.output, "1", "archived")
     # "1" has invoices — should show count
     assert "invoice" in result.output
 
@@ -240,7 +265,7 @@ def test_archive_customer_already_archived(tmp_path):
     # "2" is imported as inactive
     result = runner.invoke(cli, ["archive-customers", str(gf), "2"])
     assert result.exit_code == 1
-    assert "2: already archived" in result.output
+    _has_status_line(result.output, "2", "already archived")
 
 
 def test_archive_customer_not_found(tmp_path):
@@ -251,7 +276,7 @@ def test_archive_customer_not_found(tmp_path):
 
     result = runner.invoke(cli, ["archive-customers", str(gf), "DOES-NOT-EXIST"])
     assert result.exit_code == 1
-    assert "DOES-NOT-EXIST: not found" in result.output
+    _has_not_found_line(result.output, "DOES-NOT-EXIST")
 
 
 def test_archive_customers_batch_mixed(tmp_path):
@@ -262,8 +287,8 @@ def test_archive_customers_batch_mixed(tmp_path):
 
     result = runner.invoke(cli, ["archive-customers", str(gf), "1", "2"])
     assert result.exit_code == 1
-    assert "1: archived" in result.output
-    assert "2: already archived" in result.output
+    _has_status_line(result.output, "1", "archived")
+    _has_status_line(result.output, "2", "already archived")
 
 
 def test_archive_customer_invoice_count_in_output(tmp_path):
@@ -275,8 +300,7 @@ def test_archive_customer_invoice_count_in_output(tmp_path):
     result = runner.invoke(cli, ["archive-customers", str(gf), "1"])
     assert result.exit_code == 0
     # Must show count of linked invoices, not just "archived"
-    import re
-    assert re.search(r'1: archived — \d+ invoice', result.output), \
+    assert re.search(r'1 \([0-9a-f]{32}\): archived — \d+ invoice', result.output), \
         f"Expected invoice count in output, got: {result.output!r}"
 
 
@@ -292,7 +316,7 @@ def test_archive_vendor_with_bills(tmp_path):
 
     result = runner.invoke(cli, ["archive-vendors", str(gf), "V001"])
     assert result.exit_code == 0, result.output
-    assert "V001: archived" in result.output
+    _has_status_line(result.output, "V001", "archived")
     assert "invoice" in result.output
 
     exported = export_biz(runner, gf)
@@ -317,7 +341,7 @@ def test_archive_vendor_already_archived(tmp_path):
 
     result = runner.invoke(cli, ["archive-vendors", str(gf), "V002"])
     assert result.exit_code == 1
-    assert "V002: already archived" in result.output
+    _has_status_line(result.output, "V002", "already archived")
 
 
 def test_archive_vendor_not_found(tmp_path):
@@ -328,7 +352,7 @@ def test_archive_vendor_not_found(tmp_path):
 
     result = runner.invoke(cli, ["archive-vendors", str(gf), "DOES-NOT-EXIST"])
     assert result.exit_code == 1
-    assert "DOES-NOT-EXIST: not found" in result.output
+    _has_not_found_line(result.output, "DOES-NOT-EXIST")
 
 
 def test_archive_vendors_batch_mixed(tmp_path):
@@ -339,8 +363,8 @@ def test_archive_vendors_batch_mixed(tmp_path):
 
     result = runner.invoke(cli, ["archive-vendors", str(gf), "V001", "V002"])
     assert result.exit_code == 1
-    assert "V001: archived" in result.output
-    assert "V002: already archived" in result.output
+    _has_status_line(result.output, "V001", "archived")
+    _has_status_line(result.output, "V002", "already archived")
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -377,7 +401,11 @@ def _vendor_guid_for_id(gnc_path, vend_id):
 
 
 def test_delete_customer_by_guid_no_invoices(tmp_path):
-    """delete-customers --by-guid <guid> deletes the matching customer."""
+    """delete-customers --by-guid <guid> deletes the matching customer.
+
+    Output uses the same `<id> (<guid>)` format whether you address by id
+    or by guid, so the user always sees both identifiers.
+    """
     runner = CliRunner()
     gf = tmp_path / "test.gnucash"
     import_fixture(runner, gf)
@@ -385,8 +413,7 @@ def test_delete_customer_by_guid_no_invoices(tmp_path):
 
     result = runner.invoke(cli, ["delete-customers", str(gf), "--by-guid", guid])
     assert result.exit_code == 0, result.output
-    # Output keeps the user-facing id for readability
-    assert "2: deleted" in result.output
+    assert f"2 ({guid}): deleted" in result.output
     exported = export_biz(runner, gf)
     assert 'customer "2"' not in exported
 
@@ -400,12 +427,16 @@ def test_delete_customer_by_guid_with_invoices_blocked(tmp_path):
 
     result = runner.invoke(cli, ["delete-customers", str(gf), "--by-guid", guid])
     assert result.exit_code == 1
-    assert "1: failed" in result.output
+    assert f"1 ({guid}): failed" in result.output
     assert "cannot delete" in result.output
 
 
 def test_delete_customer_by_guid_not_found(tmp_path):
-    """--by-guid with a valid-format guid that doesn't match → not found, exit 1."""
+    """--by-guid with a valid-format guid that doesn't match → not found, exit 1.
+
+    On a miss there's no record, so no resolved id — the line falls back to
+    just the user-typed guid.
+    """
     runner = CliRunner()
     gf = tmp_path / "test.gnucash"
     import_fixture(runner, gf)
@@ -413,7 +444,7 @@ def test_delete_customer_by_guid_not_found(tmp_path):
     bogus = "deadbeefdeadbeefdeadbeefdeadbeef"
     result = runner.invoke(cli, ["delete-customers", str(gf), "--by-guid", bogus])
     assert result.exit_code == 1
-    assert "not found" in result.output.lower()
+    _has_not_found_line(result.output, bogus)
 
 
 def test_delete_customer_by_guid_invalid_format(tmp_path):
@@ -437,8 +468,8 @@ def test_delete_customers_by_guid_batch(tmp_path):
 
     result = runner.invoke(cli, ["delete-customers", str(gf), "--by-guid", g1, g2])
     assert result.exit_code == 1  # 1 failed, 2 ok → overall failure
-    assert "1: failed" in result.output
-    assert "2: deleted" in result.output
+    assert f"1 ({g1}): failed" in result.output
+    assert f"2 ({g2}): deleted" in result.output
 
 
 def test_archive_customer_by_guid_active(tmp_path):
@@ -450,7 +481,7 @@ def test_archive_customer_by_guid_active(tmp_path):
 
     result = runner.invoke(cli, ["archive-customers", str(gf), "--by-guid", guid])
     assert result.exit_code == 0, result.output
-    assert "1: archived" in result.output
+    assert f"1 ({guid}): archived" in result.output
     exported = export_biz(runner, gf)
     # Customer "1" still present, just inactive
     assert 'customer "1"' in exported
@@ -462,10 +493,10 @@ def test_archive_customer_by_guid_not_found(tmp_path):
     gf = tmp_path / "test.gnucash"
     import_fixture(runner, gf)
 
-    result = runner.invoke(cli, ["archive-customers", str(gf),
-                                 "--by-guid", "deadbeefdeadbeefdeadbeefdeadbeef"])
+    bogus = "deadbeefdeadbeefdeadbeefdeadbeef"
+    result = runner.invoke(cli, ["archive-customers", str(gf), "--by-guid", bogus])
     assert result.exit_code == 1
-    assert "not found" in result.output.lower()
+    _has_not_found_line(result.output, bogus)
 
 
 def test_archive_vendor_by_guid_active(tmp_path):
@@ -477,7 +508,7 @@ def test_archive_vendor_by_guid_active(tmp_path):
 
     result = runner.invoke(cli, ["archive-vendors", str(gf), "--by-guid", guid])
     assert result.exit_code == 0, result.output
-    assert "V001: archived" in result.output
+    assert f"V001 ({guid}): archived" in result.output
 
 
 def test_archive_vendor_by_guid_already_archived(tmp_path):
@@ -489,7 +520,7 @@ def test_archive_vendor_by_guid_already_archived(tmp_path):
 
     result = runner.invoke(cli, ["archive-vendors", str(gf), "--by-guid", guid])
     assert result.exit_code == 1
-    assert "V002: already archived" in result.output
+    assert f"V002 ({guid}): already archived" in result.output
 
 
 def test_archive_vendor_by_guid_not_found(tmp_path):
@@ -497,14 +528,18 @@ def test_archive_vendor_by_guid_not_found(tmp_path):
     gf = tmp_path / "test.gnucash"
     import_fixture(runner, gf)
 
-    result = runner.invoke(cli, ["archive-vendors", str(gf),
-                                 "--by-guid", "deadbeefdeadbeefdeadbeefdeadbeef"])
+    bogus = "deadbeefdeadbeefdeadbeefdeadbeef"
+    result = runner.invoke(cli, ["archive-vendors", str(gf), "--by-guid", bogus])
     assert result.exit_code == 1
-    assert "not found" in result.output.lower()
+    _has_not_found_line(result.output, bogus)
 
 
 def test_by_guid_accepts_uuid_with_hyphens(tmp_path):
-    """UUID-with-hyphens form is normalised the same way --txn_guid is."""
+    """UUID-with-hyphens form is normalised the same way --txn_guid is.
+
+    The output echoes the *normalised* (no-hyphen, lowercase) form so it
+    matches what the GnuCash file actually stores.
+    """
     runner = CliRunner()
     gf = tmp_path / "test.gnucash"
     import_fixture(runner, gf)
@@ -514,4 +549,4 @@ def test_by_guid_accepts_uuid_with_hyphens(tmp_path):
     result = runner.invoke(cli, ["delete-customers", str(gf),
                                  "--by-guid", uuid_form])
     assert result.exit_code == 0, result.output
-    assert "2: deleted" in result.output
+    assert f"2 ({guid}): deleted" in result.output

--- a/use_cases/delete_business_objects.py
+++ b/use_cases/delete_business_objects.py
@@ -43,8 +43,9 @@ class ArchiveStatus(Enum):
 
 @dataclass
 class DeleteResult:
-    id: str
-    status: DeleteStatus
+    id: str             # matched record's user-facing id (or original input on a miss)
+    guid: str = ''      # matched record's GUID (empty on a miss — no record to read it from)
+    status: DeleteStatus = None
     invoice_count: int = 0  # > 0 only for FAILED_HAS_INVOICES
 
     def message(self) -> str:
@@ -55,11 +56,19 @@ class DeleteResult:
             return f'failed — cannot delete, {self.invoice_count} {noun} linked'
         return 'not found'
 
+    def label(self) -> str:
+        """Per-record line prefix: '<id> (<guid>)' when a record was matched,
+        else just whatever the user typed (no guid is available on a miss)."""
+        if self.guid:
+            return f'{self.id} ({self.guid})'
+        return self.id
+
 
 @dataclass
 class ArchiveResult:
-    id: str
-    status: ArchiveStatus
+    id: str             # matched record's user-facing id (or original input on a miss)
+    guid: str = ''      # matched record's GUID (empty on a miss)
+    status: ArchiveStatus = None
     invoice_count: int = 0  # informational; > 0 when linked invoices exist
 
     def message(self) -> str:
@@ -72,6 +81,13 @@ class ArchiveResult:
             noun = 'invoice(s)' if self.invoice_count != 1 else 'invoice'
             return f'archived — {self.invoice_count} {noun} linked'
         return 'archived'
+
+    def label(self) -> str:
+        """Per-record line prefix: '<id> (<guid>)' when a record was matched,
+        else just whatever the user typed."""
+        if self.guid:
+            return f'{self.id} ({self.guid})'
+        return self.id
 
 
 def _count_invoices_for_owner(book: Book, owner_id: str, owner_type_int: int) -> int:
@@ -104,21 +120,22 @@ def _count_invoices_for_owner(book: Book, owner_id: str, owner_type_int: int) ->
 def _resolve_customer(book: Book, id_or_guid: str, by_guid: bool):
     """Look up a customer by id (default) or guid (when by_guid=True).
 
-    Returns (customer, report_id) where report_id is the user-facing id of
-    the matched customer for output, or — on a miss — the original input
-    so the caller can emit a NOT_FOUND result against what the user typed.
+    Returns (customer, report_id, report_guid):
+      - hit:  (Customer, customer.id, customer.guid)
+      - miss: (None,     original_input, '')
     """
     cust = find_customer_by_guid(book, id_or_guid) if by_guid else book.CustomerLookupByID(id_or_guid)
     if cust is None or not cust.GetID():
-        return None, id_or_guid
-    return cust, cust.GetID()
+        return None, id_or_guid, ''
+    return cust, cust.GetID(), cust.GetGUID().to_string()
 
 
 def _resolve_vendor(book: Book, id_or_guid: str, by_guid: bool):
+    """See _resolve_customer."""
     v = find_vendor_by_guid(book, id_or_guid) if by_guid else book.VendorLookupByID(id_or_guid)
     if v is None or not v.GetID():
-        return None, id_or_guid
-    return v, v.GetID()
+        return None, id_or_guid, ''
+    return v, v.GetID(), v.GetGUID().to_string()
 
 
 class DeleteCustomersUseCase:
@@ -132,16 +149,18 @@ class DeleteCustomersUseCase:
         """`ids` are customer numbers (default) or GUIDs (when by_guid=True)."""
         results = []
         for arg in ids:
-            cust, report_id = _resolve_customer(self.book, arg, by_guid)
+            cust, rid, rguid = _resolve_customer(self.book, arg, by_guid)
             if cust is None:
-                results.append(DeleteResult(id=report_id, status=DeleteStatus.NOT_FOUND))
+                results.append(DeleteResult(id=rid, status=DeleteStatus.NOT_FOUND))
                 continue
             n = _count_invoices_for_owner(self.book, cust.GetID(), 2)
             if n > 0:
-                results.append(DeleteResult(id=report_id, status=DeleteStatus.FAILED_HAS_INVOICES, invoice_count=n))
+                results.append(DeleteResult(id=rid, guid=rguid,
+                                            status=DeleteStatus.FAILED_HAS_INVOICES,
+                                            invoice_count=n))
                 continue
             cust.Destroy()
-            results.append(DeleteResult(id=report_id, status=DeleteStatus.DELETED))
+            results.append(DeleteResult(id=rid, guid=rguid, status=DeleteStatus.DELETED))
         return results
 
 
@@ -158,16 +177,18 @@ class ArchiveCustomersUseCase:
         """`ids` are customer numbers (default) or GUIDs (when by_guid=True)."""
         results = []
         for arg in ids:
-            cust, report_id = _resolve_customer(self.book, arg, by_guid)
+            cust, rid, rguid = _resolve_customer(self.book, arg, by_guid)
             if cust is None:
-                results.append(ArchiveResult(id=report_id, status=ArchiveStatus.NOT_FOUND))
+                results.append(ArchiveResult(id=rid, status=ArchiveStatus.NOT_FOUND))
                 continue
             if not cust.GetActive():
-                results.append(ArchiveResult(id=report_id, status=ArchiveStatus.ALREADY_ARCHIVED))
+                results.append(ArchiveResult(id=rid, guid=rguid,
+                                             status=ArchiveStatus.ALREADY_ARCHIVED))
                 continue
             n = _count_invoices_for_owner(self.book, cust.GetID(), 2)
             cust.SetActive(False)
-            results.append(ArchiveResult(id=report_id, status=ArchiveStatus.ARCHIVED, invoice_count=n))
+            results.append(ArchiveResult(id=rid, guid=rguid, status=ArchiveStatus.ARCHIVED,
+                                         invoice_count=n))
         return results
 
 
@@ -184,14 +205,16 @@ class ArchiveVendorsUseCase:
         """`ids` are vendor numbers (default) or GUIDs (when by_guid=True)."""
         results = []
         for arg in ids:
-            vendor, report_id = _resolve_vendor(self.book, arg, by_guid)
+            vendor, rid, rguid = _resolve_vendor(self.book, arg, by_guid)
             if vendor is None:
-                results.append(ArchiveResult(id=report_id, status=ArchiveStatus.NOT_FOUND))
+                results.append(ArchiveResult(id=rid, status=ArchiveStatus.NOT_FOUND))
                 continue
             if not vendor.GetActive():
-                results.append(ArchiveResult(id=report_id, status=ArchiveStatus.ALREADY_ARCHIVED))
+                results.append(ArchiveResult(id=rid, guid=rguid,
+                                             status=ArchiveStatus.ALREADY_ARCHIVED))
                 continue
             n = _count_invoices_for_owner(self.book, vendor.GetID(), 4)
             vendor.SetActive(False)
-            results.append(ArchiveResult(id=report_id, status=ArchiveStatus.ARCHIVED, invoice_count=n))
+            results.append(ArchiveResult(id=rid, guid=rguid, status=ArchiveStatus.ARCHIVED,
+                                         invoice_count=n))
         return results

--- a/use_cases/delete_business_objects.py
+++ b/use_cases/delete_business_objects.py
@@ -23,6 +23,11 @@ from typing import List
 import gnucash.gnucash_business as gb
 from gnucash import Book, Query
 
+from infrastructure.gnucash.guid_lookup import (
+    find_customer_by_guid,
+    find_vendor_by_guid,
+)
+
 
 class DeleteStatus(Enum):
     DELETED = auto()
@@ -96,67 +101,97 @@ def _count_invoices_for_owner(book: Book, owner_id: str, owner_type_int: int) ->
     return count
 
 
+def _resolve_customer(book: Book, id_or_guid: str, by_guid: bool):
+    """Look up a customer by id (default) or guid (when by_guid=True).
+
+    Returns (customer, report_id) where report_id is the user-facing id of
+    the matched customer for output, or — on a miss — the original input
+    so the caller can emit a NOT_FOUND result against what the user typed.
+    """
+    cust = find_customer_by_guid(book, id_or_guid) if by_guid else book.CustomerLookupByID(id_or_guid)
+    if cust is None or not cust.GetID():
+        return None, id_or_guid
+    return cust, cust.GetID()
+
+
+def _resolve_vendor(book: Book, id_or_guid: str, by_guid: bool):
+    v = find_vendor_by_guid(book, id_or_guid) if by_guid else book.VendorLookupByID(id_or_guid)
+    if v is None or not v.GetID():
+        return None, id_or_guid
+    return v, v.GetID()
+
+
 class DeleteCustomersUseCase:
-    """Hard-delete customers by ID; blocked if any invoices are linked."""
+    """Hard-delete customers by ID (or GUID with by_guid=True);
+    blocked if any invoices are linked."""
 
     def __init__(self, book: Book):
         self.book = book
 
-    def execute(self, ids: List[str]) -> List[DeleteResult]:
+    def execute(self, ids: List[str], by_guid: bool = False) -> List[DeleteResult]:
+        """`ids` are customer numbers (default) or GUIDs (when by_guid=True)."""
         results = []
-        for cid in ids:
-            cust = self.book.CustomerLookupByID(cid)
-            if cust is None or not cust.GetID():
-                results.append(DeleteResult(id=cid, status=DeleteStatus.NOT_FOUND))
+        for arg in ids:
+            cust, report_id = _resolve_customer(self.book, arg, by_guid)
+            if cust is None:
+                results.append(DeleteResult(id=report_id, status=DeleteStatus.NOT_FOUND))
                 continue
-            n = _count_invoices_for_owner(self.book, cid, 2)
+            n = _count_invoices_for_owner(self.book, cust.GetID(), 2)
             if n > 0:
-                results.append(DeleteResult(id=cid, status=DeleteStatus.FAILED_HAS_INVOICES, invoice_count=n))
+                results.append(DeleteResult(id=report_id, status=DeleteStatus.FAILED_HAS_INVOICES, invoice_count=n))
                 continue
             cust.Destroy()
-            results.append(DeleteResult(id=cid, status=DeleteStatus.DELETED))
+            results.append(DeleteResult(id=report_id, status=DeleteStatus.DELETED))
         return results
 
 
 class ArchiveCustomersUseCase:
-    """Set customers inactive (SetActive(False)); informational invoice count."""
+    """Set customers inactive (SetActive(False)); informational invoice count.
+
+    Accepts customer ids by default; pass by_guid=True to look up by GUID.
+    """
 
     def __init__(self, book: Book):
         self.book = book
 
-    def execute(self, ids: List[str]) -> List[ArchiveResult]:
+    def execute(self, ids: List[str], by_guid: bool = False) -> List[ArchiveResult]:
+        """`ids` are customer numbers (default) or GUIDs (when by_guid=True)."""
         results = []
-        for cid in ids:
-            cust = self.book.CustomerLookupByID(cid)
-            if cust is None or not cust.GetID():
-                results.append(ArchiveResult(id=cid, status=ArchiveStatus.NOT_FOUND))
+        for arg in ids:
+            cust, report_id = _resolve_customer(self.book, arg, by_guid)
+            if cust is None:
+                results.append(ArchiveResult(id=report_id, status=ArchiveStatus.NOT_FOUND))
                 continue
             if not cust.GetActive():
-                results.append(ArchiveResult(id=cid, status=ArchiveStatus.ALREADY_ARCHIVED))
+                results.append(ArchiveResult(id=report_id, status=ArchiveStatus.ALREADY_ARCHIVED))
                 continue
-            n = _count_invoices_for_owner(self.book, cid, 2)
+            n = _count_invoices_for_owner(self.book, cust.GetID(), 2)
             cust.SetActive(False)
-            results.append(ArchiveResult(id=cid, status=ArchiveStatus.ARCHIVED, invoice_count=n))
+            results.append(ArchiveResult(id=report_id, status=ArchiveStatus.ARCHIVED, invoice_count=n))
         return results
 
 
 class ArchiveVendorsUseCase:
-    """Set vendors inactive (SetActive(False)); informational bill count."""
+    """Set vendors inactive (SetActive(False)); informational bill count.
+
+    Accepts vendor ids by default; pass by_guid=True to look up by GUID.
+    """
 
     def __init__(self, book: Book):
         self.book = book
 
-    def execute(self, ids: List[str]) -> List[ArchiveResult]:
+    def execute(self, ids: List[str], by_guid: bool = False) -> List[ArchiveResult]:
+        """`ids` are vendor numbers (default) or GUIDs (when by_guid=True)."""
         results = []
-        for vid in ids:
-            vendor = self.book.VendorLookupByID(vid)
-            if vendor is None or not vendor.GetID():
-                results.append(ArchiveResult(id=vid, status=ArchiveStatus.NOT_FOUND))
+        for arg in ids:
+            vendor, report_id = _resolve_vendor(self.book, arg, by_guid)
+            if vendor is None:
+                results.append(ArchiveResult(id=report_id, status=ArchiveStatus.NOT_FOUND))
                 continue
             if not vendor.GetActive():
-                results.append(ArchiveResult(id=vid, status=ArchiveStatus.ALREADY_ARCHIVED))
+                results.append(ArchiveResult(id=report_id, status=ArchiveStatus.ALREADY_ARCHIVED))
                 continue
-            n = _count_invoices_for_owner(self.book, vid, 4)
+            n = _count_invoices_for_owner(self.book, vendor.GetID(), 4)
             vendor.SetActive(False)
-            results.append(ArchiveResult(id=vid, status=ArchiveStatus.ARCHIVED, invoice_count=n))
+            results.append(ArchiveResult(id=report_id, status=ArchiveStatus.ARCHIVED, invoice_count=n))
         return results


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                          
                                                                                                                                                                                                        
  This PR started as "let `delete-customers` / `archive-customers` /                                                                                                                                    
  `archive-vendors` accept GUIDs as well as ids", and grew during
  review to also fix two related importer issues that surfaced from                                                                                                                                     
  the user question "do we enforce unique invoice and bill numbers?"                                                                                                                                    
                                              
  Three logical changes, three commits:                                                                                                                                                                 
                                                                                                                                                                                                        
  1. **`--by-guid` flag on the three CLI commands.** Default behaviour                                                                                                                                  
     (positional args = customer/vendor numbers) is unchanged; with                                                                                                                                     
     `--by-guid` the args are GUIDs (32-char hex or UUID-with-hyphens,                                                                                                                                  
     normalised via `string_to_guid`). Mixing forms in one invocation                                                                                                                                   
     isn't supported.                         
                                                                                                                                                                                                        
  2. **Output always shows both id and guid for matched records.** A                                                                                                                                    
     hit prints `<id> (<guid>): <status>`; a miss falls back to just                                                                                                                                    
     the typed input. Format is identical regardless of `--by-guid`,                                                                                                                                    
     so the user never has to wonder which input maps to which record.                                                                                                                                  
                                                                                                                                                                                                      
  3. **Invoice/bill identity enforcement at import time.** Two related                                                                                                                                  
     problems:                                                                                                                                                                                          
     - **Bills were silently duplicating on every re-import.**                                                                                                                                          
       `book.InvoiceLookupByID(bill_id)` returns `None` for vendor                                                                                                                                      
       bills (only finds customer invoices), so the existing skip-on-                                                                                                                                   
       existing check in `import_bill` was a no-op. Re-importing a                                                                                                                                      
       bill fixture would create a fresh duplicate every time. Fixed                                                                                                                                    
       with a Query-based lookup that filters `gncInvoice` to                                                                                                                                           
       owner-type 4.                                                                                                                                                                                    
     - **Invoices/bills lacked Q-006-style id ⇔ guid enforcement.**                                                                                                                                     
       They went through a simpler "skip on id match, ignore guid"                                                                                                                                      
       path, so directive-vs-book guid mismatches went undetected.                                                                                                                                      
       Now they go through the same `_resolve_existing_or_none`                                                                                                                                         
       resolver as customers/vendors, with skip-on-hit semantics                                                                                                                                        
       (posted invoices have AR/AP lots that can't be safely mutated).                                                                                                                                  
                                                                                                                                                                                                        
  ## Why explicit `--by-guid` instead of auto-detection                                                                                                                                                 
                                                                                                                                                                                                        
  Nothing prevents a user from naming a customer                                                                                                                                                        
  `9f14a498cc894d50931f855a9a31d594` (any non-empty string is a legal                                                                                                                                   
  customer number). Auto-detection would silently misroute that arg.                                                                                                                                    
  Default stays id-based; `--by-guid` opts in.                                                                                                                                                          
                                                                                                                                                                                                        
  ## Behaviour summary                                                                                                                                                                                  
                                                                                                                                                                                                        
  | Command | Without flag | With `--by-guid` |                                                                                                                                                         
  |---|---|---|                                                                                                                                                                                         
  | `delete-customers FILE CUST-001` | look up `CUST-001` by id | look up by GUID |                                                                                                                     
  | Output line on hit | `CUST-001 (9f14a498…): deleted` | `CUST-001 (9f14a498…): deleted` |                                                                                                          
  | Output line on miss | `DOES-NOT-EXIST: not found` | `deadbeef…: not found` |
  | Malformed GUID | (treated as id, lookup fails) | `Error: Invalid GUID format: 'hello'` |
                                                                                                                                                                                                        
  For the importer side, all four scenarios now behave correctly:                                                                                                                                       
                                                                                                                                                                                                        
  | Scenario | Before | After |                                                                                                                                                                         
  |---|---|---|                                                                                                                                                                                         
  | Re-import same invoice file | skip (worked) | skip (unchanged) |                                                                                                                                    
  | Re-import same bill file | **silently duplicates** | skip |                                                                                                                                         
  | Directive's `guid:` mismatches existing record's | silently skip | error |                                                                                                                        
  | Directive's `guid:` matches a different record's id | silently skip | error |                                                                                                                       
  | Book has multiple records with same id | non-deterministic | error |                                                                                                                                
                                                                                                                                                                                                        
  ## Tests                                                                                                                                                                                              
                                                                                                                                                                                                        
  - 11 new tests in `tests/integration/test_delete_business_objects.py`                                                                                                                                 
    covering the `--by-guid` flag (happy path, unknown-guid, malformed                                                                                                                                  
    format, batch, UUID-with-hyphens normalisation, vendor cases,                                                                                                                                       
    already-archived).                                                                                                                                                                                  
  - 7 new tests in `tests/integration/test_business_object_idempotent_reimport.py`                                                                                                                    
    for the invoice/bill identity enforcement (matching guid → idempotent,                                                                                                                              
    mismatched guid → error, cross-id guid → error, all duplicated for                                                                                                                                  
    bills which would have caught the silent-duplication regression).                                                                                                                                   
  - All 14 existing id-mode delete/archive tests updated to the new                                                                                                                                     
    `<id> (<guid>)` output format via two strict regex helpers.                                                                                                                                         
                                                                                                                                                                                                        
  Full suite: **847 passed** (829 → 847 with the new tests, no regressions).                                                                                                                            
                                                                                                                                                                                                        
  ## Documentation                                                                                                                                                                                      
                                                                                                                                                                                                        
  - `README.md`: archive/delete sections show the new output format and                                                                                                                                 
    document `--by-guid`.                                                                                                                                                                               
  - `docs/issues/Q-007-delete-archive-by-guid.md`: design doc, Q-006                                                                                                                                  
    references, scope-extension section explaining what was rolled in                                                                                                                                   
    beyond the original CLI-flag scope.                                                                                                                                                               
  - `docs/DEBUGGING_GNUCASH_BINDINGS.md`: new finding documenting                                                                                                                                       
    `book.InvoiceLookupByID` not returning bills, with the verified                                                                                                                                     
    Python session output and fix guidance.                                                                                                                                                             
                                                                                                                                                                                                        
  ## Files changed                                                                                                                                                                                      
                                                                                                                                                                                                        
  - `infrastructure/gnucash/guid_lookup.py` — new shared helpers                                                                                                                                        
    (`normalise_guid`, `find_customer_by_guid`, `find_vendor_by_guid`)                                                                                                                                  
  - `services/gnucash_importer.py` — `_find_invoices_by_id` /                                                                                                                                           
    `_find_bills_by_id` / `_find_invoice_by_guid` / `_find_bill_by_guid`,                                                                                                                               
    `_swig_invoice_guid_str`, `_resolve_existing_or_none` gains an
    optional `get_guid_str` callback for ctypes-only platforms,                                                                                                                                         
    `import_invoice` and `import_bill` now go through the resolver.                                                                                                                                     
  - `use_cases/delete_business_objects.py` — `by_guid` parameter on                                                                                                                                     
    `execute()`, `_resolve_customer` / `_resolve_vendor`, result                                                                                                                                        
    dataclasses gain a `guid` field and `label()` method.                                                                                                                                               
  - `cli/delete_cmd.py` — `--by-guid` flag on all three commands.                                                                                                                                       
  - Tests, docs, README as above.                                 