### PR TITLE
fix(Q-008): enforce tax-table identity on import; fix re-import duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,30 +874,36 @@ keep the file readable; the guid is the authoritative key. When both are
 present they must resolve to the same record — otherwise the importer
 errors with the conflict spelled out.
 
-#### Re-import semantics: idempotent update
+#### Re-import semantics: idempotent, per object type
 
-Re-importing the same file is **idempotent**: existing records are
-*updated in place* rather than duplicated. The resolver looks up by `guid`
-first (when provided), falls back to lookup by id, and returns the
-existing record so the importer can update its mutable fields (name,
-address, active flag, custom KVP) without changing the GUID. This
-matches the natural workflow: edit the text, re-import, see your
-changes.
+Re-importing the same file is **idempotent** — but the exact behaviour
+varies by object type because some records have downstream
+dependencies that can't be safely mutated mid-flight:
 
-The importer **errors** rather than silently doing the wrong thing in
-these cases:
+| Block | On hit (record already exists) |
+|---|---|
+| `customer`, `vendor` | **Update** mutable fields (name, address, active flag, custom KVP) in place. |
+| `taxtable` | **Skip**. Tax tables are referenced by stored pointers from posted invoices/bills; mutating their entries would silently change accounting on past posted records. |
+| `invoice`, `bill` | **Skip**. Posted invoices/bills have AR/AP lots wired into a real transaction; mutating their fields would corrupt accounting state. |
 
-- the directive's `guid:` resolves to a record whose `id` doesn't match
-  (refusing to silently rename — invoices may reference the old id)
-- the directive's `guid:` is unknown but its `id` is taken (refusing to
-  rebuild because we cannot assign the new guid without overwriting the
-  existing record)
-- the book already contains multiple records with the same `id`
-  (legacy data needs cleanup in the GnuCash GUI before re-import)
-- an invoice/bill cross-reference has both `customer_id` (or `vendor_id`)
-  and the matching `_guid` field but they resolve to different records
+In all cases the importer first verifies that the directive's identity
+agrees with whatever's already in the book. The following are caught
+with a clear error rather than silently doing the wrong thing:
+
+- the directive's `guid:` resolves to a record whose `id` (or name, for
+  tax tables) doesn't match — refusing to silently rename, since
+  invoices may reference the old id
+- the directive's `guid:` is unknown but its `id` is taken — refusing
+  to rebuild because we cannot assign the new guid without overwriting
+  the existing record
+- the book already contains multiple records with the same `id` —
+  legacy data needs cleanup in the GnuCash GUI before re-import
+- an invoice/bill cross-reference has both `customer_id` (or
+  `vendor_id`) and the matching `_guid` field but they resolve to
+  different records
 - the requested guid is already used by a different entity type
-  (transaction, account, etc.) — GnuCash GUIDs are unique book-wide
+  (transaction, account, customer, vendor, tax table) — GnuCash GUIDs
+  are unique book-wide
 
 ### Reconciling invoice and bill payments with a bank feed
 

--- a/docs/DEBUGGING_GNUCASH_BINDINGS.md
+++ b/docs/DEBUGGING_GNUCASH_BINDINGS.md
@@ -375,6 +375,35 @@ both code paths use the same lookup shape avoids future surprises if
 the SWIG behaviour changes or if a query needs to detect legacy
 duplicates (multiple invoices with the same id, returned as a list).
 
+### 7. Tax tables are not enumerable via QofQuery (Q-008, 2026-05-07)
+
+Customer/vendor/invoice/bill objects all live in standard QOF entity
+collections and are reachable via `Query.search_for(...)`. Tax tables
+are not — they live in a per-book hash table accessed through
+`qof_book_get_data(book, "gncTaxTable")`, and the only Python-reachable
+way to enumerate them is the ctypes call:
+
+```python
+glist_ptr = lib.gncTaxTableGetTables(int(book.instance))
+# returns a GList* of GncTaxTable* pointers
+```
+
+A previous session confirmed `Query().search_for('gncTaxTable')` returns
+zero results. This means:
+
+- Any "find tax tables by name/guid" code must use `gncTaxTableGetTables`
+  + `iterate_glist` (ctypes), not `Query`.
+- Tax-table identity work (Q-008) keeps the entire find/check path
+  in ctypes per the "once ctypes, stay ctypes" rule. The resolver
+  receives raw pointers and uses ctypes-aware callbacks
+  (`get_id_str=_taxtable_name_str`, `get_guid_str=_taxtable_guid_str`)
+  rather than SWIG `record.GetID()`/`record.GetGUID()`.
+
+`gncTaxTableLookupByName(book, name)` (the C builtin) does work, but
+returns at most one match — useless if you need to detect legacy
+duplicates or build a list. Use the Query-equivalent ctypes iteration
+above when you need a multi-match lookup.
+
 ## Summary
 
 1. **No prediction possible** - test to discover failures
