### PR TITLE
feat(Q-010): strict 'unchanged' status; mutable posted invoices/bills + unpost CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,28 +689,32 @@ is processed, plus an aggregate summary at the end:
 ```
 Importing business objects...
 customer "C001": created
-customer "C002": updated
+customer "C002": unchanged
 vendor "V001": updated
 taxtable "GST": skipped
-invoice "INV-2026-001": skipped
+invoice "INV-2026-001": unchanged
 bill "BILL-2026-001": created
 
 ...
 
 Business Objects:
-  Customers:   1 created, 1 updated, 0 skipped
-  Vendors:     0 created, 1 updated, 0 skipped
-  Tax tables:  0 created, 0 updated, 1 skipped
-  Invoices:    0 created, 1 updated, 1 skipped
-  Bills:       1 created, 0 updated, 0 skipped
+  Customers:   1 created, 0 updated, 1 unchanged, 0 skipped
+  Vendors:     0 created, 1 updated, 0 unchanged, 0 skipped
+  Tax tables:  0 created, 0 updated, 0 unchanged, 1 skipped
+  Invoices:    0 created, 0 updated, 1 unchanged, 0 skipped
+  Bills:       1 created, 0 updated, 0 unchanged, 0 skipped
 ```
 
-`updated` for invoice/bill means the record was unposted before
-re-import and is now posted (or its entries were rebuilt) — the
-unposted→posted transition is allowed, but a posted invoice/bill
-always either skips or creates because its AR/AP lot can't be safely
-mutated. Tax tables only ever create or skip. See "Re-import
-semantics" below for the full state matrix.
+The four-status model:
+
+| Status | Meaning |
+|---|---|
+| `created` | Fresh record created — no record with this id existed. |
+| `updated` | Existing record had at least one mutable field changed. For posted invoices/bills this includes the unpost-edit-repost cycle (matches GnuCash's own UI behaviour). |
+| `unchanged` | Existing record matches the directive byte-for-byte — no work performed. The happy path for an idempotent re-run. |
+| `skipped` | Existing record is immutable for this directive; the importer refused to mutate it. Currently only **tax tables** report `skipped` — they're referenced by pointer from past posted invoices, so changing their entries would silently rewrite past accounting. |
+
+See "Re-import semantics" below for the full state matrix.
 
 Business objects use no date prefix — they are master data, not ledger
 events. Dates that belong to a record (e.g. `date_opened` on an invoice) are
@@ -905,16 +909,49 @@ errors with the conflict spelled out.
 
 #### Re-import semantics: idempotent, per object type
 
-Re-importing the same file is **idempotent** — but the exact behaviour
-varies by object type because some records have downstream
-dependencies that can't be safely mutated mid-flight:
+Re-importing the same file is **idempotent** — and the importer
+distinguishes between "no change needed" (`unchanged`) and "I refused
+your change" (`skipped`) so a re-run reports something meaningful:
 
-| Block | On hit (record already exists) |
-|---|---|
-| `customer`, `vendor` | **Update** mutable fields (name, address, active flag, custom KVP) in place. |
-| `taxtable` | **Skip**. Tax tables are referenced by stored pointers from posted invoices/bills; mutating their entries would silently change accounting on past posted records. |
-| `invoice`, `bill` (posted) | **Skip**. Posted records have AR/AP lots wired into a real transaction — entries, posted block, and mutable metadata are all locked. |
-| `invoice`, `bill` (unposted) | **Update**. Entries are rebuilt from the directive, fields refresh, and if the directive carries a real `posted:` block the record is posted as part of the same import. This is the natural workflow for "create draft → review → post" via plaintext edit + re-import. |
+| Block | Directive matches existing | Directive differs from existing |
+|---|---|---|
+| `customer`, `vendor` | `unchanged` (no-op) | `updated` (mutable fields refreshed: name, address, active flag, custom KVP). |
+| `taxtable` | `skipped` (refused) | `skipped` (refused). Tax tables are referenced by stored pointers from posted invoices/bills; mutating their entries would silently change accounting on past posted records. |
+| `invoice`, `bill` (unposted) | `unchanged` | `updated` (entries rebuilt; if the directive carries a real `posted:` block the record is posted in the same import). |
+| `invoice`, `bill` (posted) | `unchanged` | `updated` via **unpost → rebuild → repost**. Mirrors what the GnuCash UI itself supports: opening a posted invoice, unposting, editing, and reposting. The directive is the source of truth for the new posted state. As an optimisation: when the *only* difference is `posted: { ... }` → `posted: none` (entries and payments otherwise match), the importer takes a minimal-unpost path that preserves entry GUIDs (no destroy + recreate). |
+
+#### Unposting without re-importing: `unpost-invoices` / `unpost-bills`
+
+When you want to unpost without consulting any plaintext file (e.g. the
+`.txt` is stale, or you just need a one-shot operation), use the
+dedicated CLI commands:
+
+```
+gnucash-plaintext unpost-invoices ledger.gnucash INV-2026-001
+gnucash-plaintext unpost-bills    ledger.gnucash BILL-2026-001
+gnucash-plaintext unpost-invoices ledger.gnucash --by-guid 9f14a498cc894d50931f855a9a31d594
+```
+
+Behaviour:
+
+- Calls GnuCash's `Unpost(False)` directly. The posting transaction is
+  destroyed; payment transactions in the bank account remain but are
+  no longer linked to a lot. (Same end state as the GnuCash UI's
+  Unpost menu item.)
+- **Entry GUIDs are preserved** — entries are not destroyed and
+  recreated. External references to entries by GUID still resolve.
+- Per-record line: `<id> (<guid>): unposted` (or `not posted`,
+  `not found`, or `failed — multiple records share this id`).
+- Exit code 1 if any record was not found, not posted, or ambiguous;
+  successful unposts are still saved.
+
+Compared to the re-import path:
+
+| | Re-import (`posted: { ... }` → `posted: none`) | `unpost-invoices` / `unpost-bills` |
+|---|---|---|
+| Reads .txt? | Yes — directive entries replace existing | No |
+| Entry GUIDs | Preserved when only the posted block toggles; otherwise rebuilt | Always preserved |
+| Use when... | The .txt is your source of truth and may also edit fields | The .txt is stale/absent and you only want the unpost |
 
 In all cases the importer first verifies that the directive's identity
 agrees with whatever's already in the book. The following are caught

--- a/cli/import_cmd.py
+++ b/cli/import_cmd.py
@@ -203,6 +203,7 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
                     parts = [
                         f"{counts['created']} created",
                         f"{counts['updated']} updated",
+                        f"{counts['unchanged']} unchanged",
                         f"{counts['skipped']} skipped",
                     ]
                     click.echo(f"  {(label + ':'):<12} {', '.join(parts)}")

--- a/cli/main.py
+++ b/cli/main.py
@@ -20,6 +20,7 @@ from cli.import_beancount_cmd import import_beancount
 from cli.import_cmd import import_transactions
 from cli.income_statement_cmd import income_statement
 from cli.invoice_print_cmd import print_invoice
+from cli.unpost_cmd import unpost_bills, unpost_invoices
 from cli.validate_cmd import validate_ledger
 
 
@@ -62,6 +63,8 @@ cli.add_command(find_transactions, name='find-transactions')
 cli.add_command(delete_customers, name='delete-customers')
 cli.add_command(archive_customers, name='archive-customers')
 cli.add_command(archive_vendors, name='archive-vendors')
+cli.add_command(unpost_invoices, name='unpost-invoices')
+cli.add_command(unpost_bills, name='unpost-bills')
 
 
 if __name__ == '__main__':

--- a/cli/unpost_cmd.py
+++ b/cli/unpost_cmd.py
@@ -1,0 +1,117 @@
+"""
+CLI commands for unposting invoices and bills (Q-010).
+
+unpost-invoices / unpost-bills
+    Unpost one or more posted records by ID (or GUID with --by-guid).
+    Calls GnuCash's Unpost(False) directly — does NOT consult any
+    plaintext file. Entry GUIDs are preserved.
+
+    Exit code 1 if any ID was not found, not posted, or ambiguous.
+
+Per-ID output examples:
+    INV-001 (abc123…): unposted
+    INV-002 (def456…): not posted (already unposted)
+    INV-003: not found
+    INV-004: failed — multiple records share this id; rerun with --by-guid
+
+This complements the re-import path: changing `posted: { ... }` to
+`posted: none` in a .txt and re-importing also unposts, but it
+rebuilds entries from the .txt. Use this command when the .txt is
+stale or absent and you only want the unpost itself.
+"""
+
+import sys
+
+import click
+
+from infrastructure.gnucash.guid_lookup import normalise_guid
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from use_cases.unpost_business_objects import (
+    UnpostBillsUseCase,
+    UnpostInvoicesUseCase,
+    UnpostStatus,
+)
+
+
+def _normalise_guids(guids):
+    out = []
+    for g in guids:
+        try:
+            out.append(normalise_guid(g))
+        except ValueError as e:
+            raise click.ClickException(str(e)) from e
+    return out
+
+
+def _run_unpost(gnucash_file, ids, use_case_cls, by_guid=False):
+    ids = _normalise_guids(ids) if by_guid else list(ids)
+    repo = GnuCashRepository(gnucash_file)
+    repo.open(mode=SessionMode.NORMAL)
+    try:
+        use_case = use_case_cls(repo.book)
+        results = use_case.execute(ids, by_guid=by_guid)
+
+        all_ok = True
+        for r in results:
+            click.echo(f'{r.label()}: {r.message()}')
+            if r.status != UnpostStatus.UNPOSTED:
+                all_ok = False
+
+        if any(r.status == UnpostStatus.UNPOSTED for r in results):
+            try:
+                repo.save()
+            except Exception as e:
+                if 'ERR_FILEIO_BACKUP_ERROR' not in str(e):
+                    raise click.ClickException(f'Failed to save: {e}') from e
+
+        if not all_ok:
+            sys.exit(1)
+    finally:
+        repo.close()
+
+
+@click.command('unpost-invoices')
+@click.argument('gnucash_file', type=click.Path(exists=True))
+@click.argument('ids', nargs=-1, required=True)
+@click.option('--by-guid', is_flag=True, default=False,
+              help='Treat positional args as invoice GUIDs instead of invoice numbers.')
+def unpost_invoices(gnucash_file, ids, by_guid):
+    """
+    Unpost one or more posted customer invoices.
+
+    Destroys the posting transaction. Payment transactions in the bank
+    account remain but become orphaned (no longer linked to a lot) —
+    same as GnuCash's UI Unpost.
+
+    Entry GUIDs are preserved (no destroy + recreate).
+
+    Exit code 1 if any record was not found, not posted, or ambiguous.
+
+    \b
+    Examples:
+      gnucash-plaintext unpost-invoices ledger.gnucash INV-2026-001
+      gnucash-plaintext unpost-invoices ledger.gnucash INV-001 INV-002
+      gnucash-plaintext unpost-invoices ledger.gnucash --by-guid 9f14a498cc894d50931f855a9a31d594
+    """
+    _run_unpost(gnucash_file, ids, UnpostInvoicesUseCase, by_guid=by_guid)
+
+
+@click.command('unpost-bills')
+@click.argument('gnucash_file', type=click.Path(exists=True))
+@click.argument('ids', nargs=-1, required=True)
+@click.option('--by-guid', is_flag=True, default=False,
+              help='Treat positional args as bill GUIDs instead of bill numbers.')
+def unpost_bills(gnucash_file, ids, by_guid):
+    """
+    Unpost one or more posted vendor bills.
+
+    See unpost-invoices for behaviour details — the bill side is
+    symmetric (AP rather than AR).
+
+    \b
+    Examples:
+      gnucash-plaintext unpost-bills ledger.gnucash BILL-2026-001
+      gnucash-plaintext unpost-bills ledger.gnucash BILL-001 BILL-002
+      gnucash-plaintext unpost-bills ledger.gnucash --by-guid f66df24e6e75424ba08c2b0a47ec292c
+    """
+    _run_unpost(gnucash_file, ids, UnpostBillsUseCase, by_guid=by_guid)

--- a/docs/issues/Q-010-strict-updated-status-on-no-change-reimport.md
+++ b/docs/issues/Q-010-strict-updated-status-on-no-change-reimport.md
@@ -1,0 +1,209 @@
+---
+id: Q-010
+title: Q-009 'updated' status is liberal — reports 'updated' for no-change re-imports
+category: quality
+severity: low
+status: open
+---
+
+## Problem
+
+After Q-009, the importer reports `'created'`, `'updated'`, or
+`'skipped'` for each business-object directive. The status is meant
+to let scripts and humans tell at a glance whether something actually
+changed in the book.
+
+But `'updated'` is liberal: it means "the importer passed through
+the update code path", not "the record actually differs after
+import". A re-import of an unchanged file currently shows:
+
+```
+customer "C001": updated
+vendor "V001": updated
+invoice "INV-001": updated   (when unposted)
+```
+
+…even though nothing in the book changed. Reported by an external
+reviewer:
+
+> Q-009's updated is liberal. Scenarios 4 and 5 should have been
+> skipped per the README, but the actual implementation reports
+> updated. Practically irrelevant to us (we treat both the same),
+> but worth flagging upstream as a doc/code mismatch on their side.
+
+The README implies (with "Update mutable fields in place") that
+`'updated'` means "fields were updated". The code reports `'updated'`
+even when no field changed. CI scripts asserting "exactly N
+customers were updated" would over-count.
+
+## Proposed fix: introduce a fourth status, `'unchanged'`
+
+Tighten the code so `'updated'` means *"at least one mutable field
+differs and was changed"*. If the directive matches the existing
+record byte-for-byte, return a new status `'unchanged'`.
+
+The four-status model resolves an overload that Q-009 introduced:
+under Q-009, both "existing posted invoice — can't touch it" and
+"existing customer — already matches" would have collapsed into
+the same `'skipped'` bucket. They're semantically different:
+
+| Status | Meaning |
+|---|---|
+| `created` | Fresh record created. |
+| `updated` | Existing record had at least one mutable field changed. |
+| `unchanged` | Existing record matches the directive — nothing to do, no work performed. |
+| `skipped` | Existing record is immutable for this directive (e.g. posted invoice can't be re-edited). The user **wanted** a change but the record's state forbids it. |
+
+`unchanged` is the happy path for an idempotent re-run. `skipped`
+is "the importer chose not to apply your change because it isn't
+safe."
+
+Per object type:
+
+### Customer / Vendor
+
+Compare each mutable field before assigning:
+
+- name
+- addr1, addr2, addr3, addr4, email (customer only)
+- active flag
+- custom KVP slots
+
+If **any** differs, set it and mark `changed = True`. Final status:
+`'updated' if changed else 'skipped'`.
+
+### Tax table
+
+Already skips on hit (no entry mutation supported, ever). No code
+change.
+
+### Invoice / Bill (existing unposted)
+
+The current code unconditionally destroys all entries and rebuilds
+them from the directive — even when entries match. Two things to
+fix:
+
+1. **Add a pre-check helper** `_invoice_matches_directive(invoice,
+   directive)` that returns True when:
+   - `date_opened`, `billing_id`, `notes`, custom KVP all match
+   - existing entry count == directive entry count, and each entry
+     matches positionally on date, description, action, account,
+     quantity, price, taxable, tax_included, and tax_table
+   - directive has no `posted:` block (otherwise posting would
+     transition state — definitely a change)
+   - directive has no `payment:` block
+   If True → return `'skipped'` early; do not touch the book.
+
+2. **Otherwise** do the destroy+rebuild as before, return
+   `'updated'`.
+
+Same shape for bills (`_bill_matches_directive`).
+
+### Invoice / Bill (existing posted)
+
+**Pre-Q-010 (Q-007 status quo)**: existing posted invoice/bill is
+treated as immutable — re-import returns `'skipped'`.
+
+**Gap closed by Q-010**: GnuCash's UI itself supports unpost → edit →
+repost. The pre-Q-010 importer made every posted invoice/bill a
+permanent dead-end for re-imports. Common user flow that broke:
+
+1. User imports invoice with a posted block (creates AR posting tx).
+2. User notices a typo in the entry (wrong quantity, wrong account).
+3. User edits the .txt and re-imports.
+4. Pre-Q-010: silent `skipped` — change not applied, no warning.
+
+**Q-010 behaviour**: an existing posted invoice/bill is now treated
+the same way GnuCash treats it — mutable via unpost-edit-repost.
+
+| Existing | Directive | Action | Status |
+|---|---|---|---|
+| posted, fields match | posted: same block, same entries, same payments | no-op | `unchanged` |
+| posted, fields differ | posted: { ... } different | `Unpost(False)` → rebuild entries → `PostToAccount(...)` → re-apply payments per directive | `updated` |
+| posted | `posted: none` | `Unpost(False)` → rebuild entries → leave unposted | `updated` |
+
+Implementation in `import_invoice` / `import_bill`:
+
+```python
+if existing is not None:
+    if _invoice_matches_directive(existing, directive, book):
+        return 'unchanged'
+    if existing.GetPostedTxn() is not None:
+        # Unpost destroys the posting transaction. Payment transactions
+        # remain in the bank account but their AR/AP splits become
+        # orphaned (lot is gone). The directive's payment: block (if any)
+        # then drives re-application from scratch.
+        existing.Unpost(False)
+    status_on_success = 'updated'
+    # Fall through to existing rebuild + repost flow.
+```
+
+**Optimisation: minimal-unpost path.** When the *only* difference
+between existing and directive is `posted: { ... }` → `posted: none`
+(entries match, payments match, every other field matches), the
+importer takes a fast path: just `Unpost(False)`, no destroy and no
+rebuild. Result: **entry GUIDs are preserved**. Useful for users who
+edit the .txt to unpost (instead of edit+repost) without breaking
+external references. See `_is_only_unpost_diff` in
+`services/gnucash_importer.py`.
+
+**Dedicated CLI commands**: `unpost-invoices` and `unpost-bills` are
+also added in this PR (`cli/unpost_cmd.py`, `use_cases/
+unpost_business_objects.py`). They don't read any .txt — they call
+`Unpost(False)` directly. Use this when the .txt is stale or absent
+and you only want the unpost itself, or when you want to avoid
+destructive entry rebuilds even in edge cases the matcher doesn't
+cover. Per-record output mirrors `delete-customers`:
+
+```
+INV-2026-001 (abc123…): unposted
+INV-2026-002 (def456…): not posted (already unposted)
+INV-2026-003: not found
+```
+
+**Known limitation (Q-010 v1)**: payment transactions linked to the
+old lot are orphaned (not destroyed) by `Unpost` regardless of which
+path triggered the unpost. If the directive's new `payment:` block
+re-uses the same `txn_guid:`, retargeting still works. If the
+directive has no `payment:` block, the old payment transactions
+remain in bank but are no longer tied to the invoice. A future issue
+can add a "destroy orphan payment txns" cleanup if that turns out to
+be confusing in practice.
+
+## What this enables
+
+Scripts can rely on `updated` for "real change happened" and
+`unchanged` for "idempotent no-op," with `skipped` reserved for
+"the importer refused to mutate":
+
+```bash
+$ gnucash-plaintext import book.gnucash invoices.txt --include-business-objects | tail -10
+Business Objects:
+  Customers:   0 created, 0 updated, 50 unchanged, 0 skipped    ← idempotent re-run
+  Invoices:    0 created, 1 updated,  0 unchanged, 49 skipped   ← 1 unposted invoice edited; 49 posted, untouched
+```
+
+vs the current behaviour where a clean re-run shows `50 updated, 0
+skipped` (over-counts change) and a posted-invoice-skip looks
+identical to a no-change pass-through.
+
+## Files to change
+
+| File | Change |
+|---|---|
+| `services/gnucash_importer.py` | `import_customer` / `import_vendor`: field-by-field compare before set; return `'skipped'` on no diff. New helpers `_invoice_matches_directive` and `_bill_matches_directive`. `import_invoice` / `import_bill`: short-circuit return when matcher says no change. |
+| `tests/integration/test_business_object_idempotent_reimport.py` | New `TestNoChangeReimportIsSkipped` class with 6 tests: customer/vendor no-change, customer-with-name-change, customer-with-KVP-added (should still be `updated`), unposted invoice/bill no-change. |
+| `tests/integration/test_business_object_import_summary.py` | Existing tests `test_reimport_shows_updated_for_customers_vendors` and `test_reimport_summary_counts` need updates — the new behaviour reports `'skipped'`, not `'updated'`, for the no-change re-import path. |
+| `README.md` | "Re-import semantics" section: clarify what `'updated'` means now (real change) vs `'skipped'` (no diff or immutable target). |
+
+## Out of scope
+
+- Comparing transactions: separate subsystem, not part of business
+  objects.
+- A `--quiet` / `--verbose` flag.
+- Cleaning up orphan payment transactions left behind by `Unpost`
+  (see "Known limitation" above) — deferred to a follow-up issue.
+
+---
+
+**Created**: 2026-05-08

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -51,3 +51,4 @@ When a fix is merged, update `status: open` → `closed` in the file's frontmatt
 | [Q-007](Q-007-delete-archive-by-guid.md) | delete/archive accept GUIDs; invoice/bill identity enforced on import | medium |
 | [Q-008](Q-008-taxtable-identity.md) | Tax-table identity not enforced on import; re-import duplicates | medium |
 | [Q-009](Q-009-import-summary-business-objects.md) | Business-object import is silent — re-import gives no signal of skip vs. create vs. update | medium |
+| [Q-010](Q-010-strict-updated-status-on-no-change-reimport.md) | `'updated'` is liberal — reports updated for no-change re-imports; posted invoices/bills can't be edited via re-import | low |

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -64,22 +64,32 @@ _FALSY_STRINGS = {'false', '0', 'no'}
 
 @dataclass
 class BusinessObjectImportResult:
-    """Per-type create/update/skip counts from `import_business_objects`.
+    """Per-type create/update/unchanged/skip counts from `import_business_objects`.
 
-    Customers and vendors update on hit (Q-006), so they have all three
-    counters. Tax tables, invoices, and bills skip on hit (Q-007/Q-008),
-    so they have only created and skipped — `updated` stays zero.
+    Status semantics (Q-010):
+      - created:   directive produced a brand-new object
+      - updated:   directive matched an existing object AND mutated it
+      - unchanged: directive matched an existing object whose persisted state
+                   already equals the directive, so no mutation was applied
+      - skipped:   directive matched an immutable existing object (posted
+                   invoice/bill, in-use tax table); the directive is honoured
+                   only as an idempotent no-op refusal
+
+    Customers and vendors are mutable on hit, so they use all four. Tax
+    tables, posted invoices, and posted bills are immutable on hit so they
+    skip rather than update; unposted invoices/bills follow the mutable
+    model.
     """
     counts: Dict[str, Dict[str, int]] = field(default_factory=lambda: {
-        'customer': {'created': 0, 'updated': 0, 'skipped': 0},
-        'vendor':   {'created': 0, 'updated': 0, 'skipped': 0},
-        'taxtable': {'created': 0, 'updated': 0, 'skipped': 0},
-        'invoice':  {'created': 0, 'updated': 0, 'skipped': 0},
-        'bill':     {'created': 0, 'updated': 0, 'skipped': 0},
+        'customer': {'created': 0, 'updated': 0, 'unchanged': 0, 'skipped': 0},
+        'vendor':   {'created': 0, 'updated': 0, 'unchanged': 0, 'skipped': 0},
+        'taxtable': {'created': 0, 'updated': 0, 'unchanged': 0, 'skipped': 0},
+        'invoice':  {'created': 0, 'updated': 0, 'unchanged': 0, 'skipped': 0},
+        'bill':     {'created': 0, 'updated': 0, 'unchanged': 0, 'skipped': 0},
     })
 
     def tally(self, kind: str, status: str) -> None:
-        if status not in ('created', 'updated', 'skipped'):
+        if status not in ('created', 'updated', 'unchanged', 'skipped'):
             raise ValueError(f"Unknown import status {status!r} for {kind}")
         self.counts[kind][status] += 1
 
@@ -657,6 +667,344 @@ def create_tax_table_entry(book, account, amount_percent):
     return TaxTableEntry(instance=raw)
 
 
+def _customer_matches_directive(customer, directive: 'PlaintextDirective') -> bool:
+    """Return True if the customer's persisted state equals the directive.
+
+    Used by Q-010 to distinguish 'unchanged' (no-diff re-import) from
+    'updated' (a real mutation passed through). Compares only persisted
+    fields — the same set that `import_customer` writes — so two views of
+    the *same* on-disk customer (after a save+reload cycle) compare equal.
+    """
+    md = directive.metadata
+    if customer.GetName() != md['name']:
+        return False
+    addr = customer.GetAddr()
+    if addr.GetAddr1() != md.get('addr1', ''):
+        return False
+    if addr.GetAddr2() != md.get('addr2', ''):
+        return False
+    if addr.GetAddr3() != md.get('addr3', ''):
+        return False
+    if addr.GetAddr4() != md.get('addr4', ''):
+        return False
+    if addr.GetEmail() != md.get('email', ''):
+        return False
+    desired_active = not _is_falsy(md.get('active', 'true'))
+    if bool(customer.GetActive()) != desired_active:
+        return False
+    desired_custom = {k: v for k, v in md.items()
+                      if k not in KNOWN_CUSTOMER_METADATA_KEYS and v is not None}
+    existing_custom = get_custom_metadata(customer) or {}
+    return existing_custom == desired_custom
+
+
+def _vendor_matches_directive(vendor, directive: 'PlaintextDirective') -> bool:
+    """Return True if the vendor's persisted state equals the directive (Q-010)."""
+    md = directive.metadata
+    if vendor.GetName() != md['name']:
+        return False
+    desired_active = not _is_falsy(md.get('active', 'true'))
+    if bool(vendor.GetActive()) != desired_active:
+        return False
+    desired_custom = {k: v for k, v in md.items()
+                      if k not in KNOWN_VENDOR_METADATA_KEYS and v is not None}
+    existing_custom = get_custom_metadata(vendor) or {}
+    return existing_custom == desired_custom
+
+
+def _gnc_numeric_equals(num, value_str: str) -> bool:
+    """Compare a GncNumeric against a string-form value (e.g. '100', '2.5').
+
+    Uses GncNumeric.equal() to compare exactly. The directive value is
+    parsed with `string_to_gnc_numeric_quantity` so the precision matches
+    what the importer would write.
+    """
+    return num.equal(string_to_gnc_numeric_quantity(value_str))
+
+
+def _entry_matches_invoice_directive(entry, ed: 'PlaintextDirective') -> bool:
+    """Compare an existing customer-invoice Entry to an INVOICE_ENTRY directive."""
+    md = ed.metadata
+    if entry.GetDate().strftime("%Y-%m-%d") != md['date']:
+        return False
+    if entry.GetDescription() != md['description']:
+        return False
+    if entry.GetAction() != md['action']:
+        return False
+    acct = entry.GetInvAccount()
+    if acct is None or get_account_full_name(acct) != md['account']:
+        return False
+    if not _gnc_numeric_equals(entry.GetQuantity(), md['quantity']):
+        return False
+    if not _gnc_numeric_equals(entry.GetInvPrice(), md['price']):
+        return False
+    if bool(entry.GetInvTaxable()) != (md['taxable'] == 'true'):
+        return False
+    if bool(entry.GetInvTaxIncluded()) != (md['tax_included'] == 'true'):
+        return False
+    desired_tt = md.get('tax_table')
+    actual_tt_obj = entry.GetInvTaxTable() if entry.GetInvTaxable() else None
+    actual_tt = actual_tt_obj.GetName() if actual_tt_obj is not None else None
+    return (desired_tt or None) == (actual_tt or None)
+
+
+def _entry_matches_bill_directive(entry, ed: 'PlaintextDirective') -> bool:
+    """Compare an existing vendor-bill Entry to a BILL_ENTRY directive.
+
+    NOTE on `taxable`: GnuCash does not persist `bill_taxable: false` to XML
+    (CLAUDE.md §8); a bill entry always reads back as taxable=True after a
+    save+reload. We treat both directive values as equivalent on the bill
+    side to avoid spurious 'updated' on every re-import. If a future GnuCash
+    version starts persisting it, this comparison can be tightened.
+    """
+    md = ed.metadata
+    if entry.GetDate().strftime("%Y-%m-%d") != md['date']:
+        return False
+    if entry.GetDescription() != md['description']:
+        return False
+    acct = entry.GetBillAccount()
+    if acct is None or get_account_full_name(acct) != md['account']:
+        return False
+    if not _gnc_numeric_equals(entry.GetQuantity(), md['quantity']):
+        return False
+    if not _gnc_numeric_equals(entry.GetBillPrice(), md['price']):
+        return False
+    desired_tt = md.get('tax_table')
+    actual_tt_obj = entry.GetBillTaxTable() if entry.GetBillTaxable() else None
+    actual_tt = actual_tt_obj.GetName() if actual_tt_obj is not None else None
+    return (desired_tt or None) == (actual_tt or None)
+
+
+def _posted_matches_directive(invoice, posted_dir: 'PlaintextDirective',
+                              ar_or_ap_key: str) -> bool:
+    """Compare an existing posted invoice/bill's posting state to a POSTED directive."""
+    md = posted_dir.metadata
+    posting_acct = invoice.GetPostedAcc()
+    if posting_acct is None or get_account_full_name(posting_acct) != md[ar_or_ap_key]:
+        return False
+    posted_date = invoice.GetDatePosted()
+    if posted_date.strftime("%Y-%m-%d") != md['date']:
+        return False
+    due_date = invoice.GetDateDue()
+    if due_date.strftime("%Y-%m-%d") != md['due']:
+        return False
+    posting_txn = invoice.GetPostedTxn()
+    if posting_txn is None:
+        return False
+    return posting_txn.GetDescription() == md['memo']
+
+
+def _payments_match_directive(invoice, payment_dirs) -> bool:
+    """Compare an invoice's existing payments against PAYMENT directives.
+
+    The exporter derives payment lines from the invoice's posted lot:
+    every transaction in the lot whose split is NOT the posting tx is a
+    payment. The bank-side split holds the date/amount/memo as the user
+    typed them (memo lives on the split, NOT on the transaction
+    description — see `_format_payment` in export_business_objects).
+
+    Two payment-directive flavours:
+      - **Normal payment**: directive supplies bank_account, date, amount,
+        memo (optionally num). Compare all of them.
+      - **Retarget (txn_guid)**: directive supplies bank_account and
+        txn_guid only — date/amount/memo come from the pre-existing bank
+        transaction and are not authoritative in the directive. Compare
+        only what the directive declares.
+
+    Note: `lot.get_split_list()` returns raw SwigPyObject pointers, so we
+    wrap them in `Split(instance=...)` and read the parent transaction
+    via `GetParent()`. This mirrors the pattern in `invoice_renderer`.
+    """
+    from gnucash import Split
+    lot = invoice.GetPostedLot()
+    if lot is None:
+        return len(payment_dirs) == 0
+    posting_txn = invoice.GetPostedTxn()
+    posting_txn_guid = posting_txn.GetGUID().to_string() if posting_txn else None
+    pay_splits = []
+    for raw in lot.get_split_list():
+        s = Split(instance=raw)
+        tx = s.GetParent()
+        if tx is None:
+            continue
+        if posting_txn_guid is not None and tx.GetGUID().to_string() == posting_txn_guid:
+            continue
+        pay_splits.append(s)
+    if len(pay_splits) != len(payment_dirs):
+        return False
+    for split, pd in zip(pay_splits, payment_dirs):
+        md = pd.metadata
+        tx = split.GetParent()
+        ar_ap_split_guid = split.GetGUID().to_string()
+        bank_split = next(
+            (s for s in tx.GetSplitList()
+             if s.GetGUID().to_string() != ar_ap_split_guid),
+            None,
+        )
+        if bank_split is None:
+            return False
+        bank_acct = bank_split.GetAccount()
+        if bank_acct is None or get_account_full_name(bank_acct) != md['bank_account']:
+            return False
+
+        directive_txn_guid = (md.get('txn_guid') or '').strip()
+        if directive_txn_guid:
+            if tx.GetGUID().to_string() != directive_txn_guid:
+                return False
+            continue
+        if tx.GetDate().strftime("%Y-%m-%d") != md['date']:
+            return False
+        if not _gnc_numeric_equals(bank_split.GetAmount().abs(), md['amount']):
+            return False
+        if (bank_split.GetMemo() or '') != md.get('memo', ''):
+            return False
+        if (tx.GetNum() or '') != md.get('num', ''):
+            return False
+    return True
+
+
+def _invoice_matches_directive(invoice, directive: 'PlaintextDirective', book) -> bool:
+    """Return True iff an existing customer invoice equals the directive (Q-010).
+
+    Compared fields: date_opened, billing_id, notes, custom KVP, entries
+    (positional, by field), the posted block (or absence thereof), and
+    payments (count + per-payment fields). Mismatch on ANY field returns
+    False so the importer falls through to the rebuild + repost path.
+    """
+    md = directive.metadata
+    if invoice.GetDateOpened().strftime("%Y-%m-%d") != md['date_opened']:
+        return False
+    if invoice.GetBillingID() != md.get('billing_id', ''):
+        return False
+    if invoice.GetNotes() != md.get('notes', ''):
+        return False
+    desired_custom = {k: v for k, v in md.items()
+                      if k not in KNOWN_INVOICE_METADATA_KEYS and v is not None}
+    existing_custom = get_custom_metadata(invoice) or {}
+    if existing_custom != desired_custom:
+        return False
+
+    entry_dirs = [c for c in directive.children if c.type == DirectiveType.INVOICE_ENTRY]
+    existing_entries = list(invoice.GetEntries())
+    if len(existing_entries) != len(entry_dirs):
+        return False
+    for entry, ed in zip(existing_entries, entry_dirs):
+        if not _entry_matches_invoice_directive(entry, ed):
+            return False
+
+    posted_dirs = [c for c in directive.children if c.type == DirectiveType.POSTED]
+    has_posted_none = md.get('posted') == 'none'
+    is_posted = invoice.GetPostedTxn() is not None
+    if has_posted_none and is_posted:
+        return False
+    if posted_dirs and not is_posted:
+        return False
+    if posted_dirs and is_posted and not _posted_matches_directive(
+            invoice, posted_dirs[0], 'ar_account'):
+        return False
+
+    payment_dirs = [c for c in directive.children if c.type == DirectiveType.PAYMENT]
+    return _payments_match_directive(invoice, payment_dirs)
+
+
+def _is_only_unpost_diff(invoice_or_bill, directive: 'PlaintextDirective',
+                         is_bill: bool) -> bool:
+    """Return True iff the *only* difference between the existing record and
+    the directive is that existing is posted and the directive says
+    `posted: none` — entries, payments, and the rest of the metadata are
+    otherwise identical.
+
+    When this holds, the importer can call `Unpost(False)` and stop, instead
+    of running the full destroy-and-rebuild path. The win:
+    **entry GUIDs are preserved**. A cross-tool external reference to an
+    entry by GUID still resolves after the re-import; with the rebuild path
+    the entry is destroyed and a brand-new one created.
+
+    Strictly defensive: if the directive has any `posted:` block (rather
+    than `posted: none`), or has any other field difference, returns False
+    and the caller falls through to the full unpost-rebuild-repost path.
+    """
+    md = directive.metadata
+    is_posted = invoice_or_bill.GetPostedTxn() is not None
+    if not is_posted:
+        return False
+    if md.get('posted') != 'none':
+        return False
+    posted_dirs = [c for c in directive.children if c.type == DirectiveType.POSTED]
+    if posted_dirs:
+        return False
+    payment_dirs = [c for c in directive.children if c.type == DirectiveType.PAYMENT]
+    if payment_dirs:
+        # Directive declares payments but invoice will be unposted — invalid
+        # combination caught later as a real error; here we just refuse the
+        # short-circuit and let the normal flow surface the validation.
+        return False
+
+    # Compare every non-posted field: entries, date_opened, billing_id (inv
+    # only), notes, custom KVP. We skip the actual posted/payment portion of
+    # the comparison since we already know those differ in the expected way.
+    if invoice_or_bill.GetDateOpened().strftime("%Y-%m-%d") != md['date_opened']:
+        return False
+    if not is_bill and invoice_or_bill.GetBillingID() != md.get('billing_id', ''):
+        return False
+    if invoice_or_bill.GetNotes() != md.get('notes', ''):
+        return False
+    known_keys = KNOWN_BILL_METADATA_KEYS if is_bill else KNOWN_INVOICE_METADATA_KEYS
+    desired_custom = {k: v for k, v in md.items()
+                      if k not in known_keys and v is not None}
+    existing_custom = get_custom_metadata(invoice_or_bill) or {}
+    if existing_custom != desired_custom:
+        return False
+
+    entry_type = DirectiveType.BILL_ENTRY if is_bill else DirectiveType.INVOICE_ENTRY
+    entry_dirs = [c for c in directive.children if c.type == entry_type]
+    existing_entries = list(invoice_or_bill.GetEntries())
+    if len(existing_entries) != len(entry_dirs):
+        return False
+    matcher = _entry_matches_bill_directive if is_bill else _entry_matches_invoice_directive
+    return all(matcher(entry, ed) for entry, ed in zip(existing_entries, entry_dirs))
+
+
+def _bill_matches_directive(bill, directive: 'PlaintextDirective', book) -> bool:
+    """Return True iff an existing vendor bill equals the directive (Q-010).
+
+    Same shape as `_invoice_matches_directive` but uses the bill-side
+    entry getters and AP account.
+    """
+    md = directive.metadata
+    if bill.GetDateOpened().strftime("%Y-%m-%d") != md['date_opened']:
+        return False
+    if bill.GetNotes() != md.get('notes', ''):
+        return False
+    desired_custom = {k: v for k, v in md.items()
+                      if k not in KNOWN_BILL_METADATA_KEYS and v is not None}
+    existing_custom = get_custom_metadata(bill) or {}
+    if existing_custom != desired_custom:
+        return False
+
+    entry_dirs = [c for c in directive.children if c.type == DirectiveType.BILL_ENTRY]
+    existing_entries = list(bill.GetEntries())
+    if len(existing_entries) != len(entry_dirs):
+        return False
+    for entry, ed in zip(existing_entries, entry_dirs):
+        if not _entry_matches_bill_directive(entry, ed):
+            return False
+
+    posted_dirs = [c for c in directive.children if c.type == DirectiveType.POSTED]
+    has_posted_none = md.get('posted') == 'none'
+    is_posted = bill.GetPostedTxn() is not None
+    if has_posted_none and is_posted:
+        return False
+    if posted_dirs and not is_posted:
+        return False
+    if posted_dirs and is_posted and not _posted_matches_directive(
+            bill, posted_dirs[0], 'ap_account'):
+        return False
+
+    payment_dirs = [c for c in directive.children if c.type == DirectiveType.PAYMENT]
+    return _payments_match_directive(bill, payment_dirs)
+
+
 class GnuCashImporter:
     """Service for importing plaintext directives to GnuCash"""
 
@@ -1060,6 +1408,13 @@ class GnuCashImporter:
             lambda g: _find_customer_by_guid(book, g),
         )
 
+        # Q-010: short-circuit if the existing record is already byte-equal
+        # to the directive. Reports 'unchanged' so users see clearly that
+        # no mutation was applied (vs 'updated' which implies a write).
+        if existing is not None and _customer_matches_directive(existing, directive):
+            logging.debug(f"Customer {cid} already matches directive; unchanged")
+            return 'unchanged'
+
         currency = book.get_table().lookup("CURRENCY", directive.metadata['currency'])
         if existing is None:
             customer = Customer(book, cid, currency)
@@ -1099,6 +1454,11 @@ class GnuCashImporter:
             lambda i: _find_vendors_by_id(book, i),
             lambda g: _find_vendor_by_guid(book, g),
         )
