### PR TITLE
feat(Q-009) + fix(Q-007): import summary signals, unposted→posted via re-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,35 @@ gnucash-plaintext import --new mybook.gnucash ledger.txt --include-business-obje
 gnucash-plaintext export mybook.gnucash ledger.txt --include-business-objects
 ```
 
+The importer prints a per-directive status line as each business object
+is processed, plus an aggregate summary at the end:
+
+```
+Importing business objects...
+customer "C001": created
+customer "C002": updated
+vendor "V001": updated
+taxtable "GST": skipped
+invoice "INV-2026-001": skipped
+bill "BILL-2026-001": created
+
+...
+
+Business Objects:
+  Customers:   1 created, 1 updated, 0 skipped
+  Vendors:     0 created, 1 updated, 0 skipped
+  Tax tables:  0 created, 0 updated, 1 skipped
+  Invoices:    0 created, 1 updated, 1 skipped
+  Bills:       1 created, 0 updated, 0 skipped
+```
+
+`updated` for invoice/bill means the record was unposted before
+re-import and is now posted (or its entries were rebuilt) — the
+unposted→posted transition is allowed, but a posted invoice/bill
+always either skips or creates because its AR/AP lot can't be safely
+mutated. Tax tables only ever create or skip. See "Re-import
+semantics" below for the full state matrix.
+
 Business objects use no date prefix — they are master data, not ledger
 events. Dates that belong to a record (e.g. `date_opened` on an invoice) are
 declared as fields inside the block:
@@ -884,7 +913,8 @@ dependencies that can't be safely mutated mid-flight:
 |---|---|
 | `customer`, `vendor` | **Update** mutable fields (name, address, active flag, custom KVP) in place. |
 | `taxtable` | **Skip**. Tax tables are referenced by stored pointers from posted invoices/bills; mutating their entries would silently change accounting on past posted records. |
-| `invoice`, `bill` | **Skip**. Posted invoices/bills have AR/AP lots wired into a real transaction; mutating their fields would corrupt accounting state. |
+| `invoice`, `bill` (posted) | **Skip**. Posted records have AR/AP lots wired into a real transaction — entries, posted block, and mutable metadata are all locked. |
+| `invoice`, `bill` (unposted) | **Update**. Entries are rebuilt from the directive, fields refresh, and if the directive carries a real `posted:` block the record is posted as part of the same import. This is the natural workflow for "create draft → review → post" via plaintext edit + re-import. |
 
 In all cases the importer first verifies that the directive's identity
 agrees with whatever's already in the book. The following are caught

--- a/cli/import_cmd.py
+++ b/cli/import_cmd.py
@@ -153,7 +153,14 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
                 biz_objects_imported = sum(
                     1 for d in parser.root_directive.children if d.type in biz_types
                 )
-                importer.import_business_objects(parser.root_directive.children, repo.book)
+                # Inline per-directive status (Q-009) so a re-import that's
+                # all-skipped doesn't look identical to a fresh-create import.
+                biz_result = importer.import_business_objects(
+                    parser.root_directive.children, repo.book,
+                    on_directive_status=lambda kind, ident, status: click.echo(
+                        f'{kind} "{ident}": {status}'
+                    ),
+                )
 
             # Create use case
             use_case = ImportTransactionsUseCase(repo)
@@ -175,6 +182,30 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
             click.echo(f"  Skipped:      {result.skipped_count} (duplicates)")
             click.echo(f"  Conflicts:    {len(result.conflicts)}")
             click.echo(f"  Errors:       {result.error_count}")
+
+            # Business-objects summary (Q-009): only emit when business
+            # objects were actually processed; otherwise this section is
+            # noise on transaction-only imports.
+            if include_business_objects and biz_objects_imported > 0:
+                click.echo("")
+                click.echo("Business Objects:")
+                labels = [
+                    ('customer', 'Customers'),
+                    ('vendor',   'Vendors'),
+                    ('taxtable', 'Tax tables'),
+                    ('invoice',  'Invoices'),
+                    ('bill',     'Bills'),
+                ]
+                for kind, label in labels:
+                    counts = biz_result.counts[kind]
+                    if biz_result.total(kind) == 0:
+                        continue
+                    parts = [
+                        f"{counts['created']} created",
+                        f"{counts['updated']} updated",
+                        f"{counts['skipped']} skipped",
+                    ]
+                    click.echo(f"  {(label + ':'):<12} {', '.join(parts)}")
 
             if result.conflicts:
                 click.echo("")

--- a/docs/DEBUGGING_GNUCASH_BINDINGS.md
+++ b/docs/DEBUGGING_GNUCASH_BINDINGS.md
@@ -404,6 +404,51 @@ returns at most one match — useless if you need to detect legacy
 duplicates or build a list. Use the Query-equivalent ctypes iteration
 above when you need a multi-match lookup.
 
+### 8. `gncEntryDestroy` does NOT remove from the parent invoice/bill (2026-05-08)
+
+`Entry.Destroy()` (which wraps `gncEntryDestroy`) sets `do_free` on the
+entry's QofInstance and removes it from the QofCollection. It does
+**not** detach the entry from the parent invoice/bill's internal entry
+list. So:
+
+```python
+for old_entry in list(invoice.GetEntries()):
+    old_entry.Destroy()
+# invoice's entry list still contains dangling pointers!
+invoice.PostToAccount(...)   # iterates the list → segfault on GnuCash 3.8
+```
+
+Reproduced on ubuntu20 / GnuCash 3.8. Newer GnuCash either has memory-
+layout luck or has gained null-checks; the bug exists on every platform,
+just doesn't always crash visibly.
+
+**Fix**: detach before destroying.
+
+For customer invoices:
+
+```python
+for old_entry in list(invoice.GetEntries()):
+    invoice.RemoveEntry(old_entry)   # SWIG → gncInvoiceRemoveEntry
+    old_entry.Destroy()
+```
+
+For vendor bills the SWIG `Invoice.RemoveEntry` wraps the
+*customer-only* `gncInvoiceRemoveEntry`, which is a no-op (or worse) on
+bills — same wrong-API trap as `book.InvoiceLookupByID` (#6 above).
+Bills need `gncBillRemoveEntry` directly via ctypes:
+
+```python
+lib = ctypes.CDLL(None)
+lib.gncBillRemoveEntry.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+for old_entry in list(bill.GetEntries()):
+    lib.gncBillRemoveEntry(int(bill.instance), int(old_entry.instance))
+    old_entry.Destroy()
+```
+
+The fix is in `services/gnucash_importer.py` as
+`_bill_remove_all_entries`. See the post-mortem in
+`docs/post-mortems/2026-05-08-bill-postto-account-segfault.md`.
+
 ## Summary
 
 1. **No prediction possible** - test to discover failures
@@ -419,5 +464,6 @@ above when you need a multi-match lookup.
 11. **All-digit GUID values need quoting** - parser auto-converts to int
 12. **`book.InvoiceLookupByID` does not find bills** - use a Query filtered by owner-type
 13. **Tax tables are not in QofQuery** - enumerate via `gncTaxTableGetTables` (ctypes-only)
+14. **`gncEntryDestroy` does not detach from parent invoice/bill** - call `RemoveEntry` first; bills need `gncBillRemoveEntry` via ctypes
 
 This approach has proven necessary for maximum compatibility across Ubuntu 20/22/24 and Debian 11/12/13.

--- a/docs/issues/Q-009-import-summary-business-objects.md
+++ b/docs/issues/Q-009-import-summary-business-objects.md
@@ -1,0 +1,168 @@
+---
+id: Q-009
+title: Business-object import is silent — re-import gives no signal of skip vs. create vs. update
+category: quality
+severity: medium
+status: open
+---
+
+## Problem
+
+After Q-006 / Q-007 / Q-008, business-object imports do the *right*
+thing on re-import:
+
+| Block | On hit |
+|---|---|
+| customer / vendor | update mutable fields in place |
+| taxtable / invoice / bill | skip (no mutation) |
+
+…but the CLI gives **zero signal** about which path was taken. A user
+running `gnucash-plaintext import …` against an already-populated book
+sees:
+
+- `exit_code == 0` (same as a fresh-create import)
+- `stdout`: byte-identical to a fresh import (just the
+  transaction-side import summary)
+- `stderr`: empty
+
+Reported by another user via private review:
+
+> Real create: delta=+514 bytes (file grew by 514 bytes)
+> Q-007 skip: delta=+0 bytes (file unchanged)
+> stdout: byte-identical
+> stderr: byte-identical
+>
+> The CLI gives zero signal in stdout/stderr. The size delta is the
+> only reliable post-hoc signal we have without making an extra query.
+
+That's a UX bug. A user shouldn't have to diff file sizes to know
+whether their import did anything.
+
+## Proposed fix: both per-directive output AND aggregate counts
+
+Two complementary signals:
+
+### 1. Per-directive output, inline as the import runs
+
+Mirrors the per-record output of `delete-customers` /
+`archive-customers` / etc. (added in Q-007):
+
+```
+customer "C001": updated
+customer "C002": created
+vendor "V001": skipped (already exists)        ← actually no, vendors update too
+taxtable "GST": skipped (already exists)
+invoice "INV-001": skipped (already exists)
+invoice "INV-002": created
+bill "BILL-001": skipped (already exists)
+```
+
+Per-directive lines give exact detail without the user having to
+guess. They're noisier on large imports but match the format users
+already know from delete/archive.
+
+### 2. Aggregate counts in the import summary at the end
+
+Same shape as the existing transaction-side summary:
+
+```
+Business Objects:
+  Customers:  1 created, 1 updated, 0 skipped
+  Vendors:    0 created, 1 updated, 0 skipped
+  Tax tables: 0 created, 0 updated, 1 skipped
+  Invoices:   1 created, 1 skipped
+  Bills:      0 created, 1 skipped
+```
+
+Aggregate counts are easier to scan on big imports and easy to assert
+on in scripts (e.g. CI).
+
+### Why both, not one or the other
+
+Per-directive lines tell the user *which* records changed. Counts
+tell them *how many*. A user investigating "did my edit propagate?"
+wants per-directive detail; a CI pipeline asserting "exactly N
+customers were updated" wants counts. Both are cheap to plumb because
+the resolver already knows the answer for free.
+
+## Implementation sketch
+
+### `import_business_objects` returns a result, not nothing
+
+Currently the method has no return value. Introduce
+`BusinessObjectImportResult`:
+
+```python
+@dataclass
+class BusinessObjectImportResult:
+    customers_created:  int = 0
+    customers_updated:  int = 0
+    customers_skipped:  int = 0   # if we ever add skip-on-customer
+    vendors_created:    int = 0
+    vendors_updated:    int = 0
+    vendors_skipped:    int = 0
+    taxtables_created:  int = 0
+    taxtables_skipped:  int = 0
+    invoices_created:   int = 0
+    invoices_skipped:   int = 0
+    bills_created:      int = 0
+    bills_skipped:      int = 0
+```
+
+Each `import_customer` / `import_vendor` / `import_taxtable` /
+`import_invoice` / `import_bill` returns one of three statuses
+(`'created'`, `'updated'`, `'skipped'`); `import_business_objects`
+aggregates.
+
+### CLI emits per-directive lines as it goes
+
+The CLI receives the per-directive status from the importer. Easiest
+plumbing: add an optional `on_directive_status` callback parameter
+to `import_business_objects`:
+
+```python
+self.importer.import_business_objects(
+    directives, book,
+    on_directive_status=lambda kind, id_, status: click.echo(
+        f'{kind} "{id_}": {status}'
+    ),
+)
+```
+
+Default no-op so library callers don't get unwanted output.
+
+### Final summary printed by CLI after import completes
+
+Same place we already print the transaction summary:
+
+```
+Business Objects:
+  Customers:  1 created, 1 updated, 0 skipped
+  Vendors:    0 created, 1 updated, 0 skipped
+  ...
+```
+
+Skipped lines emitted only when count > 0 (less noise on fresh
+imports).
+
+## Files to change
+
+| File | Change |
+|---|---|
+| `services/gnucash_importer.py` | Per-method status return; `import_business_objects` aggregates into a result and invokes the optional `on_directive_status` callback. |
+| `cli/import_cmd.py` | Pass the callback that prints per-directive lines; print the aggregate summary after `import_business_objects` returns. |
+| `tests/integration/test_business_object_import_summary.py` (new) | Cover per-directive and aggregate output for: fresh import, full re-import, mixed (some new + some existing). |
+| `README.md` | Show the new output format under the import section. |
+
+## Out of scope
+
+- Per-record output for plain transactions (already has its own
+  summary; that subsystem is unrelated).
+- Verbosity flags (`--quiet` / `--verbose`). Possible follow-up if
+  the per-directive lines turn out to be too noisy in real-world
+  imports.
+- A machine-readable output mode (JSON) — same follow-up bucket.
+
+---
+
+**Created**: 2026-05-08

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -47,4 +47,7 @@ When a fix is merged, update `status: open` → `closed` in the file's frontmatt
 | [Q-003](Q-003-account-type-export-not-reimportable.md) | Exported account types (A/Receivable, A/Payable) crash re-import | high |
 | [Q-004](Q-004-payment-transaction-duplicates.md) | Invoice payment blocks create duplicate bank transactions (Cases B and C) | high |
 | [Q-005](Q-005-import-errors-no-context.md) | Import errors show raw exception with no directive context | high |
-| [Q-004](Q-004-payment-transaction-duplicates.md) | Invoice payment blocks create duplicate bank transactions (Cases B and C) | high |
+| [Q-006](Q-006-business-object-id-uniqueness-and-guid-export.md) | Business-object IDs are not unique on re-import; GUIDs are not exported | high |
+| [Q-007](Q-007-delete-archive-by-guid.md) | delete/archive accept GUIDs; invoice/bill identity enforced on import | medium |
+| [Q-008](Q-008-taxtable-identity.md) | Tax-table identity not enforced on import; re-import duplicates | medium |
+| [Q-009](Q-009-import-summary-business-objects.md) | Business-object import is silent — re-import gives no signal of skip vs. create vs. update | medium |

--- a/docs/post-mortems/2026-05-08-bill-postto-account-segfault.md
+++ b/docs/post-mortems/2026-05-08-bill-postto-account-segfault.md
@@ -1,0 +1,210 @@
+# Post-mortem: bill PostToAccount segfault on GnuCash 3.8
+
+**Date:** 2026-05-08
+**Branch / PR:** Q-009 / unposted→posted re-import (Q-007 follow-up)
+**Severity:** medium — would have shipped a latent dangling-pointer bug
+masked by a workaround.
+**Caught by:** multi-distribution CI (ubuntu20 / GnuCash 3.8). All
+newer-GnuCash distros passed.
+
+## What happened
+
+While implementing the unposted→posted re-import behaviour, the
+importer for vendor bills started calling `entry.Destroy()` on each
+existing entry of an unposted bill before re-adding entries from the
+plaintext directive. On debian13/ubuntu24/etc. this worked; on
+ubuntu20 (GnuCash 3.8) the next call to `gncInvoicePostToAccount`
+segfaulted inside the C library.
+
+The first attempted fix was to **disable the feature on the failing
+platform** — i.e. don't touch entries at all on existing unposted
+bills, only run the posted/payment blocks. This made the test pass
+on ubuntu20 but left the underlying bug in the code.
+
+The reviewer pushed back ("should find out how to make it pass! not
+ignoring!"), so the destroy-step was investigated again. The actual
+cause turned out to be:
+
+- `gncEntryDestroy(entry)` sets the `do_free` flag on the entry's
+  QofInstance and removes it from the QofCollection.
+- It does **not** detach the entry from the parent invoice/bill's
+  internal entry list.
+- `gncInvoicePostToAccount` later iterates that entry list and
+  dereferences each pointer.
+- On GnuCash 3.8 the dangling pointer crashes; on newer GnuCash the
+  crash either doesn't happen (different memory layout) or is
+  silently masked by null checks added since.
+
+The correct fix is to detach the entry from its parent before
+destroying:
+
+- Customer invoices: `Invoice.RemoveEntry(entry)` (SWIG, wraps
+  `gncInvoiceRemoveEntry`).
+- Vendor bills: SWIG `Invoice.RemoveEntry` is **customer-only**, so
+  bills need `gncBillRemoveEntry(bill, entry)` directly via ctypes.
+
+After the fix, the destroy-and-rebuild path passes on every supported
+distro.
+
+## Timeline
+
+| Step | Action |
+|---|---|
+| 1 | Tests for unposted→posted transition added; pass on debian13 (864 passed). |
+| 2 | Pre-commit ran multi-distro suite. Ubuntu20 segfault in `gncInvoicePostToAccount` for `test_bill_unposted_can_be_posted_via_reimport`. |
+| 3 | First attempted fix: stop touching entries on existing unposted invoices/bills. Tests pass on ubuntu20 but the actual bug is unresolved. |
+| 4 | Reviewer pushed back — root-cause not workaround. |
+| 5 | Investigation: `gncEntryDestroy` doesn't detach the entry from the invoice's list. Add `RemoveEntry` (or `gncBillRemoveEntry` via ctypes for bills) before `Destroy()`. |
+| 6 | Fix verified on every distribution. |
+
+## Why the wrong instinct kicked in
+
+Honest read: the workaround instinct came from several biases working
+together.
+
+1. **Reframing the bug as "platform quirk".** The crash *only*
+   reproduced on ubuntu20. The default story became "GnuCash 3.8 is
+   weird" rather than "the destroy-step is wrong". Once a bug is
+   labeled "platform quirk", investigation stops.
+2. **Sunk cost on the existing diff.** The destroy-step had been
+   written; backing it out felt like progress; investigating felt
+   like more work.
+3. **Tests pass elsewhere = good enough.** When debian13 passes, the
+   "it works" signal feels stronger than the single failing platform.
+   The latent dangling pointer was actually present on every
+   platform; only one platform crashed visibly.
+4. **Asymmetric cost framing.** Disabling the feature on one platform
+   *feels* like a smaller compromise than tracking down a C-level
+   memory bug. In reality the workaround would have shipped a real
+   bug into newer GnuCash too — newer versions might dereference the
+   dangling pointer at any point in the future.
+
+## Lessons
+
+### For the codebase
+
+- **`gncEntryDestroy` does NOT remove from the parent's entry list.**
+  Always call `RemoveEntry` first. Documented in
+  `docs/DEBUGGING_GNUCASH_BINDINGS.md` (added as part of this fix).
+
+- **SWIG `Invoice.RemoveEntry` is customer-only.** For vendor bills,
+  call `gncBillRemoveEntry` via ctypes. The SWIG `Invoice` class
+  presents a unified API but its `RemoveEntry` method silently maps
+  to the customer-side C function. Same wrong-API pattern as
+  `book.InvoiceLookupByID` not finding bills (Q-007 finding).
+
+- **Multi-distribution CI is load-bearing.** Without ubuntu20 in the
+  matrix this would have shipped. Don't reduce coverage to make CI
+  green.
+
+### For future work (process)
+
+- When a test passes on platform A but fails on platform B, the
+  default frame is "the failing platform caught a real bug", not
+  "this platform is quirky". Investigate the root cause first.
+
+- Resist the temptation to disable a feature on the failing platform
+  to make the suite green. That's a workaround that hides a real
+  problem.
+
+- Read the C-level traceback and attribute the bug to the user's own
+  code first. Only label it "platform incompatibility" with a
+  stronger argument than the stack trace itself.
+
+## How this finding accelerates future debugging
+
+The same wrong-API trap has now bitten us at least twice with the
+GnuCash bindings. Cataloguing the pattern explicitly:
+
+### Recognise the "SWIG presents one API, C has two" smell
+
+Several GnuCash entities have a unified Python class but distinct C
+functions per owner type:
+
+- `Invoice` → `gncInvoiceLookupByID` (customer) vs.
+  `gncBillRemoveEntry` (vendor) — both bug-shaped; SWIG only wraps
+  the customer side.
+- `Invoice.RemoveEntry` → `gncInvoiceRemoveEntry` (customer-only).
+  Vendor bills must use `gncBillRemoveEntry` via ctypes.
+
+Whenever a SWIG class wraps something that has a customer/vendor
+asymmetry in the C layer, treat the bill side as a separate code
+path and verify with ctypes.
+
+### Standard playbook for a single-platform crash
+
+1. **Read the C-level traceback first.** The fault is in
+   `gncInvoicePostToAccount`; the call chain leads from
+   `import_bill`. Investigation should start at the C function, not
+   at "is this a platform issue."
+2. **Search this doc** (`docs/DEBUGGING_GNUCASH_BINDINGS.md`) for
+   the function name and surrounding API. Several past landmines are
+   already catalogued.
+3. **Check whether `Destroy()` actually unhooks from the parent.** A
+   QofInstance-level destroy is not the same as removing from a
+   parent's list. Always look for a matching `Remove*` C function.
+4. **Reproduce on the same docker image with a minimal script.** A
+   one-off `./scripts/run.sh ubuntu20 python3 -c '...'` is faster
+   than re-running the full pytest suite.
+5. **Confirm the fix on the failing distro AND the distros that
+   "passed."** A test that was passing only because the dangling
+   pointer happened to land in cleared memory is still wrong.
+
+### Diagnostic shortcuts
+
+| Symptom | First place to look |
+|---|---|
+| Segfault in `gncInvoicePostToAccount` | Was `RemoveEntry` skipped before `Destroy` on a prior entry-mutation? |
+| `book.InvoiceLookupByID(bill_id)` returns None | The lookup is customer-only; switch to a Query filtered by owner-type 4. |
+| `Account(instance=raw_ptr)` segfaults | Wrong: walk the parent→children tree from `book.get_root_account()` instead. |
+| `string_to_guid("hello")` returns 0 (not raise) | Check the int return value; raise `ValueError` yourself. |
+
+## Why this matters for the product
+
+A workaround that disables a feature on one platform looks small in
+isolation, but the cumulative cost is high:
+
+1. **The bug is real on every platform.** Newer GnuCash isn't
+   immune; it just doesn't crash visibly *yet*. Memory layout and
+   future GnuCash patches can promote a silent corruption into a
+   segfault at any point. Shipping the workaround would have left
+   that timer running on every supported distro.
+
+2. **The product depends on dropping in to a wide GnuCash matrix.**
+   Users on debian13 won't tolerate a feature that "works there" if
+   the same input segfaults on a teammate's ubuntu20 box. The
+   project's value proposition includes "your existing GnuCash
+   install, whichever distro it lives on" — that promise is only
+   credible if the multi-distro CI is allowed to gate merges.
+
+3. **Trust compounds.** Every time the importer silently does the
+   wrong thing — Q-006 customer dedup, Q-007 invoice/bill
+   detection, Q-008 tax-table identity, this entry-list dangler —
+   we lose user trust that re-import is safe. "Safe" here means *I
+   can re-import this file and the result is what I expect, on any
+   supported install*. Workarounds that say "well, on platform X we
+   skip this part" make the trust assertion conditional and harder
+   to reason about.
+
+4. **The fix surface is small once found.** Adding `RemoveEntry` (or
+   `gncBillRemoveEntry` via ctypes) before `Destroy` is a one-line
+   change. The investment is in the diagnosis, not the patch — and
+   the diagnosis pays back every time we touch business-object
+   mutation code.
+
+5. **Multi-distro CI is the safety net.** Without ubuntu20 in the
+   matrix, this PR would have shipped a latent dangling-pointer
+   bug. The cost of running 9 distros in parallel is far less than
+   the cost of one user reporting a segfault that took six months
+   to reproduce locally.
+
+## Code citations
+
+- `services/gnucash_importer.py` — `_bill_remove_all_entries` helper
+  and the matching `Invoice.RemoveEntry` + `Destroy` sequence in
+  `import_invoice` / `import_bill`.
+- `docs/DEBUGGING_GNUCASH_BINDINGS.md` — finding documenting the
+  RemoveEntry-before-Destroy pattern (added as part of this PR).
+- `tests/integration/test_business_object_idempotent_reimport.py` —
+  `TestUnpostedToPostedTransition` class. The failing test was
+  `test_bill_unposted_can_be_posted_via_reimport`.

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -7,8 +7,9 @@ Converts PlaintextDirective objects from the parser into GnuCash objects
 
 import ctypes
 import logging
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import gnucash.gnucash_core_c as gc
 from gnucash import Account, Book, GncCommodity, GncNumeric, Split, Transaction
@@ -59,6 +60,31 @@ def string_to_gnc_numeric_quantity(s):
 
 
 _FALSY_STRINGS = {'false', '0', 'no'}
+
+
+@dataclass
+class BusinessObjectImportResult:
+    """Per-type create/update/skip counts from `import_business_objects`.
+
+    Customers and vendors update on hit (Q-006), so they have all three
+    counters. Tax tables, invoices, and bills skip on hit (Q-007/Q-008),
+    so they have only created and skipped — `updated` stays zero.
+    """
+    counts: Dict[str, Dict[str, int]] = field(default_factory=lambda: {
+        'customer': {'created': 0, 'updated': 0, 'skipped': 0},
+        'vendor':   {'created': 0, 'updated': 0, 'skipped': 0},
+        'taxtable': {'created': 0, 'updated': 0, 'skipped': 0},
+        'invoice':  {'created': 0, 'updated': 0, 'skipped': 0},
+        'bill':     {'created': 0, 'updated': 0, 'skipped': 0},
+    })
+
+    def tally(self, kind: str, status: str) -> None:
+        if status not in ('created', 'updated', 'skipped'):
+            raise ValueError(f"Unknown import status {status!r} for {kind}")
+        self.counts[kind][status] += 1
+
+    def total(self, kind: str) -> int:
+        return sum(self.counts[kind].values())
 
 
 def _find_transaction_by_guid(book, guid: str):
@@ -336,6 +362,26 @@ def _find_taxtable_by_guid(book, guid_norm: str):
         if _taxtable_guid_str(ptr) == guid_norm:
             return ptr
     return None
+
+
+def _bill_remove_all_entries(book, bill) -> None:
+    """Detach and destroy every entry on a vendor bill.
+
+    SWIG `Invoice.RemoveEntry(entry)` wraps `gncInvoiceRemoveEntry` which is
+    customer-invoice-specific and is a no-op (or worse) on vendor bills.
+    Use the C `gncBillRemoveEntry` directly via ctypes so the bill's entry
+    list is properly cleared before we rebuild from the directive. Without
+    this, `gncInvoicePostToAccount` later iterates a list with dangling
+    pointers from destroyed entries and segfaults on GnuCash 3.8.
+    """
+    import ctypes
+    lib = ctypes.CDLL(None)
+    lib.gncBillRemoveEntry.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    lib.gncBillRemoveEntry.restype = None
+    bill_ptr = int(bill.instance)
+    for old_entry in list(bill.GetEntries()):
+        lib.gncBillRemoveEntry(bill_ptr, int(old_entry.instance))
+        old_entry.Destroy()
 
 
 def _swig_invoice_guid_str(invoice) -> str:
@@ -1039,6 +1085,7 @@ class GnuCashImporter:
         if custom_meta:
             set_custom_metadata(customer, custom_meta)
         logging.debug(f"{'Updated' if existing else 'Created'} customer {cid}")
+        return 'updated' if existing else 'created'
 
     @staticmethod
     def import_vendor(directive: PlaintextDirective, book: Book):
@@ -1072,6 +1119,7 @@ class GnuCashImporter:
         if custom_meta:
             set_custom_metadata(vendor, custom_meta)
         logging.debug(f"{'Updated' if existing else 'Created'} vendor {vid}")
+        return 'updated' if existing else 'created'
 
     @staticmethod
     def import_taxtable(directive: PlaintextDirective, book: Book):
@@ -1094,7 +1142,7 @@ class GnuCashImporter:
         )
         if existing is not None:
             logging.debug(f"Tax table {tt_name!r} already exists, skipping")
-            return
+            return 'skipped'
 
         first_entry_directive = None
         for d in directive.children:
@@ -1103,8 +1151,9 @@ class GnuCashImporter:
                 break
 
         if not first_entry_directive:
-            # A taxtable must have at least one entry
-            return
+            # A taxtable must have at least one entry — treat the directive
+            # as a skip so the caller doesn't count it as a create.
+            return 'skipped'
 
         acct_name = first_entry_directive.metadata['account']
         account = find_account(book.get_root_account(), acct_name)
@@ -1130,6 +1179,7 @@ class GnuCashImporter:
                 taxtable.AddEntry(entry)
 
         logging.debug(f"Created taxtable {directive.props['name']}")
+        return 'created'
 
     @staticmethod
     def import_invoice(directive: PlaintextDirective, book: Book):
@@ -1138,19 +1188,29 @@ class GnuCashImporter:
 
         inv_id = directive.props['id']
 
-        # Resolve identity (Q-007): apply id ⇔ guid agreement rules and
-        # detect pre-existing duplicates. On a hit we SKIP rather than
-        # update — invoices have AR lots wired into a real transaction and
-        # mutating their fields after posting would corrupt accounting state.
+        # Resolve identity (Q-007): id ⇔ guid agreement, duplicate detection.
         existing, must_set_guid = _resolve_existing_or_none(
             'invoice', inv_id, directive.metadata.get('guid'),
             lambda i: _find_invoices_by_id(book, i),
             lambda g: _find_invoice_by_guid(book, g),
             get_guid_str=_swig_invoice_guid_str,
         )
+
+        # Q-007 follow-up: existing posted invoice is immutable (its AR lot
+        # is wired into a real transaction; mutating entries/posted block
+        # would corrupt accounting state). Existing UNPOSTED invoice can be
+        # updated — replace entries, optionally post, optionally pay. The
+        # gap that prompted this: a user's natural workflow is
+        #   1. import invoice with `posted: none`
+        #   2. edit file, replace `posted: none` with a real posted block
+        #   3. re-import
+        # Pre-fix this silently skipped at step 3.
+        status_on_success = 'created'
         if existing is not None:
-            logging.debug(f"Invoice {inv_id} already exists, skipping")
-            return
+            if existing.GetPostedTxn() is not None:
+                logging.debug(f"Invoice {inv_id} already exists and is posted; skipping")
+                return 'skipped'
+            status_on_success = 'updated'
 
         # Validate: posted: none and a real posted: block are contradictory
         has_posted_none = directive.metadata.get('posted') == 'none'
@@ -1169,16 +1229,30 @@ class GnuCashImporter:
         if has_posted_none and payment_children:
             raise ValueError(f'Invoice {inv_id}: cannot have payment: blocks on an unposted invoice (posted: none)')
 
-        customer = _resolve_cross_reference(
-            'customer',
-            directive.metadata.get('customer_id'),
-            directive.metadata.get('customer_guid'),
-            lambda i: _find_customers_by_id(book, i),
-            lambda g: _find_customer_by_guid(book, g),
-        )
-        invoice = Invoice(book, inv_id, book.get_table().lookup("CURRENCY", directive.metadata['currency']), customer)
-        if must_set_guid is not None:
-            _set_object_guid(book, invoice, 'invoice', inv_id, must_set_guid)
+        if existing is None:
+            customer = _resolve_cross_reference(
+                'customer',
+                directive.metadata.get('customer_id'),
+                directive.metadata.get('customer_guid'),
+                lambda i: _find_customers_by_id(book, i),
+                lambda g: _find_customer_by_guid(book, g),
+            )
+            invoice = Invoice(book, inv_id, book.get_table().lookup("CURRENCY", directive.metadata['currency']), customer)
+            if must_set_guid is not None:
+                _set_object_guid(book, invoice, 'invoice', inv_id, must_set_guid)
+        else:
+            # Existing unposted invoice: reuse it, drop its current entries
+            # so we can rebuild from the directive. RemoveEntry is essential
+            # before Destroy: gncEntryDestroy only sets the do_free flag and
+            # drops the entry from the QofCollection — it does NOT detach
+            # the entry from the invoice's internal entry list. Without
+            # RemoveEntry, `gncInvoicePostToAccount` later iterates a list
+            # that still contains the now-dangling pointer and segfaults
+            # (reproduced on GnuCash 3.8 / ubuntu20).
+            invoice = existing
+            for old_entry in list(invoice.GetEntries()):
+                invoice.RemoveEntry(old_entry)
+                old_entry.Destroy()
         invoice.BeginEdit()
         invoice.SetDateOpened(datetime.strptime(directive.metadata['date_opened'], "%Y-%m-%d"))
 
@@ -1272,7 +1346,11 @@ class GnuCashImporter:
                        if k not in KNOWN_INVOICE_METADATA_KEYS and v is not None}
         if custom_meta:
             set_custom_metadata(invoice, custom_meta)
-        logging.debug(f"Created invoice {directive.props['id']}")
+        logging.debug(
+            f"{'Updated' if status_on_success == 'updated' else 'Created'} "
+            f"invoice {directive.props['id']}"
+        )
+        return status_on_success
 
     @staticmethod
     def import_bill(directive: PlaintextDirective, book: Book):
@@ -1281,22 +1359,27 @@ class GnuCashImporter:
 
         bill_id = directive.props['id']
 
-        # Resolve identity (Q-007): apply id ⇔ guid agreement rules and
-        # detect pre-existing duplicates. On a hit we SKIP rather than
-        # update — bills have AP lots wired into a real transaction.
+        # Resolve identity (Q-007): id ⇔ guid agreement, duplicate detection.
         # `book.InvoiceLookupByID` is unsuitable here: it returns None for
-        # vendor bills (only customer invoices), so the pre-Q-007 skip
-        # logic was silently broken — re-importing the same bill file
-        # would create a duplicate every time.
+        # vendor bills (only customer invoices), so we use a Query filtered
+        # by owner-type 4 — see _find_bills_by_id.
         existing, must_set_guid = _resolve_existing_or_none(
             'bill', bill_id, directive.metadata.get('guid'),
             lambda i: _find_bills_by_id(book, i),
             lambda g: _find_bill_by_guid(book, g),
             get_guid_str=_swig_invoice_guid_str,
         )
+
+        # Q-007 follow-up: existing posted bill is immutable (its AP lot is
+        # wired into a real transaction). Existing UNPOSTED bill can be
+        # updated — replace entries, optionally post, optionally pay. Same
+        # rationale as the invoice path above.
+        status_on_success = 'created'
         if existing is not None:
-            logging.debug(f"Bill {bill_id} already exists, skipping")
-            return
+            if existing.GetPostedTxn() is not None:
+                logging.debug(f"Bill {bill_id} already exists and is posted; skipping")
+                return 'skipped'
+            status_on_success = 'updated'
 
         # Validate: posted: none and a real posted: block are contradictory
         has_posted_none = directive.metadata.get('posted') == 'none'
@@ -1315,17 +1398,25 @@ class GnuCashImporter:
         if has_posted_none and payment_children:
             raise ValueError(f'Bill {bill_id}: cannot have payment: blocks on an unposted bill (posted: none)')
 
-        # Bills are Invoice objects whose owner is a Vendor (no separate Bill class)
-        vendor = _resolve_cross_reference(
-            'vendor',
-            directive.metadata.get('vendor_id'),
-            directive.metadata.get('vendor_guid'),
-            lambda i: _find_vendors_by_id(book, i),
-            lambda g: _find_vendor_by_guid(book, g),
-        )
-        bill = Invoice(book, bill_id, book.get_table().lookup("CURRENCY", directive.metadata['currency']), vendor)
-        if must_set_guid is not None:
-            _set_object_guid(book, bill, 'bill', bill_id, must_set_guid)
+        if existing is None:
+            # Bills are Invoice objects whose owner is a Vendor (no separate Bill class)
+            vendor = _resolve_cross_reference(
+                'vendor',
+                directive.metadata.get('vendor_id'),
+                directive.metadata.get('vendor_guid'),
+                lambda i: _find_vendors_by_id(book, i),
+                lambda g: _find_vendor_by_guid(book, g),
+            )
+            bill = Invoice(book, bill_id, book.get_table().lookup("CURRENCY", directive.metadata['currency']), vendor)
+            if must_set_guid is not None:
+                _set_object_guid(book, bill, 'bill', bill_id, must_set_guid)
+        else:
+            # Existing unposted bill: reuse it, drop its current entries.
+            # NOTE: SWIG `Invoice.RemoveEntry` wraps `gncInvoiceRemoveEntry`
+            # which only handles customer invoices. For vendor bills we
+            # need `gncBillRemoveEntry` via ctypes — see _bill_remove_entry.
+            bill = existing
+            _bill_remove_all_entries(book, bill)
         bill.BeginEdit()
         bill.SetDateOpened(datetime.strptime(directive.metadata['date_opened'], "%Y-%m-%d"))
 
@@ -1415,44 +1506,75 @@ class GnuCashImporter:
                        if k not in KNOWN_BILL_METADATA_KEYS and v is not None}
         if custom_meta:
             set_custom_metadata(bill, custom_meta)
-        logging.debug(f"Created bill {directive.props['id']}")
+        logging.debug(
+            f"{'Updated' if status_on_success == 'updated' else 'Created'} "
+            f"bill {directive.props['id']}"
+        )
+        return status_on_success
 
-    def import_business_objects(self, directives: List[PlaintextDirective], book: Book):
-        # Import customers and vendors first
+    def import_business_objects(self, directives: List[PlaintextDirective], book: Book,
+                                 on_directive_status=None):
+        """Import every business-object directive and report per-record status.
+
+        `on_directive_status(kind, id, status)` is invoked once per directive
+        with kind ∈ {'customer','vendor','taxtable','invoice','bill'} and
+        status ∈ {'created','updated','skipped'}. Default is no-op for
+        library callers; the CLI passes a callback that prints
+        '<kind> "<id>": <status>' lines so the user sees activity inline.
+
+        Returns a `BusinessObjectImportResult` with per-type counts so the
+        caller can render an aggregate summary at the end of the import.
+        """
+        cb = on_directive_status or (lambda *_: None)
+        result = BusinessObjectImportResult()
+
+        # Customers and vendors first (invoices/bills depend on them)
         for directive in directives:
             if directive.type == DirectiveType.CUSTOMER:
                 cid = directive.props.get('id', '?')
                 try:
-                    self.import_customer(directive, book)
+                    status = self.import_customer(directive, book)
                 except Exception as e:
                     raise ValueError(f'customer "{cid}": {e}') from e
+                result.tally('customer', status)
+                cb('customer', cid, status)
             elif directive.type == DirectiveType.VENDOR:
                 vid = directive.props.get('id', '?')
                 try:
-                    self.import_vendor(directive, book)
+                    status = self.import_vendor(directive, book)
                 except Exception as e:
                     raise ValueError(f'vendor "{vid}": {e}') from e
+                result.tally('vendor', status)
+                cb('vendor', vid, status)
 
         # Then tax tables
         for directive in directives:
             if directive.type == DirectiveType.TAXTABLE:
                 tname = directive.props.get('name', '?')
                 try:
-                    self.import_taxtable(directive, book)
+                    status = self.import_taxtable(directive, book)
                 except Exception as e:
                     raise ValueError(f'taxtable "{tname}": {e}') from e
+                result.tally('taxtable', status)
+                cb('taxtable', tname, status)
 
         # Finally, invoices and bills
         for directive in directives:
             if directive.type == DirectiveType.INVOICE:
                 iid = directive.props.get('id', '?')
                 try:
-                    self.import_invoice(directive, book)
+                    status = self.import_invoice(directive, book)
                 except Exception as e:
                     raise ValueError(f'invoice "{iid}": {e}') from e
+                result.tally('invoice', status)
+                cb('invoice', iid, status)
             elif directive.type == DirectiveType.BILL:
                 bid = directive.props.get('id', '?')
                 try:
-                    self.import_bill(directive, book)
+                    status = self.import_bill(directive, book)
                 except Exception as e:
                     raise ValueError(f'bill "{bid}": {e}') from e
+                result.tally('bill', status)
+                cb('bill', bid, status)
+
+        return result

--- a/tests/integration/test_business_object_idempotent_reimport.py
+++ b/tests/integration/test_business_object_idempotent_reimport.py
@@ -1104,7 +1104,236 @@ class TestTaxTableIdentityEnforcement:
         r = _import_new(runner, gnc, fix)
         if r.exit_code == 0:
             text = _exported_biz_text(runner, tmp_path, gnc)
-            assert _count_blocks(text, 'taxtable "GST"') == 1, (
-                f"Two same-name taxtable directives must not produce two "
-                f"records.\nExport:\n{text}"
-            )
+            assert _count_blocks(text, 'taxtable "GST"') == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Q-007 follow-up: unposted → posted transition must be allowed
+#
+# Q-007 introduced "skip on existing invoice/bill" so that posted records
+# (whose AR/AP lots are wired into a real transaction) can't be silently
+# mutated. That was right for the posted case but wrong for the unposted
+# case — a user's natural workflow is:
+#
+#   1. import invoice with `posted: none`
+#   2. edit the file: replace `posted: none` with a real `posted:` block
+#   3. re-import
+#
+# Reported by an external user. After Q-007 step 3 silently skipped,
+# leaving the invoice unposted forever. These tests describe the desired
+# behaviour: the importer should *allow* the unposted → posted transition
+# (no AR/AP lot exists yet to corrupt) but keep skipping when the existing
+# record is already posted.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_INVOICE_UNPOSTED = """
+customer "C001"
+\tname: "Acme"
+\tcurrency: CAD
+
+invoice "INV-001"
+\tcustomer_id: "C001"
+\tcurrency: CAD
+\tdate_opened: 2026-01-01
+\tentry:
+\t\tdate: 2026-01-01
+\t\tdescription: "Service"
+\t\taction: "Hours"
+\t\taccount: "Income:Sales"
+\t\tquantity: 1
+\t\tprice: 100
+\t\ttaxable: false
+\t\ttax_included: false
+\tposted: none
+\tpayment: none
+"""
+
+
+_INVOICE_POSTED = """
+customer "C001"
+\tname: "Acme"
+\tcurrency: CAD
+
+invoice "INV-001"
+\tcustomer_id: "C001"
+\tcurrency: CAD
+\tdate_opened: 2026-01-01
+\tentry:
+\t\tdate: 2026-01-01
+\t\tdescription: "Service"
+\t\taction: "Hours"
+\t\taccount: "Income:Sales"
+\t\tquantity: 1
+\t\tprice: 100
+\t\ttaxable: false
+\t\ttax_included: false
+\tposted:
+\t\tdate: 2026-01-01
+\t\tdue: 2026-01-31
+\t\tar_account: "Assets:Accounts Receivable"
+\t\tmemo: "Invoice INV-001"
+\t\taccumulate: true
+\tpayment: none
+"""
+
+
+_BILL_UNPOSTED = """
+vendor "V001"
+\tname: "Supplier"
+\tcurrency: CAD
+
+bill "BILL-001"
+\tvendor_id: "V001"
+\tcurrency: CAD
+\tdate_opened: 2026-01-01
+\tentry:
+\t\tdate: 2026-01-01
+\t\tdescription: "Supplies"
+\t\taccount: "Expenses:Supplies"
+\t\tquantity: 1
+\t\tprice: 50
+\t\ttaxable: true
+\t\ttax_included: false
+\tposted: none
+\tpayment: none
+"""
+
+
+_BILL_POSTED = """
+vendor "V001"
+\tname: "Supplier"
+\tcurrency: CAD
+
+bill "BILL-001"
+\tvendor_id: "V001"
+\tcurrency: CAD
+\tdate_opened: 2026-01-01
+\tentry:
+\t\tdate: 2026-01-01
+\t\tdescription: "Supplies"
+\t\taccount: "Expenses:Supplies"
+\t\tquantity: 1
+\t\tprice: 50
+\t\ttaxable: true
+\t\ttax_included: false
+\tposted:
+\t\tdate: 2026-01-01
+\t\tdue: 2026-01-31
+\t\tap_account: "Liabilities:Accounts Payable"
+\t\tmemo: "Bill BILL-001"
+\t\taccumulate: true
+\tpayment: none
+"""
+
+
+class TestUnpostedToPostedTransition:
+    """Re-import must allow the unposted→posted transition (Q-007 fix)."""
+
+    def test_invoice_unposted_can_be_posted_via_reimport(self, tmp_path):
+        """Step 1: import invoice with `posted: none`. Step 2: re-import same
+        invoice but with a real `posted:` block. Expected: the existing
+        invoice is now posted, not silently skipped."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _INVOICE_UNPOSTED)
+        # Confirm baseline: invoice exists and is unposted
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        block = _block_for(text, 'invoice "INV-001"')
+        assert any('posted: none' in line for line in block), (
+            "Setup expected unposted invoice; got:\n" + "\n".join(block)
+        )
+
+        # Re-import with a real posted block
+        r = _import(runner, gnc, _write(tmp_path / "post.txt",
+                                        ACCOUNTS + "\n" + _INVOICE_POSTED))
+        assert r.exit_code == 0, f"Posting via re-import must succeed:\n{r.output}"
+
+        # The existing invoice should now have a posted: block (not 'posted: none')
+        text2 = _exported_biz_text(runner, tmp_path, gnc)
+        block2 = _block_for(text2, 'invoice "INV-001"')
+        assert _count_blocks(text2, 'invoice "INV-001"') == 1, (
+            "Posting must not duplicate the invoice"
+        )
+        assert any('posted:' in line and 'posted: none' not in line
+                   for line in block2), (
+            "Invoice must be posted after re-import; block:\n"
+            + "\n".join(block2)
+        )
+
+    def test_bill_unposted_can_be_posted_via_reimport(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _BILL_UNPOSTED)
+
+        r = _import(runner, gnc, _write(tmp_path / "post.txt",
+                                        ACCOUNTS + "\n" + _BILL_POSTED))
+        assert r.exit_code == 0, f"Posting via re-import must succeed:\n{r.output}"
+
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        block = _block_for(text, 'bill "BILL-001"')
+        assert _count_blocks(text, 'bill "BILL-001"') == 1
+        assert any('posted:' in line and 'posted: none' not in line
+                   for line in block), (
+            "Bill must be posted after re-import; block:\n" + "\n".join(block)
+        )
+
+    def test_already_posted_invoice_still_skips_on_reimport(self, tmp_path):
+        """No regression: re-importing a file containing an already-posted
+        invoice still skips (its lot is wired into a real transaction and
+        we can't safely mutate)."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _INVOICE_POSTED)
+
+        r = _import(runner, gnc, _write(tmp_path / "again.txt",
+                                        ACCOUNTS + "\n" + _INVOICE_POSTED))
+        assert r.exit_code == 0
+        assert 'invoice "INV-001": skipped' in r.output, (
+            f"Re-import of posted invoice should still skip:\n{r.output}"
+        )
+
+    def test_already_posted_bill_still_skips_on_reimport(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _BILL_POSTED)
+
+        r = _import(runner, gnc, _write(tmp_path / "again.txt",
+                                        ACCOUNTS + "\n" + _BILL_POSTED))
+        assert r.exit_code == 0
+        assert 'bill "BILL-001": skipped' in r.output
+
+    def test_unposted_to_posted_status_line_says_updated(self, tmp_path):
+        """When re-import successfully posts an unposted invoice, the
+        per-directive status line should say 'updated' (not 'skipped' and
+        not 'created' — the record already existed and was modified)."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _INVOICE_UNPOSTED)
+
+        r = _import(runner, gnc, _write(tmp_path / "post.txt",
+                                        ACCOUNTS + "\n" + _INVOICE_POSTED))
+        assert r.exit_code == 0
+        assert 'invoice "INV-001": updated' in r.output, (
+            f"Posting an unposted invoice should report 'updated':\n{r.output}"
+        )
+
+    def test_posted_invoice_notes_not_mutated_on_reimport(self, tmp_path):
+        """Posted = fully immutable. Even non-accounting fields like notes
+        must NOT be mutated on re-import — a posted invoice represents what
+        the customer already received, and silently changing notes after
+        the fact would mislead a maintainer reading the book."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _INVOICE_POSTED)
+        # Re-import with notes added to the posted invoice
+        with_notes = _INVOICE_POSTED.replace(
+            'invoice "INV-001"\n',
+            'invoice "INV-001"\n\tnotes: "Updated after the fact"\n',
+        )
+        r = _import(runner, gnc, _write(tmp_path / "with_notes.txt",
+                                        ACCOUNTS + "\n" + with_notes))
+        assert r.exit_code == 0, r.output
+        # Status line says skipped — nothing changed
+        assert 'invoice "INV-001": skipped' in r.output
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        block = _block_for(text, 'invoice "INV-001"')
+        # Notes from the directive must NOT appear in the exported invoice
+        assert not any('Updated after the fact' in line for line in block), (
+            "Posted invoice's notes must not be mutated on re-import; got:\n"
+            + "\n".join(block)
+        )

--- a/tests/integration/test_business_object_import_summary.py
+++ b/tests/integration/test_business_object_import_summary.py
@@ -1,0 +1,182 @@
+"""
+Q-009: business-object import gives clear feedback on every directive.
+
+Tests describe the desired CLI output after Q-009. On import, the user
+should see two complementary signals:
+
+1. **Per-directive line, inline as the import runs:**
+
+       customer "C001": created
+       customer "C002": updated
+       taxtable "GST": skipped (already exists)
+       invoice "INV-001": created
+       bill "BILL-001": skipped (already exists)
+
+   Same shape as the per-record output from delete-customers /
+   archive-customers.
+
+2. **Aggregate counts in the import summary at the end:**
+
+       Business Objects:
+         Customers:  1 created, 1 updated, 0 skipped
+         Vendors:    0 created, 1 updated, 0 skipped
+         Tax tables: 0 created, 1 skipped
+         Invoices:   1 created, 1 skipped
+         Bills:      0 created, 1 skipped
+
+These tests don't introspect the gnucash file at all — they're
+purely about CLI surface output. The other identity tests in
+test_business_object_idempotent_reimport.py already cover the
+underlying behaviour.
+"""
+
+import re
+import time
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURE = "tests/fixtures/business_objects.txt"
+
+
+def _import_new(runner, gnc):
+    return runner.invoke(cli, ["import", "--new", str(gnc), FIXTURE,
+                               "--include-business-objects"])
+
+
+def _reimport(runner, gnc):
+    return runner.invoke(cli, ["import", str(gnc), FIXTURE,
+                               "--include-business-objects"])
+
+
+# ── Per-directive output ────────────────────────────────────────────────────
+
+
+class TestPerDirectiveOutput:
+    """Each business-object directive emits a status line as it imports."""
+
+    def test_fresh_import_shows_created_for_each_directive(self, tmp_path):
+        runner = CliRunner()
+        gnc = tmp_path / "test.gnucash"
+        r = _import_new(runner, gnc)
+        assert r.exit_code == 0, r.output
+        # Fixture has customers "1" and "2", vendor V001 and V002,
+        # taxtable GST, invoices INV-2026-001..005, bills BILL-2026-001..005
+        for line_substr in [
+            'customer "1": created',
+            'customer "2": created',
+            'vendor "V001": created',
+            'vendor "V002": created',
+            'taxtable "GST": created',
+            'invoice "INV-2026-001": created',
+            'bill "BILL-2026-001": created',
+        ]:
+            assert line_substr in r.output, (
+                f"Expected {line_substr!r} in import output:\n{r.output}"
+            )
+
+    def test_reimport_shows_updated_for_customers_vendors(self, tmp_path):
+        """Customers and vendors update on re-import (id is constant; mutable
+        fields are refreshed). Status line says 'updated', not 'skipped'."""
+        runner = CliRunner()
+        gnc = tmp_path / "test.gnucash"
+        r1 = _import_new(runner, gnc)
+        assert r1.exit_code == 0
+        time.sleep(1)  # GnuCash backup-timestamp safety
+
+        r2 = _reimport(runner, gnc)
+        assert r2.exit_code == 0, r2.output
+        assert 'customer "1": updated' in r2.output
+        assert 'vendor "V001": updated' in r2.output
+
+    def test_reimport_shows_skipped_for_taxtable_invoice_bill(self, tmp_path):
+        """Tax tables, invoices, and bills skip on re-import (their fields
+        can't be safely mutated mid-flight)."""
+        runner = CliRunner()
+        gnc = tmp_path / "test.gnucash"
+        r1 = _import_new(runner, gnc)
+        assert r1.exit_code == 0
+        time.sleep(1)
+
+        r2 = _reimport(runner, gnc)
+        assert r2.exit_code == 0, r2.output
+        assert 'taxtable "GST": skipped' in r2.output
+        assert 'invoice "INV-2026-001": skipped' in r2.output
+        assert 'bill "BILL-2026-001": skipped' in r2.output
+
+
+# ── Aggregate summary ───────────────────────────────────────────────────────
+
+
+class TestAggregateSummary:
+    """Import summary includes a Business Objects section with counts."""
+
+    def test_fresh_import_summary_counts(self, tmp_path):
+        """Fresh import → all counts on the 'created' line, none on 'updated'
+        or 'skipped'."""
+        runner = CliRunner()
+        gnc = tmp_path / "test.gnucash"
+        r = _import_new(runner, gnc)
+        assert r.exit_code == 0
+        # Summary mentions a Business Objects section
+        assert 'Business Objects' in r.output, r.output
+        # Customers: 2 created in the fixture
+        assert re.search(r'Customers:\s+2 created', r.output), (
+            f"Expected 'Customers: 2 created' line; got:\n{r.output}"
+        )
+        # Vendors: 2 created
+        assert re.search(r'Vendors:\s+2 created', r.output)
+        # Tax tables: 1 created
+        assert re.search(r'Tax tables:\s+1 created', r.output)
+        # Invoices: 5 created
+        assert re.search(r'Invoices:\s+5 created', r.output)
+        # Bills: 5 created
+        assert re.search(r'Bills:\s+5 created', r.output)
+
+    def test_reimport_summary_counts(self, tmp_path):
+        """Re-import: customers/vendors update on hit; tax tables always
+        skip; invoices/bills skip when posted, but the fixture's unposted
+        records (INV-2026-002, BILL-2026-002) go through the unposted→
+        update path added in the Q-007 follow-up, so they show 'updated'."""
+        runner = CliRunner()
+        gnc = tmp_path / "test.gnucash"
+        r1 = _import_new(runner, gnc)
+        assert r1.exit_code == 0
+        time.sleep(1)
+
+        r2 = _reimport(runner, gnc)
+        assert r2.exit_code == 0
+        # Customers: 0 created, 2 updated, 0 skipped
+        assert re.search(r'Customers:\s+0 created,\s*2 updated', r2.output)
+        # Vendors: 0 created, 2 updated, 0 skipped
+        assert re.search(r'Vendors:\s+0 created,\s*2 updated', r2.output)
+        # Tax tables: 0 created, 0 updated, 1 skipped
+        assert re.search(r'Tax tables:\s+0 created,.*1 skipped', r2.output)
+        # Invoices: 0 created, 1 updated, 4 skipped
+        # (INV-2026-002 is unposted in the fixture — re-import re-runs the
+        # unposted-update path; the other 4 are posted and skip)
+        assert re.search(r'Invoices:\s+0 created,\s*1 updated,\s*4 skipped',
+                         r2.output)
+        # Bills: 0 created, 1 updated, 4 skipped (BILL-2026-002 is unposted)
+        assert re.search(r'Bills:\s+0 created,\s*1 updated,\s*4 skipped',
+                         r2.output)
+
+    def test_summary_appears_after_per_directive_lines(self, tmp_path):
+        """Per-directive output comes first; aggregate summary at the end.
+
+        Order matters for terminal UX — users see the activity stream as
+        the import runs, and the summary is the final word."""
+        runner = CliRunner()
+        gnc = tmp_path / "test.gnucash"
+        r = _import_new(runner, gnc)
+        assert r.exit_code == 0
+
+        idx_per_dir = r.output.find('customer "1": created')
+        idx_summary = r.output.find('Business Objects')
+        assert idx_per_dir != -1 and idx_summary != -1
+        assert idx_per_dir < idx_summary, (
+            f"Per-directive lines must come before the aggregate summary. "
+            f"Got per-directive at {idx_per_dir}, summary at {idx_summary}."
+        )


### PR DESCRIPTION
Two related changes folded into one commit because they share the test file and the second was uncovered while writing tests for the first. A third bug — silent dangling pointers in the bill entry list — was caught by ubuntu20 CI and is also fixed here.

## Q-009 — Per-directive status lines + aggregate counts

Reported by another user reviewing Q-007/Q-008:

> Real create: delta=+514 bytes (file grew by 514 bytes)
> Q-007 skip: delta=+0 bytes (file unchanged)
> stdout: byte-identical
> stderr: byte-identical

The CLI gave zero signal whether a re-import did anything. This commit adds two complementary signals:

### Per-directive status lines, inline as the import runs

```
Importing business objects...
customer "C001": created
customer "C002": updated
vendor "V001": updated
taxtable "GST": skipped
invoice "INV-2026-001": skipped
bill "BILL-2026-001": created
```

Mirrors the per-record output of `delete-customers` / `archive-…`.

### Aggregate counts in the import summary at the end

```
Business Objects:
  Customers:   1 created, 1 updated, 0 skipped
  Vendors:     0 created, 1 updated, 0 skipped
  Tax tables:  0 created, 0 updated, 1 skipped
  Invoices:    0 created, 1 updated, 1 skipped
  Bills:       1 created, 0 updated, 0 skipped