@@ -389,5 +418,6 @@ duplicates (multiple invoices with the same id, returned as a list).
 10. **`Account(instance=raw_ptr)` from a Query result is unsafe** - walk the tree instead
 11. **All-digit GUID values need quoting** - parser auto-converts to int
 12. **`book.InvoiceLookupByID` does not find bills** - use a Query filtered by owner-type
+13. **Tax tables are not in QofQuery** - enumerate via `gncTaxTableGetTables` (ctypes-only)
 
 This approach has proven necessary for maximum compatibility across Ubuntu 20/22/24 and Debian 11/12/13.

--- a/docs/issues/Q-008-taxtable-identity.md
+++ b/docs/issues/Q-008-taxtable-identity.md
@@ -1,0 +1,93 @@
+---
+id: Q-008
+title: Tax-table identity not enforced on import; re-import duplicates
+category: quality
+severity: medium
+status: open
+---
+
+## Problem
+
+`import_taxtable` calls `TaxTable(book, name, first_entry)` directly
+with no precondition check. Re-importing a plaintext file that
+contains a `taxtable "GST"` block creates a fresh tax table every
+time, accumulating multiple tax tables with the same name and
+different GUIDs.
+
+Downstream impact: invoice/bill entries reference tax tables by name
+(`tax_table: "GST"`) and the importer resolves that via
+`gncTaxTableLookupByName(book, "GST")`, which returns the first
+match. With duplicates in the book the choice is non-deterministic,
+silently routing tax onto whichever rate the lookup happened to
+return first.
+
+The exporter already emits `guid: "<hex>"` on every taxtable block
+(added in Q-006), so the round-trip carries the identity — the
+importer just doesn't honour it.
+
+## Why our existing tests miss it
+
+`test_business_objects_persisted_when_imported_into_existing_file`
+re-imports the full business-objects fixture (which contains a `GST`
+tax table) but only asserts presence of customer/invoice/bill blocks,
+never the count of tax tables.
+
+## Proposed fix
+
+Same shape as Q-006 (customer/vendor) and Q-007 (invoice/bill):
+
+1. **Idempotent skip on re-import.** Look up by name first
+   (`gncTaxTableLookupByName`); on a hit, skip — tax tables are
+   referenced by existing invoices via stored pointers, mutating
+   their entries mid-flight could corrupt those references.
+2. **Honour the directive's `guid:` field.** When the directive
+   provides a guid:
+   - validate format via `string_to_guid`
+   - look up the tax table by guid (Query iteration over
+     `gncTaxTableGetTables` since QofQuery doesn't index tax tables)
+   - apply the §2 resolution table from Q-006: id-vs-guid agreement
+     is required, multiple-name match is an error, etc.
+3. **Persist a user-supplied guid on a freshly created tax table**
+   via `qof_instance_set_guid`, with a global-uniqueness check the
+   way Q-006 does for customers/vendors (`_guid_in_use_anywhere`
+   already covers transactions/accounts/customers/vendors; tax
+   tables can join that list).
+
+### Resolution table (mirrors Q-006 §2 with name-instead-of-id)
+
+| `guid:` provided? | name lookup | guid lookup | action |
+|---|---|---|---|
+| no | not found | — | create |
+| no | one match | — | skip |
+| no | multiple matches | — | error: book has duplicates, resolve in GUI |
+| yes | — | not found, name taken | error |
+| yes | name matches resolved record | (same record) | skip |
+| yes | name mismatches resolved record | — | error |
+
+### Cross-reference (invoice/bill `tax_table: "GST"`) stays name-based
+
+We already document in Q-007 that introducing a per-reference guid
+field (`tax_table_guid:`) is out of scope — accounts/taxtables
+reference each other by name and that's been good enough so far.
+If a future bug shows the cross-reference itself is fragile, file
+that separately.
+
+## Files to change
+
+| File | Change |
+|---|---|
+| `services/gnucash_importer.py` | Add `_find_taxtables_by_name` (Query-based since `gncTaxTableLookupByName` returns at most one), `_find_taxtable_by_guid`, `_swig_taxtable_guid_str` (ctypes — tax tables are only reachable via ctypes anyway). `import_taxtable` goes through `_resolve_existing_or_none` with skip-on-hit. `_set_object_guid` is called when the directive provides a guid for a fresh create. |
+| `tests/integration/test_business_object_idempotent_reimport.py` | New `TestTaxTableIdentityEnforcement` class with: re-import same taxtable file is idempotent; re-import with matching guid is idempotent; re-import with mismatched guid errors; directive's guid resolves to a different taxtable name → error; same-file two `taxtable "GST"` blocks → either error or count == 1 in export. |
+| `docs/DEBUGGING_GNUCASH_BINDINGS.md` | If we discover any further GnuCash quirks for tax tables (likely some — they're already the most ctypes-heavy area), document them in the existing business-object findings section. |
+
+## Out of scope
+
+- Cross-reference identity (`tax_table_guid:` on invoice/bill entries)
+  — see Q-007 reasoning.
+- Updating tax-table entries on re-import. They're effectively
+  immutable once invoices reference the tax table, and an update
+  would silently change accounting on past posted invoices.
+
+---
+
+**Created**: 2026-05-07

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -279,6 +279,65 @@ def _find_bill_by_guid(book, guid_norm: str):
     return found
 
 
+def _iter_taxtables(book):
+    """Yield raw ctypes pointers to all tax tables in `book`.
+
+    Tax tables are stored in a per-book hash via `qof_book_get_data` and are
+    *not* enumerable through QofQuery — `gncTaxTableGetTables` (ctypes) is
+    the only way to list them. Once a pointer enters this codepath it stays
+    in ctypes (per the "once ctypes, stay ctypes" rule in CLAUDE.md).
+    """
+    from infrastructure.gnucash.engine import iterate_glist, load_gnc_engine
+    lib = load_gnc_engine()
+    glist_ptr = lib.gncTaxTableGetTables(int(book.instance))
+    return iterate_glist(lib, glist_ptr, lambda lib, ptr: ptr)
+
+
+def _taxtable_guid_str(tt_ptr) -> str:
+    """Read a tax-table's GUID via ctypes given its raw pointer."""
+    import ctypes
+
+    from infrastructure.gnucash.engine import load_gnc_engine
+    lib = load_gnc_engine()
+    lib.qof_instance_get_guid.argtypes = [ctypes.c_void_p]
+    lib.qof_instance_get_guid.restype = ctypes.c_void_p
+    lib.guid_to_string_buff.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    lib.guid_to_string_buff.restype = ctypes.c_char_p
+    buf = ctypes.create_string_buffer(40)
+    guid_ptr = lib.qof_instance_get_guid(tt_ptr)
+    if not guid_ptr:
+        return ''
+    lib.guid_to_string_buff(guid_ptr, buf)
+    return buf.value.decode('ascii')
+
+
+def _taxtable_name_str(tt_ptr) -> str:
+    """Read a tax-table's name via ctypes given its raw pointer."""
+    from infrastructure.gnucash.engine import load_gnc_engine, safe_ctypes_string
+    lib = load_gnc_engine()
+    return safe_ctypes_string(lib.gncTaxTableGetName, tt_ptr)
+
+
+def _find_taxtables_by_name(book, name: str):
+    """Return list of tax-table ctypes pointers whose name == `name`.
+
+    Returns a list (rather than a single pointer) so the resolver can detect
+    pre-existing duplicates that would otherwise silently misroute tax onto
+    whichever rate the lookup happened to pick first.
+    """
+    return [ptr for ptr in _iter_taxtables(book)
+            if _taxtable_name_str(ptr) == name]
+
+
+def _find_taxtable_by_guid(book, guid_norm: str):
+    """Return the tax-table ctypes pointer whose GUID matches `guid_norm`,
+    or None."""
+    for ptr in _iter_taxtables(book):
+        if _taxtable_guid_str(ptr) == guid_norm:
+            return ptr
+    return None
+
+
 def _swig_invoice_guid_str(invoice) -> str:
     """Read an Invoice's GUID via ctypes (qof_instance_get_guid + guid_to_string_buff).
     SWIG `Invoice.GetGUID()` is missing on some platforms; this works everywhere
@@ -299,17 +358,20 @@ def _swig_invoice_guid_str(invoice) -> str:
 
 def _resolve_existing_or_none(kind: str, id_: str, guid_str: Optional[str],
                               find_by_id, find_by_guid,
-                              get_guid_str=lambda r: r.GetGUID().to_string()):
+                              get_guid_str=lambda r: r.GetGUID().to_string(),
+                              get_id_str=lambda r: r.GetID()):
     """Apply Q-006 §2 resolution rules. Returns (existing, must_set_guid_str).
 
-    `kind` is 'customer'/'vendor'/'invoice'/'bill' for error messages.
+    `kind` is 'customer'/'vendor'/'invoice'/'bill'/'taxtable' for error messages.
     `existing` is the matched record or None (caller creates new).
     `must_set_guid_str` is the normalised guid to assign to a freshly-created
     record (for round-trip into a fresh book), or None.
     `get_guid_str(record) -> str` reads the guid from a matched record for
     error reporting. Defaults to SWIG `record.GetGUID().to_string()`, which
     works for Customer/Vendor; pass a ctypes-based callback for Invoice/Bill
-    where SWIG's `GetGUID` is missing on some platforms.
+    or for tax-table pointers where SWIG access is unavailable.
+    `get_id_str(record) -> str` reads the user-facing id (or name, for tax
+    tables) from a matched record. Defaults to SWIG `record.GetID()`.
 
     Raises ValueError on any contradiction the user must resolve manually.
     """
@@ -340,10 +402,11 @@ def _resolve_existing_or_none(kind: str, id_: str, guid_str: Optional[str],
         )
 
     if by_guid is not None:
-        if by_guid.GetID() != id_:
+        existing_id = get_id_str(by_guid)
+        if existing_id != id_:
             raise ValueError(
                 f'{kind} "{id_}": directive guid {guid_str!r} resolves to a '
-                f'{kind} with id {by_guid.GetID()!r} — refusing to rename. '
+                f'{kind} with id {existing_id!r} — refusing to rename. '
                 f'{kind} ids are immutable; fix the directive to match.'
             )
         return by_guid, None
@@ -424,6 +487,8 @@ def _guid_in_use_anywhere(book, guid_norm: str) -> Optional[str]:
         return 'customer'
     if _find_vendor_by_guid(book, guid_norm) is not None:
         return 'vendor'
+    if _find_taxtable_by_guid(book, guid_norm) is not None:
+        return 'taxtable'
     return None
 
 
@@ -1013,6 +1078,24 @@ class GnuCashImporter:
         if directive.type != DirectiveType.TAXTABLE:
             raise ValueError(f"Expected TAXTABLE but got {directive.type}")
 
+        tt_name = directive.props['name']
+
+        # Resolve identity (Q-008): apply id ⇔ guid agreement rules and
+        # detect pre-existing duplicates. On a hit we SKIP rather than
+        # update — tax tables are referenced by stored pointers from posted
+        # invoices/bills, and mutating their entries would silently change
+        # accounting on past posted invoices.
+        existing, must_set_guid = _resolve_existing_or_none(
+            'taxtable', tt_name, directive.metadata.get('guid'),
+            lambda n: _find_taxtables_by_name(book, n),
+            lambda g: _find_taxtable_by_guid(book, g),
+            get_guid_str=_taxtable_guid_str,
+            get_id_str=_taxtable_name_str,
+        )
+        if existing is not None:
+            logging.debug(f"Tax table {tt_name!r} already exists, skipping")
+            return
+
         first_entry_directive = None
         for d in directive.children:
             if d.type == DirectiveType.TAXTABLE_ENTRY:
@@ -1026,19 +1109,21 @@ class GnuCashImporter:
         acct_name = first_entry_directive.metadata['account']
         account = find_account(book.get_root_account(), acct_name)
         if account is None:
-            raise Exception(f'Account {acct_name!r} not found when creating tax table {directive.props["name"]}')
+            raise Exception(f'Account {acct_name!r} not found when creating tax table {tt_name}')
         rate_str = first_entry_directive.metadata['rate']
         rate = float(rate_str.replace("%", ""))
         first_entry = create_tax_table_entry(book, account, rate)
 
-        taxtable = TaxTable(book, directive.props['name'], first_entry)
+        taxtable = TaxTable(book, tt_name, first_entry)
+        if must_set_guid is not None:
+            _set_object_guid(book, taxtable, 'taxtable', tt_name, must_set_guid)
 
         for entry_directive in directive.children[1:]:
             if entry_directive.type == DirectiveType.TAXTABLE_ENTRY:
                 acct_name = entry_directive.metadata['account']
                 account = find_account(book.get_root_account(), acct_name)
                 if account is None:
-                    raise Exception(f'Account {acct_name!r} not found when creating tax table {directive.props["name"]}')
+                    raise Exception(f'Account {acct_name!r} not found when creating tax table {tt_name}')
                 rate_str = entry_directive.metadata['rate']
                 rate = float(rate_str.replace("%", ""))
                 entry = create_tax_table_entry(book, account, rate)

--- a/tests/integration/test_business_object_idempotent_reimport.py
+++ b/tests/integration/test_business_object_idempotent_reimport.py
@@ -985,3 +985,126 @@ class TestInvoiceBillIdentityEnforcement:
         assert r.exit_code != 0, (
             f"Mismatched guid on existing bill id must error:\n{r.output}"
         )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tax-table identity enforcement (Q-008)
+#
+# Tax tables previously had no idempotency or guid honour at all in the
+# importer: each re-import created a fresh duplicate, and invoice/bill
+# entries that reference `tax_table: "GST"` would non-deterministically
+# pick whichever match `gncTaxTableLookupByName` returned first. That
+# silently misroutes tax onto the wrong rate. These tests describe the
+# desired behaviour after extending Q-006 §2 resolution to tax tables:
+#
+#   - skip-on-existing (referenced by posted invoices, can't safely mutate)
+#   - directive's `guid:` must match the existing tax table's guid, else
+#     error
+#   - directive's `guid:` resolving to a different name → error
+#   - book has multiple tax tables with the same name → error
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_TAXTABLE_BASE = """
+taxtable "GST"
+\tentry:
+\t\taccount: "Liabilities:Accounts Payable"
+\t\trate: 5.0%
+\t\ttype: PERCENT
+"""
+
+
+_TAXTABLE_PST = """
+taxtable "PST"
+\tentry:
+\t\taccount: "Liabilities:Accounts Payable"
+\t\trate: 7.0%
+\t\ttype: PERCENT
+"""
+
+
+class TestTaxTableIdentityEnforcement:
+    """Tax-table identity must be consistent on re-import."""
+
+    def test_reimport_same_taxtable_is_idempotent(self, tmp_path):
+        """Re-importing a file with the same `taxtable "GST"` block must
+        not create a duplicate."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _TAXTABLE_BASE)
+        r = _import(runner, gnc, _write(tmp_path / "again.txt",
+                                        ACCOUNTS + "\n" + _TAXTABLE_BASE))
+        assert r.exit_code == 0, f"Re-import should be idempotent:\n{r.output}"
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        assert _count_blocks(text, 'taxtable "GST"') == 1, (
+            f"Expected exactly one taxtable 'GST' after re-import; got\n{text}"
+        )
+
+    def test_reimport_taxtable_with_matching_guid_is_idempotent(self, tmp_path):
+        """Directive carries `guid:` matching the existing tax table → skip."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _TAXTABLE_BASE)
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        guid = _field_in_block(_block_for(text, 'taxtable "GST"'),
+                               'guid', strip_quotes=True)
+        assert guid
+
+        with_guid = _TAXTABLE_BASE.replace(
+            'taxtable "GST"\n',
+            f'taxtable "GST"\n\tguid: "{guid}"\n',
+        )
+        r = _import(runner, gnc, _write(tmp_path / "again.txt",
+                                        ACCOUNTS + "\n" + with_guid))
+        assert r.exit_code == 0, f"Re-import with matching guid must succeed:\n{r.output}"
+        text2 = _exported_biz_text(runner, tmp_path, gnc)
+        assert _count_blocks(text2, 'taxtable "GST"') == 1
+
+    def test_reimport_taxtable_with_mismatched_guid_errors(self, tmp_path):
+        """Directive's `guid:` doesn't match the existing GST's guid → error."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _TAXTABLE_BASE)
+
+        bad = _TAXTABLE_BASE.replace(
+            'taxtable "GST"\n',
+            'taxtable "GST"\n\tguid: "deadbeefdeadbeefdeadbeefdeadbeef"\n',
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt",
+                                        ACCOUNTS + "\n" + bad))
+        assert r.exit_code != 0, (
+            f"Mismatched guid on existing taxtable name must error:\n{r.output}"
+        )
+
+    def test_reimport_taxtable_guid_resolves_to_different_name_errors(self, tmp_path):
+        """Directive says `taxtable "PST"` + guid of existing GST → error."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _TAXTABLE_BASE)
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        gst_guid = _field_in_block(_block_for(text, 'taxtable "GST"'),
+                                   'guid', strip_quotes=True)
+        assert gst_guid
+
+        bad = _TAXTABLE_PST.replace(
+            'taxtable "PST"\n',
+            f'taxtable "PST"\n\tguid: "{gst_guid}"\n',
+        )
+        r = _import(runner, gnc, _write(tmp_path / "bad.txt",
+                                        ACCOUNTS + "\n" + bad))
+        assert r.exit_code != 0, (
+            f"Reusing GST's guid for new PST must error:\n{r.output}"
+        )
+
+    def test_same_file_two_taxtables_with_same_name(self, tmp_path):
+        """Two `taxtable "GST"` blocks in one file must NOT produce two
+        records. Either the importer errors or the second is skipped
+        (because the first already created the table). Both are acceptable;
+        what we forbid is silent duplication."""
+        runner = CliRunner()
+        fixture = _TAXTABLE_BASE + _TAXTABLE_BASE  # duplicate!
+        gnc = tmp_path / "book.gnucash"
+        fix = _write(tmp_path / "dup.txt", ACCOUNTS + "\n" + fixture)
+        r = _import_new(runner, gnc, fix)
+        if r.exit_code == 0:
+            text = _exported_biz_text(runner, tmp_path, gnc)
+            assert _count_blocks(text, 'taxtable "GST"') == 1, (
+                f"Two same-name taxtable directives must not produce two "
+                f"records.\nExport:\n{text}"
+            )


### PR DESCRIPTION
The third in the customer/vendor (Q-006), invoice/bill (Q-007), and now tax-table (Q-008) trilogy of identity-enforcement work. Same pattern as the others: re-importing the same plaintext file with a `taxtable "GST"` block was creating a fresh duplicate every time.

Worse than the customer/vendor case because tax tables are referenced by name from invoice/bill entries (`tax_table: "GST"`), and the importer resolves that via `gncTaxTableLookupByName(book, "GST")`, which returns the *first* match. With duplicates in the book the pick is non-deterministic — silently routing tax onto whichever rate the lookup happened to find first.

The exporter already emitted `guid: "<hex>"` on every taxtable block (Q-006 §3), so the round-trip carried the identity — the importer just didn't honour it.

## Implementation

`import_taxtable` now goes through `_resolve_existing_or_none` (the helper that customer/vendor/invoice/bill share) with skip-on-hit semantics. Tax tables are referenced by stored pointers from posted invoices/bills, so updating their entries mid-flight could silently change accounting on past records — same constraint as invoice/bill.

The resolver gained an optional `get_id_str` callback alongside the existing `get_guid_str`. Default is SWIG `record.GetID()`; tax-table callers pass `_taxtable_name_str` (ctypes-based) since tax tables aren't enumerable via QofQuery and stay in the ctypes domain end-to-end.

New helpers in `services/gnucash_importer.py`:

- `_iter_taxtables(book)` — wraps `gncTaxTableGetTables` + `iterate_glist`
- `_taxtable_name_str(ptr)` / `_taxtable_guid_str(ptr)` — ctypes-aware readers
- `_find_taxtables_by_name(book, name)` — list of pointers (Query-style multi-match for legacy-duplicate detection)
- `_find_taxtable_by_guid(book, guid_norm)` — single pointer or None

`_guid_in_use_anywhere` extended to check tax tables alongside transactions/accounts/customers/vendors so a directive can't accidentally reuse a tax-table guid for some other entity type.

## Tests

`tests/integration/test_business_object_idempotent_reimport.py` adds a new `TestTaxTableIdentityEnforcement` class with 5 tests:
  - re-import same taxtable file is idempotent
  - re-import with matching guid is idempotent
  - re-import with mismatched guid errors
  - directive's guid resolves to a different name → error
  - same-file two `taxtable "GST"` blocks: error or count == 1

All 5 fail against unmodified code, confirming the bug; all 5 pass after the fix. Full suite: 852 passed (847 → 852, no regressions).

## Documentation

- `docs/issues/Q-008-taxtable-identity.md` — issue doc with the resolution table and rationale.
- `docs/DEBUGGING_GNUCASH_BINDINGS.md` — new finding (#7 in the business-object section) documenting that tax tables aren't enumerable via QofQuery and must be reached through `gncTaxTableGetTables` (ctypes). Closing summary list gains entry #13.
- `README.md` — the "Re-import semantics" section in the business objects chapter now distinguishes per-object behaviour explicitly: customers/vendors update on hit; tax tables/invoices/bills skip, with reasons. Same enumerated list of error cases that catch inconsistencies before they corrupt accounting state.