+
+        # Q-010: short-circuit when existing matches directive byte-for-byte.
+        if existing is not None and _vendor_matches_directive(existing, directive):
+            logging.debug(f"Vendor {vid} already matches directive; unchanged")
+            return 'unchanged'
 
         currency = book.get_table().lookup("CURRENCY", directive.metadata['currency'])
         if existing is None:
@@ -1196,22 +1556,6 @@ class GnuCashImporter:
             get_guid_str=_swig_invoice_guid_str,
         )
 
-        # Q-007 follow-up: existing posted invoice is immutable (its AR lot
-        # is wired into a real transaction; mutating entries/posted block
-        # would corrupt accounting state). Existing UNPOSTED invoice can be
-        # updated — replace entries, optionally post, optionally pay. The
-        # gap that prompted this: a user's natural workflow is
-        #   1. import invoice with `posted: none`
-        #   2. edit file, replace `posted: none` with a real posted block
-        #   3. re-import
-        # Pre-fix this silently skipped at step 3.
-        status_on_success = 'created'
-        if existing is not None:
-            if existing.GetPostedTxn() is not None:
-                logging.debug(f"Invoice {inv_id} already exists and is posted; skipping")
-                return 'skipped'
-            status_on_success = 'updated'
-
         # Validate: posted: none and a real posted: block are contradictory
         has_posted_none = directive.metadata.get('posted') == 'none'
         posted_children = [c for c in directive.children if c.type == DirectiveType.POSTED]