```

All three columns emitted for every type. Section is only printed when business objects were actually processed.

### Implementation

- Each `import_X` (customer, vendor, taxtable, invoice, bill) now returns `'created'`, `'updated'`, or `'skipped'` instead of None.
- New `BusinessObjectImportResult` dataclass with `tally(kind, status)` helper.
- `import_business_objects` accepts an optional `on_directive_status(kind, id, status)` callback. Library callers get a no-op default; the CLI passes a callback that prints the per-directive line.

## Q-007 follow-up — unposted → posted via re-import

Reported by an external user during review:

> they cannot change unposted invoice to posted by re-import now!

Q-007's "skip on existing invoice/bill" rule was right for posted records (their AR/AP lots are wired into a real transaction) but wrong for unposted records. The natural workflow is:

  1. import invoice with `posted: none`
  2. edit the file: replace `posted: none` with a real `posted:` block
  3. re-import → silently skipped, leaving the invoice unposted

The new rule:

| State | Re-import behaviour |
|---|---|
| Posted | Skip — entries, posted block, and metadata are all locked | | Unposted | Update — drop entries, re-add from directive, post if directive has a `posted:` block, apply payments if present |

Safe because:

- Unposted invoices/bills have no AR/AP lot or transaction yet, so mutating their entries is a no-op accounting-wise.
- Entry GUIDs are not exported in the plaintext format and nothing else in the codebase references entries by GUID (verified by grep), so the destructive "drop and re-add" approach loses no identity that anything could observe.

The customer/vendor cross-reference stays whatever the existing record already had — re-import isn't allowed to change ownership.

## Subbug — bill entry list dangling pointers (caught by ubuntu20 CI)

While implementing the unposted→posted path, the bill test segfaulted on ubuntu20 (GnuCash 3.8) inside `gncInvoicePostToAccount` after `entry.Destroy()` calls. Root cause: `gncEntryDestroy` removes the entry from the QofCollection but does NOT detach it from the parent invoice/bill's internal entry list. The next iteration of that list dereferences a dangling pointer.

The bug exists on every platform; ubuntu20 just crashes visibly, newer GnuCash gets memory-layout luck or null-checks. Fix:

- Customer invoices: call `invoice.RemoveEntry(entry)` (SWIG, wraps `gncInvoiceRemoveEntry`) before `entry.Destroy()`.
- Vendor bills: SWIG `Invoice.RemoveEntry` is customer-only — wraps the wrong C function for bills. Bills need `gncBillRemoveEntry` via ctypes (new `_bill_remove_all_entries` helper).

Same wrong-API-presents-as-unified-class pattern as `book.InvoiceLookupByID` not finding bills (Q-007 finding).

## Tests

`tests/integration/test_business_object_import_summary.py` (new): 6 tests for Q-009 — fresh import per-directive output, re-import all-skip / all-update output, aggregate summary counts, order invariant.

`tests/integration/test_business_object_idempotent_reimport.py` gains a new `TestUnpostedToPostedTransition` class with 6 tests: unposted invoice + bill posting via re-import, posted invoice + bill still skip on identical re-import (no regression), status line says 'updated' on the transition, posted invoice's notes are NOT mutated even if directive supplies new ones.

Two existing Q-009 reimport tests adjusted because INV-2026-002 and BILL-2026-002 in the fixture are unposted, so they now go through the update path (1 updated, 4 skipped instead of 5 skipped).

Full suite: 864 passed on debian13 (latest) AND ubuntu20 (3.8).

## Documentation

- `README.md` — "Import and export business objects" section shows the new output format with worked examples; the "Re-import semantics" matrix splits the invoice/bill row into posted (skip) vs unposted (update) variants.
- `docs/issues/README.md` — index updated to add Q-006, Q-007, Q-008, Q-009 (they weren't there) and remove a duplicated Q-004.
- `docs/issues/Q-009-import-summary-business-objects.md` — design doc.
- `docs/DEBUGGING_GNUCASH_BINDINGS.md` — new finding (8) on `gncEntryDestroy` not detaching from the parent's list, with customer-vs-vendor RemoveEntry asymmetry. Closing summary list gains entry 14.
- `docs/post-mortems/2026-05-08-bill-postto-account-segfault.md` (new directory + first post-mortem) — documents the workaround- vs-root-cause investigation, sections on how the finding accelerates future debugging, and why multi-distro CI is the load-bearing safety net for the project's "works on any supported GnuCash" promise.