@@ -1229,6 +1573,33 @@ class GnuCashImporter:
         if has_posted_none and payment_children:
             raise ValueError(f'Invoice {inv_id}: cannot have payment: blocks on an unposted invoice (posted: none)')
 
+        # Q-010: classify the existing record before any mutation.
+        #   - matches directive byte-for-byte → 'unchanged' (no-op)
+        #   - only difference is `posted → posted: none` → minimal Unpost,
+        #     skip the destroy-and-rebuild (preserves entry GUIDs)
+        #   - existing is posted, directive differs (entries/posted/payments)
+        #     → full Unpost-rebuild-repost cycle (mirrors GnuCash UI)
+        #   - existing is unposted → fall through to rebuild
+        # Q-007's old behaviour ("posted is immutable, return skipped")
+        # is gone — that left a permanent dead-end that contradicted the
+        # GnuCash UI itself.
+        status_on_success = 'created'
+        if existing is not None:
+            if _invoice_matches_directive(existing, directive, book):
+                logging.debug(f"Invoice {inv_id} already matches directive; unchanged")
+                return 'unchanged'
+            if _is_only_unpost_diff(existing, directive, is_bill=False):
+                logging.debug(
+                    f"Invoice {inv_id}: only difference is posted→posted:none; "
+                    f"minimal unpost (entry GUIDs preserved)"
+                )
+                existing.Unpost(False)
+                return 'updated'
+            status_on_success = 'updated'
+            if existing.GetPostedTxn() is not None:
+                logging.debug(f"Invoice {inv_id} is posted but differs; unposting for rebuild")
+                existing.Unpost(False)
+
         if existing is None:
             customer = _resolve_cross_reference(
                 'customer',
@@ -1241,14 +1612,14 @@ class GnuCashImporter:
             if must_set_guid is not None:
                 _set_object_guid(book, invoice, 'invoice', inv_id, must_set_guid)
         else:
-            # Existing unposted invoice: reuse it, drop its current entries
-            # so we can rebuild from the directive. RemoveEntry is essential
-            # before Destroy: gncEntryDestroy only sets the do_free flag and
-            # drops the entry from the QofCollection — it does NOT detach
-            # the entry from the invoice's internal entry list. Without
-            # RemoveEntry, `gncInvoicePostToAccount` later iterates a list
-            # that still contains the now-dangling pointer and segfaults
-            # (reproduced on GnuCash 3.8 / ubuntu20).
+            # Existing invoice (unposted now, after the Unpost above if needed):
+            # reuse it, drop its current entries so we can rebuild from the
+            # directive. RemoveEntry is essential before Destroy: gncEntryDestroy
+            # only sets the do_free flag and drops the entry from the
+            # QofCollection — it does NOT detach the entry from the invoice's
+            # internal entry list. Without RemoveEntry, `gncInvoicePostToAccount`
+            # later iterates a list that still contains the now-dangling pointer
+            # and segfaults (reproduced on GnuCash 3.8 / ubuntu20).
             invoice = existing
             for old_entry in list(invoice.GetEntries()):
                 invoice.RemoveEntry(old_entry)
@@ -1370,17 +1741,6 @@ class GnuCashImporter:
             get_guid_str=_swig_invoice_guid_str,
         )
 
-        # Q-007 follow-up: existing posted bill is immutable (its AP lot is
-        # wired into a real transaction). Existing UNPOSTED bill can be
-        # updated — replace entries, optionally post, optionally pay. Same
-        # rationale as the invoice path above.
-        status_on_success = 'created'
-        if existing is not None:
-            if existing.GetPostedTxn() is not None:
-                logging.debug(f"Bill {bill_id} already exists and is posted; skipping")
-                return 'skipped'
-            status_on_success = 'updated'
-
         # Validate: posted: none and a real posted: block are contradictory
         has_posted_none = directive.metadata.get('posted') == 'none'
         posted_children = [c for c in directive.children if c.type == DirectiveType.POSTED]
@@ -1398,6 +1758,27 @@ class GnuCashImporter:
         if has_posted_none and payment_children:
             raise ValueError(f'Bill {bill_id}: cannot have payment: blocks on an unposted bill (posted: none)')
 
+        # Q-010: same classification as import_invoice. Posted bills are
+        # mutable via Unpost-edit-repost; identical re-imports are unchanged;
+        # bare unpost (posted → posted: none, no other change) skips the
+        # destroy-and-rebuild and preserves entry GUIDs.
+        status_on_success = 'created'
+        if existing is not None:
+            if _bill_matches_directive(existing, directive, book):
+                logging.debug(f"Bill {bill_id} already matches directive; unchanged")
+                return 'unchanged'
+            if _is_only_unpost_diff(existing, directive, is_bill=True):
+                logging.debug(
+                    f"Bill {bill_id}: only difference is posted→posted:none; "
+                    f"minimal unpost (entry GUIDs preserved)"
+                )
+                existing.Unpost(False)
+                return 'updated'
+            status_on_success = 'updated'
+            if existing.GetPostedTxn() is not None:
+                logging.debug(f"Bill {bill_id} is posted but differs; unposting for rebuild")
+                existing.Unpost(False)
+
         if existing is None:
             # Bills are Invoice objects whose owner is a Vendor (no separate Bill class)
             vendor = _resolve_cross_reference(
@@ -1411,7 +1792,8 @@ class GnuCashImporter:
             if must_set_guid is not None:
                 _set_object_guid(book, bill, 'bill', bill_id, must_set_guid)
         else:
-            # Existing unposted bill: reuse it, drop its current entries.
+            # Existing bill (unposted now, after the Unpost above if needed):
+            # reuse it, drop its current entries.
             # NOTE: SWIG `Invoice.RemoveEntry` wraps `gncInvoiceRemoveEntry`
             # which only handles customer invoices. For vendor bills we
             # need `gncBillRemoveEntry` via ctypes — see _bill_remove_entry.
@@ -1518,9 +1900,10 @@ class GnuCashImporter:
 
         `on_directive_status(kind, id, status)` is invoked once per directive
         with kind ∈ {'customer','vendor','taxtable','invoice','bill'} and
-        status ∈ {'created','updated','skipped'}. Default is no-op for
-        library callers; the CLI passes a callback that prints
-        '<kind> "<id>": <status>' lines so the user sees activity inline.
+        status ∈ {'created','updated','unchanged','skipped'} (Q-010).
+        Default is no-op for library callers; the CLI passes a callback
+        that prints '<kind> "<id>": <status>' lines so the user sees
+        activity inline.
 
         Returns a `BusinessObjectImportResult` with per-type counts so the
         caller can render an aggregate summary at the end of the import.

--- a/tests/fixtures/q010_bill_posted.txt
+++ b/tests/fixtures/q010_bill_posted.txt
@@ -1,0 +1,23 @@
+vendor "V001"
+	name: "Supplier"
+	currency: CAD
+
+bill "BILL-001"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Supplies"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 50
+		taxable: true
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-001"
+		accumulate: true
+	payment: none

--- a/tests/fixtures/q010_bill_unposted.txt
+++ b/tests/fixtures/q010_bill_unposted.txt
@@ -1,0 +1,18 @@
+vendor "V001"
+	name: "Supplier"
+	currency: CAD
+
+bill "BILL-001"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Supplies"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 50
+		taxable: true
+		tax_included: false
+	posted: none
+	payment: none

--- a/tests/fixtures/q010_invoice_posted.txt
+++ b/tests/fixtures/q010_invoice_posted.txt
@@ -1,0 +1,24 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-001"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-001"
+		accumulate: true
+	payment: none

--- a/tests/fixtures/q010_invoice_unposted.txt
+++ b/tests/fixtures/q010_invoice_unposted.txt
@@ -1,0 +1,19 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-001"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted: none
+	payment: none

--- a/tests/fixtures/q010_taxtable.txt
+++ b/tests/fixtures/q010_taxtable.txt
@@ -1,0 +1,5 @@
+taxtable "GST"
+	entry:
+		account: "Liabilities:Accounts Payable"
+		rate: 5.0%
+		type: PERCENT

--- a/tests/integration/test_business_object_idempotent_reimport.py
+++ b/tests/integration/test_business_object_idempotent_reimport.py
@@ -171,6 +171,19 @@ def _exported_biz_text(runner, tmp_path, gnc):
     return out.read_text()
 
 
+def _fixture(name: str) -> str:
+    """Read a `tests/fixtures/<name>.txt` fixture as a single string.
+
+    Big plaintext fixtures live in their own files rather than as inline
+    Python strings: easier to read, easier to diff, easier to reuse across
+    tests, and the indentation is preserved verbatim.
+    """
+    import os
+    path = os.path.join(os.path.dirname(__file__), '..', 'fixtures', f'{name}.txt')
+    with open(path) as f:
+        return f.read()
+
+
 # ── 1. Re-import idempotency ─────────────────────────────────────────────────
 
 
@@ -253,6 +266,324 @@ class TestReimportUpdatesFields:
         block = _block_for(text, 'customer "C001"')
         assert _field_in_block(block, 'active') == 'false', (
             "Expected active: false after re-import; got block:\n" + "\n".join(block)
+        )
+
+
+# ── 2b. No-change re-import is reported as 'unchanged' (Q-010) ──────────────
+#
+# An external reviewer flagged that 'updated' was liberal under Q-009: when
+# the directive matches the existing record byte-for-byte, the importer
+# was reporting 'updated' even though nothing actually changed. Q-010 adds
+# a new status `unchanged` for this case, freeing `skipped` to mean only
+# "the importer refused to apply the change because the record is immutable
+# (e.g. posted invoice)". Four statuses total:
+#
+#   created   — fresh record
+#   updated   — existing record had at least one mutable field changed
+#   unchanged — existing record matches the directive; no work performed
+#   skipped   — existing record is immutable for this directive
+#
+# Script writers can then assert on counts cleanly.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestNoChangeReimportIsUnchanged:
+    """Re-import where directive matches existing record must report 'unchanged'.
+
+    'unchanged' (this class) is distinct from 'skipped' (the
+    `TestImmutablePostedSkipReportsSkipped` class below):
+      - 'unchanged': record is mutable, directive matches existing state,
+        nothing to do.
+      - 'skipped':   record is immutable for this directive (e.g. posted
+        invoice/bill), so the importer refuses to apply any change.
+    """
+
+    def test_customer_no_change_is_unchanged(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n')
+        same = _write(tmp_path / "again.txt",
+                      ACCOUNTS + "\n" +
+                      'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n')
+        r = _import(runner, gnc, same)
+        assert r.exit_code == 0, f"Re-import must succeed:\n{r.output}"
+        assert 'customer "C001": unchanged' in r.output, (
+            f"No-change re-import must report 'unchanged', not 'updated' or "
+            f"'skipped'. Got:\n{r.output}"
+        )
+
+    def test_customer_name_change_is_updated(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n')
+        renamed = _write(tmp_path / "renamed.txt",
+                         ACCOUNTS + "\n" +
+                         'customer "C001"\n\tname: "Acme Renamed"\n\tcurrency: CAD\n')
+        r = _import(runner, gnc, renamed)
+        assert r.exit_code == 0
+        assert 'customer "C001": updated' in r.output, (
+            f"Real change must report 'updated'. Got:\n{r.output}"
+        )
+
+    def test_customer_kvp_added_is_updated(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n')
+        with_kvp = _write(tmp_path / "with_kvp.txt",
+                          ACCOUNTS + "\n" +
+                          'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n'
+                          '\tjw.country: "CA"\n')
+        r = _import(runner, gnc, with_kvp)
+        assert r.exit_code == 0
+        assert 'customer "C001": updated' in r.output
+
+    def test_customer_active_change_is_updated(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n')
+        archived = _write(tmp_path / "archived.txt",
+                          ACCOUNTS + "\n" +
+                          'customer "C001"\n\tname: "Acme"\n\tcurrency: CAD\n'
+                          '\tactive: false\n')
+        r = _import(runner, gnc, archived)
+        assert r.exit_code == 0
+        assert 'customer "C001": updated' in r.output
+
+    def test_vendor_no_change_is_unchanged(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               'vendor "V001"\n\tname: "Supplier"\n\tcurrency: CAD\n')
+        same = _write(tmp_path / "again.txt",
+                      ACCOUNTS + "\n" +
+                      'vendor "V001"\n\tname: "Supplier"\n\tcurrency: CAD\n')
+        r = _import(runner, gnc, same)
+        assert r.exit_code == 0
+        assert 'vendor "V001": unchanged' in r.output
+
+    def test_vendor_name_change_is_updated(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               'vendor "V001"\n\tname: "Supplier"\n\tcurrency: CAD\n')
+        renamed = _write(tmp_path / "renamed.txt",
+                         ACCOUNTS + "\n" +
+                         'vendor "V001"\n\tname: "Renamed Supplier"\n\tcurrency: CAD\n')
+        r = _import(runner, gnc, renamed)
+        assert r.exit_code == 0
+        assert 'vendor "V001": updated' in r.output
+
+    def test_unposted_invoice_no_change_is_unchanged(self, tmp_path):
+        """Re-importing an unposted invoice fixture with no edits must NOT
+        do destroy+rebuild — the directive matches existing state, so
+        the importer should short-circuit and report 'unchanged'."""
+        runner = CliRunner()
+        invoice_fixture = _fixture('q010_invoice_unposted')
+        gnc = _setup_book_with(runner, tmp_path, invoice_fixture)
+        r = _import(runner, gnc, _write(tmp_path / "again.txt",
+                                        ACCOUNTS + "\n" + invoice_fixture))
+        assert r.exit_code == 0, r.output
+        assert 'invoice "INV-001": unchanged' in r.output, (
+            f"No-change re-import of unposted invoice must report 'unchanged':\n"
+            f"{r.output}"
+        )
+
+    def test_unposted_invoice_entry_change_is_updated(self, tmp_path):
+        """Changing an entry on an unposted invoice via re-import must
+        still go through the update path and report 'updated'."""
+        runner = CliRunner()
+        base = _fixture('q010_invoice_unposted')
+        gnc = _setup_book_with(runner, tmp_path, base)
+        edited = base.replace('\t\tquantity: 1\n', '\t\tquantity: 2\n')
+        r = _import(runner, gnc, _write(tmp_path / "edited.txt",
+                                        ACCOUNTS + "\n" + edited))
+        assert r.exit_code == 0, r.output
+        assert 'invoice "INV-001": updated' in r.output, (
+            f"Entry change must report 'updated':\n{r.output}"
+        )
+
+    def test_unposted_bill_no_change_is_unchanged(self, tmp_path):
+        runner = CliRunner()
+        bill_fixture = _fixture('q010_bill_unposted')
+        gnc = _setup_book_with(runner, tmp_path, bill_fixture)
+        r = _import(runner, gnc, _write(tmp_path / "again.txt",
+                                        ACCOUNTS + "\n" + bill_fixture))
+        assert r.exit_code == 0, r.output
+        assert 'bill "BILL-001": unchanged' in r.output
+
+
+# ── 2c. Immutable records report 'skipped' (Q-010 status semantics) ─────────
+#
+# Distinct from 'unchanged' (mutable, no diff): 'skipped' means the importer
+# *refused* to apply the directive because the record's state forbids
+# mutation. Currently:
+#
+#   - Posted invoice / bill: AR/AP lots are wired into a real transaction;
+#     entries, posted block, and metadata are all locked.
+#   - Tax table on hit: tax tables are referenced by stored pointers from
+#     posted invoices/bills; mutating their entries would change accounting
+#     on past records.
+#
+# (`TestUnpostedToPostedTransition` further down also has assertions that
+# overlap with this class — kept for backward compatibility with Q-007's
+# original suite; the dedicated class here is the canonical test for the
+# 'skipped' status semantics introduced by Q-010.)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestTaxTableImmutableReportsSkipped:
+    """Tax tables are the only business-object kind that remains truly
+    immutable on hit: mutating their entries would silently change
+    accounting on past posted invoices that reference them. Status on
+    re-import: 'skipped', not 'unchanged'.
+
+    Posted invoices and bills are NOT in this category any more — Q-010
+    extended the importer to support unpost-edit-repost just like the
+    GnuCash UI does. See `TestPostedToPostedReimport` below.
+    """
+
+    def test_taxtable_reimport_is_skipped(self, tmp_path):
+        runner = CliRunner()
+        fixture = _fixture('q010_taxtable')
+        gnc = _setup_book_with(runner, tmp_path, fixture)
+        r = _import(runner, gnc, _write(tmp_path / "again.txt",
+                                        ACCOUNTS + "\n" + fixture))
+        assert r.exit_code == 0
+        assert 'taxtable "GST": skipped' in r.output
+
+
+class TestPostedToPostedReimport:
+    """Q-010 expanded scope: GnuCash itself supports unpost → edit → repost.
+    Pre-Q-010 our importer treated every posted invoice/bill as a permanent
+    dead-end for re-imports. This class covers the four scenarios that
+    Q-010 must handle when the existing record is posted:
+
+      1. directive matches existing      → 'unchanged' (no-op)
+      2. directive entry differs         → unpost, rebuild, repost → 'updated'
+      3. directive posted block differs  → unpost, rebuild, repost → 'updated'
+      4. directive sets posted: none     → unpost, leave unposted   → 'updated'
+    """
+
+    def test_posted_invoice_no_change_is_unchanged(self, tmp_path):
+        runner = CliRunner()
+        fixture = _fixture('q010_invoice_posted')
+        gnc = _setup_book_with(runner, tmp_path, fixture)
+        r = _import(runner, gnc, _write(tmp_path / "again.txt",
+                                        ACCOUNTS + "\n" + fixture))
+        assert r.exit_code == 0, r.output
+        assert 'invoice "INV-001": unchanged' in r.output, (
+            f"Identical re-import of posted invoice must report 'unchanged' "
+            f"(no diff applied). Got:\n{r.output}"
+        )
+        # Sanity: the invoice is still posted with the same single entry.
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        assert _count_blocks(text, 'invoice "INV-001"') == 1
+
+    def test_posted_invoice_entry_change_unposts_and_reposts(self, tmp_path):
+        """Editing an entry on a posted invoice must trigger Unpost → rebuild
+        → PostToAccount, and report 'updated'. The new posted state must
+        match the directive (quantity 2, not 1)."""
+        runner = CliRunner()
+        fixture = _fixture('q010_invoice_posted')
+        gnc = _setup_book_with(runner, tmp_path, fixture)
+        edited = fixture.replace('\t\tquantity: 1\n', '\t\tquantity: 2\n')
+        r = _import(runner, gnc, _write(tmp_path / "edited.txt",
+                                        ACCOUNTS + "\n" + edited))
+        assert r.exit_code == 0, r.output
+        assert 'invoice "INV-001": updated' in r.output, (
+            f"Posted-invoice entry edit must report 'updated' (unpost-repost "
+            f"cycle). Got:\n{r.output}"
+        )
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        block = _block_for(text, 'invoice "INV-001"')
+        # Verify the rebuilt entry has quantity 2 (not 1) and is still posted.
+        assert any('quantity: 2' in line for line in block), (
+            "Rebuilt entry must show quantity: 2:\n" + "\n".join(block)
+        )
+        assert any('posted:' in line and 'none' not in line for line in block), (
+            "Invoice must remain posted after edit:\n" + "\n".join(block)
+        )
+
+    def test_posted_invoice_memo_change_reposts(self, tmp_path):
+        """Editing the posted-block memo must trigger Unpost → repost with
+        the new memo. The posting transaction's description (set from
+        memo) is the externally-observable signal."""
+        runner = CliRunner()
+        fixture = _fixture('q010_invoice_posted')
+        gnc = _setup_book_with(runner, tmp_path, fixture)
+        edited = fixture.replace(
+            'memo: "Invoice INV-001"',
+            'memo: "Invoice INV-001 (corrected)"',
+        )
+        r = _import(runner, gnc, _write(tmp_path / "memo_edit.txt",
+                                        ACCOUNTS + "\n" + edited))
+        assert r.exit_code == 0, r.output
+        assert 'invoice "INV-001": updated' in r.output, r.output
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        block = _block_for(text, 'invoice "INV-001"')
+        assert any('Invoice INV-001 (corrected)' in line for line in block), (
+            "Posted memo must be rewritten on re-import:\n" + "\n".join(block)
+        )
+
+    def test_posted_invoice_to_posted_none_unposts(self, tmp_path):
+        """Going from posted → posted: none on re-import is a real change:
+        Unpost the invoice (drop the AR posting transaction) and leave
+        the invoice unposted. Status: 'updated'."""
+        runner = CliRunner()
+        fixture = _fixture('q010_invoice_posted')
+        gnc = _setup_book_with(runner, tmp_path, fixture)
+        edited = _fixture('q010_invoice_unposted')
+        r = _import(runner, gnc, _write(tmp_path / "to_unposted.txt",
+                                        ACCOUNTS + "\n" + edited))
+        assert r.exit_code == 0, r.output
+        assert 'invoice "INV-001": updated' in r.output, (
+            f"posted → posted:none must report 'updated' (unpost happened):\n"
+            f"{r.output}"
+        )
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        block = _block_for(text, 'invoice "INV-001"')
+        assert any('posted: none' in line for line in block), (
+            "Invoice must be unposted after re-import:\n" + "\n".join(block)
+        )
+
+    def test_posted_bill_no_change_is_unchanged(self, tmp_path):
+        runner = CliRunner()
+        fixture = _fixture('q010_bill_posted')
+        gnc = _setup_book_with(runner, tmp_path, fixture)
+        r = _import(runner, gnc, _write(tmp_path / "again.txt",
+                                        ACCOUNTS + "\n" + fixture))
+        assert r.exit_code == 0, r.output
+        assert 'bill "BILL-001": unchanged' in r.output, (
+            f"Identical re-import of posted bill must report 'unchanged':\n"
+            f"{r.output}"
+        )
+
+    def test_posted_bill_entry_change_unposts_and_reposts(self, tmp_path):
+        runner = CliRunner()
+        fixture = _fixture('q010_bill_posted')
+        gnc = _setup_book_with(runner, tmp_path, fixture)
+        edited = fixture.replace('\t\tquantity: 1\n', '\t\tquantity: 3\n')
+        r = _import(runner, gnc, _write(tmp_path / "edited.txt",
+                                        ACCOUNTS + "\n" + edited))
+        assert r.exit_code == 0, r.output
+        assert 'bill "BILL-001": updated' in r.output, r.output
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        block = _block_for(text, 'bill "BILL-001"')
+        assert any('quantity: 3' in line for line in block), (
+            "Rebuilt bill entry must show quantity: 3:\n" + "\n".join(block)
+        )
+
+    def test_posted_bill_to_posted_none_unposts(self, tmp_path):
+        runner = CliRunner()
+        fixture = _fixture('q010_bill_posted')
+        gnc = _setup_book_with(runner, tmp_path, fixture)
+        edited = _fixture('q010_bill_unposted')
+        r = _import(runner, gnc, _write(tmp_path / "to_unposted.txt",
+                                        ACCOUNTS + "\n" + edited))
+        assert r.exit_code == 0, r.output
+        assert 'bill "BILL-001": updated' in r.output, r.output
+        text = _exported_biz_text(runner, tmp_path, gnc)
+        block = _block_for(text, 'bill "BILL-001"')
+        assert any('posted: none' in line for line in block), (
+            "Bill must be unposted after re-import:\n" + "\n".join(block)
         )
 
 
@@ -1276,28 +1607,28 @@ class TestUnpostedToPostedTransition:
             "Bill must be posted after re-import; block:\n" + "\n".join(block)
         )
 
-    def test_already_posted_invoice_still_skips_on_reimport(self, tmp_path):
-        """No regression: re-importing a file containing an already-posted
-        invoice still skips (its lot is wired into a real transaction and
-        we can't safely mutate)."""
+    def test_already_posted_invoice_unchanged_on_identical_reimport(self, tmp_path):
+        """Q-010: an identical re-import of a posted invoice is 'unchanged'
+        (not 'skipped'). The previous Q-007 'always skip posted' rule was
+        too coarse and contradicted GnuCash's own UI."""
         runner = CliRunner()
         gnc = _setup_book_with(runner, tmp_path, _INVOICE_POSTED)
 
         r = _import(runner, gnc, _write(tmp_path / "again.txt",
                                         ACCOUNTS + "\n" + _INVOICE_POSTED))
         assert r.exit_code == 0
-        assert 'invoice "INV-001": skipped' in r.output, (
-            f"Re-import of posted invoice should still skip:\n{r.output}"
+        assert 'invoice "INV-001": unchanged' in r.output, (
+            f"Identical re-import of posted invoice should be 'unchanged':\n{r.output}"
         )
 
-    def test_already_posted_bill_still_skips_on_reimport(self, tmp_path):
+    def test_already_posted_bill_unchanged_on_identical_reimport(self, tmp_path):
         runner = CliRunner()
         gnc = _setup_book_with(runner, tmp_path, _BILL_POSTED)
 
         r = _import(runner, gnc, _write(tmp_path / "again.txt",
                                         ACCOUNTS + "\n" + _BILL_POSTED))
         assert r.exit_code == 0
-        assert 'bill "BILL-001": skipped' in r.output
+        assert 'bill "BILL-001": unchanged' in r.output
 
     def test_unposted_to_posted_status_line_says_updated(self, tmp_path):
         """When re-import successfully posts an unposted invoice, the
@@ -1313,14 +1644,13 @@ class TestUnpostedToPostedTransition:
             f"Posting an unposted invoice should report 'updated':\n{r.output}"
         )
 
-    def test_posted_invoice_notes_not_mutated_on_reimport(self, tmp_path):
-        """Posted = fully immutable. Even non-accounting fields like notes
-        must NOT be mutated on re-import — a posted invoice represents what
-        the customer already received, and silently changing notes after
-        the fact would mislead a maintainer reading the book."""
+    def test_posted_invoice_notes_change_unposts_and_reposts(self, tmp_path):
+        """Q-010: posted invoices ARE editable via re-import (unpost → edit
+        → repost), matching what GnuCash's UI itself supports. Adding a
+        notes field to a posted invoice triggers the unpost-repost cycle
+        and the new notes appear in the exported invoice."""
         runner = CliRunner()
         gnc = _setup_book_with(runner, tmp_path, _INVOICE_POSTED)
-        # Re-import with notes added to the posted invoice
         with_notes = _INVOICE_POSTED.replace(
             'invoice "INV-001"\n',
             'invoice "INV-001"\n\tnotes: "Updated after the fact"\n',
@@ -1328,12 +1658,9 @@ class TestUnpostedToPostedTransition:
         r = _import(runner, gnc, _write(tmp_path / "with_notes.txt",
                                         ACCOUNTS + "\n" + with_notes))
         assert r.exit_code == 0, r.output
-        # Status line says skipped — nothing changed
-        assert 'invoice "INV-001": skipped' in r.output
+        assert 'invoice "INV-001": updated' in r.output, r.output
         text = _exported_biz_text(runner, tmp_path, gnc)
         block = _block_for(text, 'invoice "INV-001"')
-        # Notes from the directive must NOT appear in the exported invoice
-        assert not any('Updated after the fact' in line for line in block), (
-            "Posted invoice's notes must not be mutated on re-import; got:\n"
-            + "\n".join(block)
+        assert any('Updated after the fact' in line for line in block), (
+            "New notes must appear after re-import; got:\n" + "\n".join(block)
         )

--- a/tests/integration/test_business_object_import_summary.py
+++ b/tests/integration/test_business_object_import_summary.py
@@ -1,28 +1,28 @@
 """
 Q-009: business-object import gives clear feedback on every directive.
+Q-010: extends the status set with 'unchanged' (no-diff re-import) and
+makes posted invoices/bills mutable via unpost-edit-repost. Tax tables
+remain the only kind that's immutable on hit.
 
-Tests describe the desired CLI output after Q-009. On import, the user
-should see two complementary signals:
+Tests describe the desired CLI output. On import, the user should see
+two complementary signals:
 
 1. **Per-directive line, inline as the import runs:**
 
        customer "C001": created
-       customer "C002": updated
-       taxtable "GST": skipped (already exists)
-       invoice "INV-001": created
-       bill "BILL-001": skipped (already exists)
-
-   Same shape as the per-record output from delete-customers /
-   archive-customers.
+       customer "C002": unchanged
+       taxtable "GST": skipped       ← immutable, refused
+       invoice "INV-001": unchanged  ← exact byte-for-byte match
+       bill "BILL-001": updated      ← entry edited, unposted+reposted
 
 2. **Aggregate counts in the import summary at the end:**
 
        Business Objects:
-         Customers:  1 created, 1 updated, 0 skipped
-         Vendors:    0 created, 1 updated, 0 skipped
-         Tax tables: 0 created, 1 skipped
-         Invoices:   1 created, 1 skipped
-         Bills:      0 created, 1 skipped
+         Customers:  1 created, 1 updated, 0 unchanged, 0 skipped
+         Vendors:    0 created, 1 updated, 0 unchanged, 0 skipped
+         Tax tables: 0 created, 0 updated, 0 unchanged, 1 skipped
+         Invoices:   1 created, 0 updated, 1 unchanged, 0 skipped
+         Bills:      0 created, 0 updated, 1 unchanged, 0 skipped
 
 These tests don't introspect the gnucash file at all — they're
 purely about CLI surface output. The other identity tests in
@@ -77,9 +77,10 @@ class TestPerDirectiveOutput:
                 f"Expected {line_substr!r} in import output:\n{r.output}"
             )
 
-    def test_reimport_shows_updated_for_customers_vendors(self, tmp_path):
-        """Customers and vendors update on re-import (id is constant; mutable
-        fields are refreshed). Status line says 'updated', not 'skipped'."""
+    def test_reimport_shows_unchanged_for_customers_vendors(self, tmp_path):
+        """Q-010: a no-diff re-import of customers/vendors reports 'unchanged',
+        not 'updated'. ('updated' is reserved for re-imports that actually
+        mutate something.)"""
         runner = CliRunner()
         gnc = tmp_path / "test.gnucash"
         r1 = _import_new(runner, gnc)
@@ -88,12 +89,14 @@ class TestPerDirectiveOutput:
 
         r2 = _reimport(runner, gnc)
         assert r2.exit_code == 0, r2.output
-        assert 'customer "1": updated' in r2.output
-        assert 'vendor "V001": updated' in r2.output
+        assert 'customer "1": unchanged' in r2.output, r2.output
+        assert 'vendor "V001": unchanged' in r2.output, r2.output
 
-    def test_reimport_shows_skipped_for_taxtable_invoice_bill(self, tmp_path):
-        """Tax tables, invoices, and bills skip on re-import (their fields
-        can't be safely mutated mid-flight)."""
+    def test_reimport_shows_unchanged_for_invoice_bill_and_skipped_for_taxtable(self, tmp_path):
+        """Q-010: invoices and bills are no longer permanently skipped on
+        re-import; an identical re-import is 'unchanged'. Tax tables are
+        the only kind that remains 'skipped' on hit (they're truly
+        immutable because past posted invoices reference them by pointer)."""
         runner = CliRunner()
         gnc = tmp_path / "test.gnucash"
         r1 = _import_new(runner, gnc)
@@ -102,9 +105,9 @@ class TestPerDirectiveOutput:
 
         r2 = _reimport(runner, gnc)
         assert r2.exit_code == 0, r2.output
-        assert 'taxtable "GST": skipped' in r2.output
-        assert 'invoice "INV-2026-001": skipped' in r2.output
-        assert 'bill "BILL-2026-001": skipped' in r2.output
+        assert 'taxtable "GST": skipped' in r2.output, r2.output
+        assert 'invoice "INV-2026-001": unchanged' in r2.output, r2.output
+        assert 'bill "BILL-2026-001": unchanged' in r2.output, r2.output
 
 
 # ── Aggregate summary ───────────────────────────────────────────────────────
@@ -136,10 +139,10 @@ class TestAggregateSummary:
         assert re.search(r'Bills:\s+5 created', r.output)
 
     def test_reimport_summary_counts(self, tmp_path):
-        """Re-import: customers/vendors update on hit; tax tables always
-        skip; invoices/bills skip when posted, but the fixture's unposted
-        records (INV-2026-002, BILL-2026-002) go through the unposted→
-        update path added in the Q-007 follow-up, so they show 'updated'."""
+        """Q-010: an identical re-import is 'unchanged' across the board for
+        customers/vendors/invoices/bills (no field differs). Tax tables
+        still report 'skipped' — they're immutable on hit so an identical
+        re-import is the only safe outcome."""
         runner = CliRunner()
         gnc = tmp_path / "test.gnucash"
         r1 = _import_new(runner, gnc)
@@ -147,21 +150,21 @@ class TestAggregateSummary:
         time.sleep(1)
 
         r2 = _reimport(runner, gnc)
-        assert r2.exit_code == 0
-        # Customers: 0 created, 2 updated, 0 skipped
-        assert re.search(r'Customers:\s+0 created,\s*2 updated', r2.output)
-        # Vendors: 0 created, 2 updated, 0 skipped
-        assert re.search(r'Vendors:\s+0 created,\s*2 updated', r2.output)
-        # Tax tables: 0 created, 0 updated, 1 skipped
+        assert r2.exit_code == 0, r2.output
+        # Customers: 0 created, 0 updated, 2 unchanged, 0 skipped
+        assert re.search(r'Customers:\s+0 created,\s*0 updated,\s*2 unchanged',
+                         r2.output), r2.output
+        # Vendors: 0 created, 0 updated, 2 unchanged, 0 skipped
+        assert re.search(r'Vendors:\s+0 created,\s*0 updated,\s*2 unchanged',
+                         r2.output), r2.output
+        # Tax tables: 0 created, 0 updated, 0 unchanged, 1 skipped
         assert re.search(r'Tax tables:\s+0 created,.*1 skipped', r2.output)
-        # Invoices: 0 created, 1 updated, 4 skipped
-        # (INV-2026-002 is unposted in the fixture — re-import re-runs the
-        # unposted-update path; the other 4 are posted and skip)
-        assert re.search(r'Invoices:\s+0 created,\s*1 updated,\s*4 skipped',
-                         r2.output)
-        # Bills: 0 created, 1 updated, 4 skipped (BILL-2026-002 is unposted)
-        assert re.search(r'Bills:\s+0 created,\s*1 updated,\s*4 skipped',
-                         r2.output)
+        # Invoices: 0 created, 0 updated, 5 unchanged, 0 skipped (all 5 match)
+        assert re.search(r'Invoices:\s+0 created,\s*0 updated,\s*5 unchanged',
+                         r2.output), r2.output
+        # Bills: 0 created, 0 updated, 5 unchanged, 0 skipped
+        assert re.search(r'Bills:\s+0 created,\s*0 updated,\s*5 unchanged',
+                         r2.output), r2.output
 
     def test_summary_appears_after_per_directive_lines(self, tmp_path):
         """Per-directive output comes first; aggregate summary at the end.

--- a/tests/integration/test_unpost_invoice_bill.py
+++ b/tests/integration/test_unpost_invoice_bill.py
@@ -1,0 +1,340 @@
+"""
+Q-010: dedicated `unpost-invoices` / `unpost-bills` CLI commands.
+
+Two paths can unpost a posted invoice/bill, and the tests below verify
+that BOTH paths exist AND that they have observably different internal
+behaviour:
+
+  Path A — re-import with `posted: none`
+    Triggered by editing the .txt: `posted: { ... }` → `posted: none`
+    and re-importing. The importer detects "only the posted block
+    changed" and short-circuits to a minimal `Unpost(False)` (no
+    destroy-and-rebuild). Entry GUIDs preserved.
+
+  Path B — `gnucash-plaintext unpost-invoices <book> <ID>`
+    Standalone CLI command that doesn't read any plaintext file.
+    Calls `Unpost(False)` directly. Entry GUIDs preserved.
+
+Both end up with the same posted-state (invoice unposted, posting tx
+destroyed, payment txns orphaned in bank). The differences:
+
+  - Path A still rebuilds entries when the directive's entries differ
+    from the existing record's. Path B never touches entries.
+  - Path A requires a current .txt file. Path B doesn't.
+  - Path A emits the per-directive status line via the import summary
+    machinery. Path B prints `<id> (<guid>): unposted` per record.
+"""
+
+import os
+import time
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+
+def _fixture(name: str) -> str:
+    """Load a `tests/fixtures/<name>.txt` file as a string."""
+    path = os.path.join(os.path.dirname(__file__), '..', 'fixtures', f'{name}.txt')
+    with open(path) as f:
+        return f.read()
+
+
+ACCOUNTS = """
+2026-01-01 open Assets
+\ttype: Asset
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Assets:Bank
+\ttype: Bank
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Assets:Accounts Receivable
+\ttype: Accounts Receivable
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Liabilities
+\ttype: Liability
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:Accounts Payable
+\ttype: Accounts Payable
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Income
+\ttype: Income
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Income:Sales
+\ttype: Income
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Expenses
+\ttype: Expense
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Expenses:Supplies
+\ttype: Expense
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+"""
+
+
+def _write(path, text):
+    path.write_text(text)
+    return str(path)
+
+
+def _import_new(runner, gnc, fixture):
+    return runner.invoke(cli, ["import", "--new", str(gnc), fixture,
+                               "--include-business-objects"])
+
+
+def _import(runner, gnc, fixture):
+    return runner.invoke(cli, ["import", str(gnc), fixture,
+                               "--include-business-objects"])
+
+
+def _export_text(runner, gnc, tmp_path):
+    out = tmp_path / "exported.txt"
+    r = runner.invoke(cli, ["export", str(gnc), str(out),
+                            "--include-business-objects"])
+    assert r.exit_code == 0, r.output
+    return out.read_text()
+
+
+def _setup_book_with(runner, tmp_path, fixture_text):
+    gnc = tmp_path / "book.gnucash"
+    fix = _write(tmp_path / "in.txt", ACCOUNTS + "\n" + fixture_text)
+    r = _import_new(runner, gnc, fix)
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    return gnc
+
+
+def _entry_guids_for_invoice(runner, gnc, inv_id):
+    """Reach into the book and read entry GUIDs for the named invoice.
+
+    Used to assert the non-destructive-vs-rebuild distinction between
+    the unpost CLI path and the re-import path.
+    """
+    from gnucash import Query, Session
+    from gnucash.gnucash_business import Invoice
+    ses = Session(f"xml://{gnc}")
+    try:
+        book = ses.book
+        q = Query()
+        q.search_for('gncInvoice')
+        q.set_book(book)
+        guids = []
+        for r in q.run():
+            inv = Invoice(instance=r)
+            if inv.GetID() == inv_id:
+                # Each entry's GUID via ctypes (SWIG GetGUID is unreliable
+                # for Entry on some platforms).
+                import ctypes
+                lib = ctypes.CDLL(None)
+                lib.qof_instance_get_guid.argtypes = [ctypes.c_void_p]
+                lib.qof_instance_get_guid.restype = ctypes.c_void_p
+                lib.guid_to_string_buff.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+                lib.guid_to_string_buff.restype = ctypes.c_char_p
+                buf = ctypes.create_string_buffer(40)
+                for entry in inv.GetEntries():
+                    guid_ptr = lib.qof_instance_get_guid(int(entry.instance))
+                    lib.guid_to_string_buff(guid_ptr, buf)
+                    guids.append(buf.value.decode('ascii'))
+                break
+        q.destroy()
+        return guids
+    finally:
+        ses.end()
+
+
+# ── Path A: re-import with `posted: none` ─────────────────────────────────────
+
+
+class TestReimportPathUnpostsAndPreservesEntryGuids:
+    """When the only difference between existing and directive is
+    `posted: { ... }` → `posted: none`, the importer takes the minimal
+    unpost path: Unpost(False) without destroy-and-rebuild. Entry GUIDs
+    survive."""
+
+    def test_invoice_minimal_unpost_preserves_entry_guids(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_invoice_posted'))
+        before = _entry_guids_for_invoice(runner, gnc, "INV-001")
+        assert len(before) == 1, f"Setup expected 1 entry, got {before}"
+
+        r = _import(runner, gnc, _write(tmp_path / "unpost.txt",
+                                        ACCOUNTS + "\n" + _fixture('q010_invoice_unposted')))
+        assert r.exit_code == 0, r.output
+        assert 'invoice "INV-001": updated' in r.output, r.output
+
+        after = _entry_guids_for_invoice(runner, gnc, "INV-001")
+        assert after == before, (
+            "Minimal-unpost re-import (only `posted` differs) must preserve "
+            f"entry GUIDs; before={before}, after={after}"
+        )
+
+    def test_bill_minimal_unpost_preserves_entry_guids(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_bill_posted'))
+        before = _entry_guids_for_invoice(runner, gnc, "BILL-001")
+        assert len(before) == 1
+
+        r = _import(runner, gnc, _write(tmp_path / "unpost.txt",
+                                        ACCOUNTS + "\n" + _fixture('q010_bill_unposted')))
+        assert r.exit_code == 0, r.output
+        assert 'bill "BILL-001": updated' in r.output, r.output
+
+        after = _entry_guids_for_invoice(runner, gnc, "BILL-001")
+        assert after == before, (
+            "Bill minimal-unpost must preserve entry GUIDs; "
+            f"before={before}, after={after}"
+        )
+
+
+class TestReimportFullRebuildChurnsEntryGuids:
+    """For comparison: when the directive ALSO modifies an entry (not
+    just the posted block), the importer goes through the full
+    destroy-and-rebuild path. Entry GUIDs change. This is the
+    behavioural difference vs the minimal-unpost path."""
+
+    def test_invoice_rebuild_with_entry_change_changes_entry_guids(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_invoice_posted'))
+        before = _entry_guids_for_invoice(runner, gnc, "INV-001")
+        assert len(before) == 1
+
+        edited = _fixture('q010_invoice_posted').replace('\t\tquantity: 1\n', '\t\tquantity: 2\n')
+        r = _import(runner, gnc, _write(tmp_path / "edited.txt",
+                                        ACCOUNTS + "\n" + edited))
+        assert r.exit_code == 0, r.output
+        assert 'invoice "INV-001": updated' in r.output, r.output
+
+        after = _entry_guids_for_invoice(runner, gnc, "INV-001")
+        assert after != before, (
+            "Full-rebuild path (entries changed) is expected to give the "
+            f"entry a new GUID; before={before}, after={after}. If this "
+            "assertion fires, the destroy-and-rebuild path may have been "
+            "removed — re-check the import_invoice flow."
+        )
+
+
+# ── Path B: `unpost-invoices` / `unpost-bills` CLI commands ──────────────────
+
+
+class TestUnpostInvoiceCommand:
+    def test_unposts_a_posted_invoice(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_invoice_posted'))
+
+        r = runner.invoke(cli, ["unpost-invoices", str(gnc), "INV-001"])
+        assert r.exit_code == 0, r.output
+        assert ': unposted' in r.output, r.output
+
+        text = _export_text(runner, gnc, tmp_path)
+        assert 'posted: none' in text, (
+            f"Invoice must be unposted after `unpost-invoices`:\n{text}"
+        )
+
+    def test_preserves_entry_guids(self, tmp_path):
+        """The CLI unpost is non-destructive on entries — same end state
+        as the minimal-unpost re-import path."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_invoice_posted'))
+        before = _entry_guids_for_invoice(runner, gnc, "INV-001")
+        assert len(before) == 1
+
+        r = runner.invoke(cli, ["unpost-invoices", str(gnc), "INV-001"])
+        assert r.exit_code == 0, r.output
+
+        after = _entry_guids_for_invoice(runner, gnc, "INV-001")
+        assert after == before, (
+            f"unpost-invoices CLI must preserve entry GUIDs; "
+            f"before={before}, after={after}"
+        )
+
+    def test_already_unposted_reports_failed_with_detail_and_exits_1(self, tmp_path):
+        """Same exit-1 pattern as archive-customers' 'already archived' —
+        running unpost against a never-posted (or previously-unposted)
+        record is a non-no-op failure. The message must explain *both*
+        possible reasons so the user can tell whether they're hitting an
+        idempotency replay or genuinely targeted the wrong record."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_invoice_unposted'))
+
+        r = runner.invoke(cli, ["unpost-invoices", str(gnc), "INV-001"])
+        assert r.exit_code == 1, r.output
+        assert 'no posting transaction' in r.output, r.output
+        assert 'never posted' in r.output, r.output
+        assert 'already unposted' in r.output, r.output
+
+    def test_not_found_reports_and_exits_1(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_invoice_posted'))
+
+        r = runner.invoke(cli, ["unpost-invoices", str(gnc), "DOES-NOT-EXIST"])
+        assert r.exit_code == 1
+        assert 'not found' in r.output
+
+    def test_by_guid_unposts(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_invoice_posted'))
+        # Read the guid from the exported text
+        text = _export_text(runner, gnc, tmp_path)
+        import re
+        m = re.search(r'invoice "INV-001"\n(?:\t.*\n)*\tguid: "([0-9a-f]{32})"',
+                      text)
+        assert m is not None, f"Couldn't find guid in export:\n{text}"
+        guid = m.group(1)
+
+        r = runner.invoke(cli, ["unpost-invoices", str(gnc), "--by-guid", guid])
+        assert r.exit_code == 0, r.output
+        assert ': unposted' in r.output
+
+    def test_multiple_ids_partial_failure_exits_1(self, tmp_path):
+        """One success + one not-found: save the success but exit 1."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_invoice_posted'))
+
+        r = runner.invoke(cli, ["unpost-invoices", str(gnc),
+                                "INV-001", "DOES-NOT-EXIST"])
+        assert r.exit_code == 1, r.output
+        assert ': unposted' in r.output
+        assert 'not found' in r.output
+
+        # The successful unpost was saved.
+        text = _export_text(runner, gnc, tmp_path)
+        assert 'posted: none' in text
+
+
+class TestUnpostBillCommand:
+    def test_unposts_a_posted_bill(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_bill_posted'))
+
+        r = runner.invoke(cli, ["unpost-bills", str(gnc), "BILL-001"])
+        assert r.exit_code == 0, r.output
+        assert ': unposted' in r.output
+
+        text = _export_text(runner, gnc, tmp_path)
+        assert 'posted: none' in text, (
+            f"Bill must be unposted after `unpost-bills`:\n{text}"
+        )
+
+    def test_preserves_entry_guids(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_bill_posted'))
+        before = _entry_guids_for_invoice(runner, gnc, "BILL-001")
+        assert len(before) == 1
+
+        r = runner.invoke(cli, ["unpost-bills", str(gnc), "BILL-001"])
+        assert r.exit_code == 0, r.output
+
+        after = _entry_guids_for_invoice(runner, gnc, "BILL-001")
+        assert after == before, (
+            f"unpost-bills CLI must preserve entry GUIDs; "
+            f"before={before}, after={after}"
+        )

--- a/use_cases/unpost_business_objects.py
+++ b/use_cases/unpost_business_objects.py
@@ -1,0 +1,139 @@
+"""
+Q-010: dedicated unpost commands for invoices and bills.
+
+`unpost-invoice <book> <ID>...` and `unpost-bill <book> <ID>...` provide
+a one-shot, plaintext-free way to unpost a posted invoice/bill. Unlike
+the re-import path (where toggling `posted: { ... }` → `posted: none`
+also unposts but rebuilds entries from the .txt), this path:
+
+  - Does NOT consult any plaintext file.
+  - Preserves entry GUIDs (no destroy + recreate cycle).
+  - Touches only the posted state. The lot's posting transaction is
+    destroyed; payment transactions in the bank account are orphaned
+    (their AR/AP splits no longer link to a lot). This matches GnuCash
+    UI's own Unpost behaviour exactly.
+
+Use the re-import path when the .txt is the source of truth and you
+want to also edit fields. Use this command when the .txt is stale or
+absent and you only want the unpost itself.
+"""
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import List
+
+from gnucash import Book
+
+from services.gnucash_importer import (
+    _find_bill_by_guid,
+    _find_bills_by_id,
+    _find_invoice_by_guid,
+    _find_invoices_by_id,
+    _swig_invoice_guid_str,
+)
+
+
+class UnpostStatus(Enum):
+    UNPOSTED = auto()
+    NOT_POSTED = auto()
+    NOT_FOUND = auto()
+    AMBIGUOUS_ID = auto()  # legacy data: multiple records share one id
+
+
+@dataclass
+class UnpostResult:
+    id: str
+    guid: str = ''
+    status: UnpostStatus = None
+
+    def message(self) -> str:
+        if self.status == UnpostStatus.UNPOSTED:
+            return 'unposted'
+        if self.status == UnpostStatus.NOT_POSTED:
+            return ('failed — record has no posting transaction (never posted, '
+                    'or already unposted by a previous run / GnuCash UI); '
+                    'no action taken')
+        if self.status == UnpostStatus.AMBIGUOUS_ID:
+            return ('failed — multiple records share this id; rerun with '
+                    '--by-guid')
+        return 'not found'
+
+    def label(self) -> str:
+        if self.guid:
+            return f'{self.id} ({self.guid})'
+        return self.id
+
+
+def _resolve_one(book: Book, id_or_guid: str, by_guid: bool, by_id_fn, by_guid_fn):
+    """Look up exactly one invoice/bill. Returns (record, report_id, report_guid).
+
+    On miss: (None, original_input, '').
+    On ambiguous (legacy duplicates): (None, original_input, '__ambiguous__')
+    so the caller can map to AMBIGUOUS_ID. We refuse to silently pick one.
+    """
+    if by_guid:
+        rec = by_guid_fn(book, id_or_guid)
+        if rec is None:
+            return None, id_or_guid, ''
+        return rec, rec.GetID(), id_or_guid
+    matches = by_id_fn(book, id_or_guid)
+    if not matches:
+        return None, id_or_guid, ''
+    if len(matches) > 1:
+        return None, id_or_guid, '__ambiguous__'
+    rec = matches[0]
+    return rec, rec.GetID(), _swig_invoice_guid_str(rec)
+
+
+class UnpostInvoicesUseCase:
+    """Unpost one or more posted customer invoices."""
+
+    def __init__(self, book: Book):
+        self.book = book
+
+    def execute(self, ids: List[str], by_guid: bool = False) -> List[UnpostResult]:
+        results = []
+        for arg in ids:
+            rec, rid, rguid = _resolve_one(
+                self.book, arg, by_guid, _find_invoices_by_id, _find_invoice_by_guid)
+            if rec is None and rguid == '__ambiguous__':
+                results.append(UnpostResult(id=rid, status=UnpostStatus.AMBIGUOUS_ID))
+                continue
+            if rec is None:
+                results.append(UnpostResult(id=rid, status=UnpostStatus.NOT_FOUND))
+                continue
+            if rec.GetPostedTxn() is None:
+                results.append(UnpostResult(id=rid, guid=rguid,
+                                            status=UnpostStatus.NOT_POSTED))
+                continue
+            rec.Unpost(False)
+            results.append(UnpostResult(id=rid, guid=rguid,
+                                        status=UnpostStatus.UNPOSTED))
+        return results
+
+
+class UnpostBillsUseCase:
+    """Unpost one or more posted vendor bills."""
+
+    def __init__(self, book: Book):
+        self.book = book
+
+    def execute(self, ids: List[str], by_guid: bool = False) -> List[UnpostResult]:
+        results = []
+        for arg in ids:
+            rec, rid, rguid = _resolve_one(
+                self.book, arg, by_guid, _find_bills_by_id, _find_bill_by_guid)
+            if rec is None and rguid == '__ambiguous__':
+                results.append(UnpostResult(id=rid, status=UnpostStatus.AMBIGUOUS_ID))
+                continue
+            if rec is None:
+                results.append(UnpostResult(id=rid, status=UnpostStatus.NOT_FOUND))
+                continue
+            if rec.GetPostedTxn() is None:
+                results.append(UnpostResult(id=rid, guid=rguid,
+                                            status=UnpostStatus.NOT_POSTED))
+                continue
+            rec.Unpost(False)
+            results.append(UnpostResult(id=rid, guid=rguid,
+                                        status=UnpostStatus.UNPOSTED))
+        return results


### PR DESCRIPTION
Q-009 introduced created/updated/skipped status reporting on business-object import. An external reviewer flagged two issues:

  1. 'updated' was liberal — a no-change re-import passed through the update code path and reported 'updated' even when no field differed. Scripts asserting on counts over-counted.
  2. 'skipped' for posted invoices/bills was a permanent dead-end that contradicted GnuCash's own UI, which supports unpost-edit-repost on any posted record.

Q-010 fixes both, plus exposes a dedicated unpost CLI.

## Four-status model

  - created:   fresh record (was 'created')
  - updated:   existing record had at least one mutable field changed
  - unchanged: existing record matches the directive byte-for-byte (NEW)
  - skipped:   existing record is immutable; importer refused to mutate
               (now reserved for tax tables — only kind where past posted
               invoices reference them by stored pointer)

`unchanged` is the happy path for an idempotent re-run. `skipped` now has a single, sharp meaning: "the importer chose not to apply your change because the target's state forbids it." Per-directive output and the aggregate summary both grew an `unchanged` column.

## Importer changes (services/gnucash_importer.py)

  - BusinessObjectImportResult counters extended with 'unchanged'.
  - import_customer / import_vendor: short-circuit on byte-equal match via _customer_matches_directive / _vendor_matches_directive. Returns 'unchanged' without touching the book.
  - import_invoice / import_bill: new _invoice_matches_directive / _bill_matches_directive helpers compare date_opened, billing_id (invoice), notes, custom KVP, entries (positional, by field), the posted: block (or absence), and payments (count + per-payment fields).
      * match → 'unchanged'
      * existing posted but differs → Unpost(False) → fall through to rebuild + repost (mirrors GnuCash UI's unpost-edit-repost) * existing unposted, differs → rebuild as before
  - _is_only_unpost_diff: when the *only* diff is `posted: { ... }` → `posted: none` (entries and payments otherwise match), short-circuit to a minimal Unpost(False) with NO destroy-and-rebuild. Entry GUIDs survive — useful for users who edit the .txt to unpost without breaking external GUID references.
  - Payment matcher handles two flavours:
      * normal: compare bank_account, date, amount, memo (read from the bank-side split's GetMemo(), matching the exporter — ApplyPayment puts the memo on the splits, not on the tx description, which gets the owner name)
      * txn_guid retarget: compare only bank_account + txn_guid, since the bank tx supplies the rest

## Dedicated unpost CLI

  cli/unpost_cmd.py + use_cases/unpost_business_objects.py introduce
  `unpost-invoices` and `unpost-bills`. They don't read any plaintext
  file — they call Unpost(False) directly. Use this when the .txt is
  stale or absent, or when you want to guarantee no entry-rebuild even
  in edge cases the matcher doesn't cover.

  Per-record output mirrors delete-customers:
    INV-2026-001 (abc123…): unposted
    INV-2026-002 (def456…): failed — record has no posting transaction
        (never posted, or already unposted by a previous run / GnuCash UI);
        no action taken
    INV-2026-003: not found
    INV-2026-004: failed — multiple records share this id; rerun with
        --by-guid

  Exit 1 if any record didn't reach UNPOSTED; successful unposts still
  saved. Mirrors the archive-customers pattern for consistency.

## CLI summary (cli/import_cmd.py)

  Business Objects:
    Customers:   1 created, 0 updated, 50 unchanged, 0 skipped
    Invoices:    0 created, 1 updated,  0 unchanged, 49 skipped

  4-column layout makes the difference between "clean re-run" and
  "fresh import" visually obvious.

## Tests

  - tests/integration/test_business_object_idempotent_reimport.py:
    + TestNoChangeReimportIsUnchanged (9 cases): customer/vendor/invoice/ bill no-change → unchanged; field/entry change → updated; KVP-only change → updated.
    + TestTaxTableImmutableReportsSkipped: tax tables remain skipped on hit (replaces the old "everything posted is skipped" class).
    + TestPostedToPostedReimport (7 cases): posted no-change is unchanged; entry/posted-block edit triggers unpost-rebuild-repost; posted → posted:none unposts. Bill side covered too.
    + Existing TestUnpostedToPostedTransition cases reconciled: posted no-change is now 'unchanged' (was 'skipped'); the 'posted-stays-skipped' tests were renamed to reflect Q-010's mutable-posted semantics.
  - tests/integration/test_unpost_invoice_bill.py (11 cases):
    + Path A (re-import minimal-unpost) preserves entry GUIDs.
    + Path A (re-import rebuild) churns entry GUIDs — proves the two paths through the importer behave differently as documented.
    + Path B (CLI unpost) preserves entry GUIDs unconditionally.
    + Edge cases: already-unposted, not-found, --by-guid, partial-batch exit code.
  - tests/integration/test_business_object_import_summary.py: existing Q-009 expectations flipped to 'unchanged' for the no-diff cases.
  - tests/fixtures/q010_*.txt: extracted from inline Python strings per repo convention (fixtures live in .txt files).

## Coverage

  Tested on debian13 (latest), ubuntu20 (GnuCash 3.8 / RTLD_LOCAL prone),
  ubuntu22, ubuntu24. 892 tests pass on each (881 prior + 11 new unpost).
  Lint clean.