### PR TITLE
feat(Q-012): render unposted invoices as drafts instead of crashing

### DIFF
--- a/docs/issues/Q-012-print-invoice-on-unposted-invoice-crashes.md
+++ b/docs/issues/Q-012-print-invoice-on-unposted-invoice-crashes.md
@@ -1,0 +1,98 @@
+---
+id: Q-012
+title: `print-invoice` on an unposted invoice crashes with NoneType error
+category: quality
+severity: medium
+status: open
+---
+
+## Problem
+
+Calling `gnucash-plaintext print-invoice <book> --invoice-id <id>` on an
+**unposted** invoice (one with `posted: none` in plaintext, or
+unposted in the GnuCash UI) crashes the renderer with a stack trace:
+
+```
+File "services/invoice_renderer.py", line 179, in invoice_to_xml
+    for i in range(posting_txn.CountSplits()):
+                   ^^^^^^^^^^^^^^^^^^^^^^^
+AttributeError: 'NoneType' object has no attribute 'CountSplits'
+```
+
+`inv.GetPostedTxn()` returns `None` for unposted invoices; the renderer
+unconditionally calls `.CountSplits()` on the result. Same problem one
+loop later for `inv.GetPostedLot().get_split_list()`.
+
+Reported by a real user (Cloudflare Wrangler log, 2026-05-08) when
+their frontend asked the API to render an unposted draft invoice as a
+PDF preview. The API returned 500 with the trace. The reviewer for
+Q-011 noted this pre-existing issue and recommended a separate ticket;
+filing now that a real user has hit it.
+
+## Why it matters
+
+Drafts are a normal workflow:
+
+- User creates an invoice in plaintext with `posted: none`
+- User wants to preview it (or share with the client) as a PDF before
+  posting
+- Currently impossible — must post first, then print
+
+Posting is irreversible-ish (creates AR/AP transactions), so forcing
+the user to post just to preview is a significant friction.
+
+## Fix
+
+Make the renderer handle unposted invoices without crashing. Strategy:
+
+1. Detect unposted state at the top of `invoice_to_xml`:
+   `posting_txn = inv.GetPostedTxn()` is None.
+2. Set the invoice's XML `status` attribute to `'draft'` instead of
+   `'paid'` / `'unpaid'`.
+3. Compute `<subtotal>` from the entries themselves (`quantity * price`
+   per entry, summed). Already trivially available — the entry loop
+   computes `qty * price` for the per-row `<amount>`.
+4. Skip the tax-lines, payments, and amount-remaining elements
+   entirely for drafts. Tax breakdown only exists post-posting; payments
+   require a posted lot.
+5. Set `<total>` equal to subtotal for drafts (no tax breakdown
+   yet — see "Known limitation" below).
+
+In the XSLT (`services/invoice.xslt`), extend the existing status
+`<xsl:choose>` with a `'draft'` case showing a DRAFT badge. Add a CSS
+class `badge-draft` for grey/neutral colouring. The payment-history
+section is already conditional (`<xsl:if test="payments/payment">`) so
+it naturally vanishes when no payments exist.
+
+## Known limitation (Q-012 v1)
+
+A draft invoice's PDF will show subtotal but **no per-tax breakdown**
+(no GST line, PST line, etc.) and no grand total inclusive of tax. To
+compute taxes pre-posting we'd need to walk each entry's `tax_table`
+and apply the rate (PERCENT/VALUE) per entry, then aggregate by tax
+account — non-trivial because GnuCash's `gnc_entry_get_value` /
+`gnc_entry_get_tax_value` SWIG bindings are unreliable across versions
+(per CLAUDE.md hard-won findings). A future issue can extend this.
+
+For the draft preview use case, showing line items + subtotal is
+already a meaningful improvement over "500 Internal Server Error".
+
+## Files to change
+
+| File | Change |
+|---|---|
+| `services/invoice_renderer.py` | Branch on `posting_txn is None`. Compute subtotal from entries. Skip tax-lines / payments / amount-remaining for drafts. Set `status='draft'`. |
+| `services/invoice.xslt` | Add `'draft'` case to the status badge `<xsl:choose>`. Add `.badge-draft` CSS rule. |
+| `tests/integration/test_q012_print_unposted_invoice.py` | New test file: print-invoice on unposted → exit 0 + PDF created; rendered HTML contains DRAFT badge; rendered HTML contains entry rows; rendered HTML does NOT contain payment-history table. |
+
+## Out of scope
+
+- Computing tax breakdown for drafts (see Known limitation above).
+- A "watermark" / overlay on draft PDFs — `badge-draft` in the header
+  is enough signal.
+- Bill rendering — there's no `print-bill` command; bills are received,
+  not sent.
+
+---
+
+**Created**: 2026-05-08

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -53,3 +53,4 @@ When a fix is merged, update `status: open` → `closed` in the file's frontmatt
 | [Q-009](Q-009-import-summary-business-objects.md) | Business-object import is silent — re-import gives no signal of skip vs. create vs. update | medium |
 | [Q-010](Q-010-strict-updated-status-on-no-change-reimport.md) | `'updated'` is liberal — reports updated for no-change re-imports; posted invoices/bills can't be edited via re-import | low |
 | [Q-011](Q-011-invoice-action-optional-and-custom-template.md) | Invoice `action` field forces a hardcode; UNIT column shows nonsense; no template override | low |
+| [Q-012](Q-012-print-invoice-on-unposted-invoice-crashes.md) | `print-invoice` on an unposted invoice crashes with NoneType error | medium |

--- a/services/invoice.xslt
+++ b/services/invoice.xslt
@@ -4,7 +4,7 @@
   ============================================
   Input XML structure (see invoice_to_xml() in test_business_roundtrip.py):
 
-    <invoice status="paid|unpaid" currency="CAD">
+    <invoice status="paid|unpaid|draft" currency="CAD">
       <id>, <date>, <due-date>, <billing-id>, <notes>
       <customer>  <name>, <addr1..4>, <email>, <phone>
       <company>   <name>, <id>, <addr1..4>, <phone>, <email>, <url>
@@ -72,6 +72,7 @@
                     letter-spacing: 1px; margin-left: 10px; vertical-align: middle; }
     .badge-paid   { background: #d4edda; color: #155724; }
     .badge-unpaid { background: #fff3cd; color: #856404; }
+    .badge-draft  { background: #e2e3e5; color: #383d41; }
 
     /* ── Payment history section ───────────────────────────────────── */
     .payment-section { margin-top: 28px; }
@@ -122,11 +123,17 @@
 <body>
 
   <!-- Invoice title + status badge -->
+  <!-- Q-012: 'draft' status is set by the renderer when the invoice is
+       not yet posted. A draft has line items but no per-tax breakdown
+       (taxes only exist post-posting) and no payment history. -->
   <h1>
     Invoice
     <xsl:choose>
       <xsl:when test="@status = 'paid'">
         <span class="badge badge-paid">Paid</span>
+      </xsl:when>
+      <xsl:when test="@status = 'draft'">
+        <span class="badge badge-draft">Draft</span>
       </xsl:when>
       <xsl:otherwise>
         <span class="badge badge-unpaid">Unpaid</span>

--- a/services/invoice_renderer.py
+++ b/services/invoice_renderer.py
@@ -101,7 +101,12 @@ def invoice_to_xml(inv, book, company_info=None):
     lib = load_gnc_engine()
 
     inv_id = inv.GetID()
-    is_paid = gc.gncInvoiceIsPaid(inv.instance)
+    # Q-012: detect unposted state up front. The renderer's tax/payment
+    # blocks below all assume a posted invoice (posting_txn + posted_lot
+    # both non-None); for unposted we render a "draft" preview instead.
+    posting_txn = inv.GetPostedTxn()
+    is_draft = posting_txn is None
+    is_paid = False if is_draft else gc.gncInvoiceIsPaid(inv.instance)
     currency = inv.GetCurrency().get_mnemonic()
     date_opened = inv.GetDateOpened().strftime("%Y-%m-%d")
     date_due = inv.GetDateDue()
@@ -124,9 +129,13 @@ def invoice_to_xml(inv, book, company_info=None):
     addr3, addr4 = addr.GetAddr3(), addr.GetAddr4()
     email = addr.GetEmail()
 
-    root = ET.Element('invoice',
-                      status='paid' if is_paid else 'unpaid',
-                      currency=currency)
+    if is_draft:
+        status = 'draft'
+    elif is_paid:
+        status = 'paid'
+    else:
+        status = 'unpaid'
+    root = ET.Element('invoice', status=status, currency=currency)
     ET.SubElement(root, 'id').text = inv_id
     ET.SubElement(root, 'date').text = date_opened
     ET.SubElement(root, 'due-date').text = date_due_s
@@ -154,6 +163,7 @@ def invoice_to_xml(inv, book, company_info=None):
     ET.SubElement(co_el, 'url').text = co.get('url', '')
 
     entries_el = ET.SubElement(root, 'entries')
+    entries_subtotal = 0.0  # Q-012: accumulate for drafts (no posting tx yet).
     for raw_entry in inv.GetEntries():
         ptr = int(raw_entry.instance)
         desc = safe_ctypes_string(lib.gncEntryGetDescription, ptr)
@@ -162,6 +172,8 @@ def invoice_to_xml(inv, book, company_info=None):
         price_c = lib.gncEntryGetInvPrice(ptr)
         qty = qty_c.num / qty_c.denom if qty_c.denom else 0.0
         price = price_c.num / price_c.denom if price_c.denom else 0.0
+        line_amount = qty * price
+        entries_subtotal += line_amount
 
         tax_label, tax_type = _read_tax_label(lib, ptr)
 
@@ -170,12 +182,25 @@ def invoice_to_xml(inv, book, company_info=None):
         ET.SubElement(e_el, 'action').text = action
         ET.SubElement(e_el, 'quantity').text = f"{qty:.4f}".rstrip('0').rstrip('.')
         ET.SubElement(e_el, 'unit-price').text = f"{price:.2f}"
-        ET.SubElement(e_el, 'amount').text = f"{qty * price:.2f}"
+        ET.SubElement(e_el, 'amount').text = f"{line_amount:.2f}"
         ET.SubElement(e_el, 'tax-label', type=tax_type).text = tax_label
 
-    posting_txn = inv.GetPostedTxn()
-    subtotal_total = 0.0
     tax_lines_el = ET.SubElement(root, 'tax-lines')
+    payments_el = ET.SubElement(root, 'payments')
+
+    if is_draft:
+        # Q-012: drafts have no posting tx and no lot. Show subtotal from
+        # the entries themselves; no per-tax breakdown (would require
+        # walking each entry's tax_table — non-trivial across GnuCash
+        # versions, see issue Q-012 "Known limitation"). No payments,
+        # no amount-remaining. Total = subtotal as a placeholder; the
+        # XSLT shows a DRAFT badge so the user knows tax isn't included.
+        ET.SubElement(root, 'subtotal').text = f"{entries_subtotal:.2f}"
+        ET.SubElement(root, 'total').text = f"{entries_subtotal:.2f}"
+        return ET.ElementTree(root)
+
+    # Posted: derive tax lines + subtotal from the posting transaction's splits.
+    subtotal_total = 0.0
     for i in range(posting_txn.CountSplits()):
         s = posting_txn.GetSplit(i)
         acct = s.GetAccount()
@@ -195,7 +220,6 @@ def invoice_to_xml(inv, book, company_info=None):
     ET.SubElement(root, 'total').text = f"{grand_total:.2f}"
 
     lot = inv.GetPostedLot()
-    payments_el = ET.SubElement(root, 'payments')
     for raw_split in lot.get_split_list():
         s = Split(instance=raw_split)
         txn = s.GetParent()

--- a/tests/fixtures/q012_invoice_posted_simple.txt
+++ b/tests/fixtures/q012_invoice_posted_simple.txt
@@ -1,0 +1,24 @@
+customer "C001"
+	name: "Acme Corp"
+	currency: CAD
+
+invoice "INV-POSTED-001"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-05-08
+	entry:
+		date: 2026-05-08
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 10
+		price: 50
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-05-08
+		due: 2026-05-23
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-POSTED-001"
+		accumulate: true
+	payment: none

--- a/tests/fixtures/q012_invoice_unposted_draft.txt
+++ b/tests/fixtures/q012_invoice_unposted_draft.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme Corp"
+	currency: CAD
+
+invoice "INV-DRAFT-001"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-05-08
+	entry:
+		date: 2026-05-08
+		description: "Goods"
+		action: ""
+		account: "Income:Sales"
+		quantity: 100
+		price: 15
+		taxable: false
+		tax_included: false
+	entry:
+		date: 2026-05-08
+		description: "Sales"
+		action: ""
+		account: "Income:Sales"
+		quantity: 5
+		price: 20
+		taxable: false
+		tax_included: false
+	posted: none
+	payment: none

--- a/tests/integration/test_q012_print_unposted_invoice.py
+++ b/tests/integration/test_q012_print_unposted_invoice.py
@@ -1,0 +1,192 @@
+"""
+Q-012: `print-invoice` on an unposted invoice no longer crashes.
+
+Pre-Q-012, calling `print-invoice` on an invoice with `posted: none`
+would hit `posting_txn.CountSplits()` on a None object and crash. Real
+user incident: their frontend asked the API to render a draft invoice
+and got a 500 with a NoneType AttributeError.
+
+Q-012 makes the renderer treat unposted invoices as drafts:
+  - Status attribute = 'draft' (vs 'paid' / 'unpaid' for posted)
+  - Subtotal computed from entries directly (qty * price)
+  - No tax-line breakdown (would require pre-post tax computation per
+    entry; deferred — see issue Q-012)
+  - No payment-history table (drafts can't have payments)
+  - No amount-remaining
+
+The XSLT shows a DRAFT badge so the user knows the rendered total
+doesn't include tax.
+"""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_XSLT = _REPO_ROOT / "services" / "invoice.xslt"
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+_ACCOUNTS = """
+2026-01-01 open Assets
+\ttype: Asset
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Assets:Bank
+\ttype: Bank
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Assets:Accounts Receivable
+\ttype: Accounts Receivable
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Income
+\ttype: Income
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Income:Sales
+\ttype: Income
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+"""
+
+
+def _fixture(name: str) -> str:
+    """Load a `tests/fixtures/<name>.txt` file as a string."""
+    return (_FIXTURES / f"{name}.txt").read_text()
+
+
+def _write(path: Path, text: str) -> str:
+    path.write_text(text)
+    return str(path)
+
+
+def _import_new(runner, gnc, fixture):
+    return runner.invoke(cli, ["import", "--new", str(gnc), fixture,
+                               "--include-business-objects"])
+
+
+def _render_invoice_html(gnc_path: str, invoice_id: str) -> str:
+    """Render the named invoice through the embedded XSLT — same path
+    print-invoice uses internally, minus the weasyprint PDF step."""
+    from gnucash import Query, Session
+    from gnucash.gnucash_business import Invoice
+
+    from services.invoice_renderer import render_to_html
+
+    ses = Session(f"xml://{gnc_path}")
+    try:
+        book = ses.book
+        q = Query()
+        q.search_for('gncInvoice')
+        q.set_book(book)
+        inv = next(
+            (i for r in q.run() for i in [Invoice(instance=r)] if i.GetID() == invoice_id),
+            None,
+        )
+        q.destroy()
+        assert inv is not None, f"Invoice {invoice_id!r} not found"
+        return render_to_html(inv, book, str(_DEFAULT_XSLT))
+    finally:
+        ses.end()
+
+
+@pytest.fixture
+def gnc_with_draft_invoice(tmp_path):
+    runner = CliRunner()
+    gnc = tmp_path / "book.gnucash"
+    fixture = _ACCOUNTS + _fixture("q012_invoice_unposted_draft")
+    r = _import_new(runner, gnc, _write(tmp_path / "in.txt", fixture))
+    assert r.exit_code == 0, r.output
+    return str(gnc)
+
+
+class TestPrintInvoiceOnUnpostedNoLongerCrashes:
+    """The original bug: 500 with `'NoneType' object has no attribute
+    'CountSplits'`. After Q-012 the renderer must succeed and produce
+    a PDF."""
+
+    def test_print_unposted_invoice_succeeds(self, gnc_with_draft_invoice, tmp_path):
+        pdf = tmp_path / "draft.pdf"
+        runner = CliRunner()
+        r = runner.invoke(cli, [
+            "print-invoice", gnc_with_draft_invoice,
+            "--invoice-id", "INV-DRAFT-001",
+            "-o", str(pdf),
+        ])
+        assert r.exit_code == 0, (
+            f"print-invoice on an unposted invoice must not crash. Got:\n"
+            f"{r.output}"
+        )
+        assert pdf.exists() and pdf.stat().st_size > 0
+
+
+class TestRenderedDraftInvoice:
+    """The HTML produced for a draft invoice must:
+      - mark itself as a draft (status='draft' → DRAFT badge),
+      - include all entry rows,
+      - omit per-tax breakdown (drafts can't compute taxes pre-post),
+      - omit the payment-history table (drafts have no payments)."""
+
+    def test_draft_badge_present(self, gnc_with_draft_invoice):
+        """Match the active <span> rather than the class name alone — the
+        embedded XSLT defines `.badge-paid`/`.badge-unpaid`/`.badge-draft`
+        in the <style> block, so all three substrings appear in every
+        rendered HTML. The discriminator is which span is actually
+        emitted."""
+        html = _render_invoice_html(gnc_with_draft_invoice, "INV-DRAFT-001")
+        assert '<span class="badge badge-draft">Draft</span>' in html, (
+            f"Draft invoice must render a DRAFT badge span.\nHTML:\n{html}"
+        )
+        assert '<span class="badge badge-paid">' not in html
+        assert '<span class="badge badge-unpaid">' not in html
+
+    def test_entry_rows_present(self, gnc_with_draft_invoice):
+        html = _render_invoice_html(gnc_with_draft_invoice, "INV-DRAFT-001")
+        # Both entries should appear in the line-items table.
+        assert '>Goods<' in html, html
+        assert '>Sales<' in html, html
+
+    def test_subtotal_matches_sum_of_entry_amounts(self, gnc_with_draft_invoice):
+        """Q-012: drafts compute subtotal as sum of (qty * price). Our
+        fixture: 100 * $15 + 5 * $20 = $1500 + $100 = $1600."""
+        html = _render_invoice_html(gnc_with_draft_invoice, "INV-DRAFT-001")
+        assert '1,600.00' in html, (
+            f"Draft subtotal must equal sum of entry amounts ($1,600.00). "
+            f"HTML:\n{html}"
+        )
+
+    def test_no_payment_history_section(self, gnc_with_draft_invoice):
+        html = _render_invoice_html(gnc_with_draft_invoice, "INV-DRAFT-001")
+        # Payment History header is conditional on payments existing.
+        assert 'Payment History' not in html, (
+            f"Draft invoice has no payments — Payment History section must "
+            f"NOT render.\nHTML:\n{html}"
+        )
+
+    def test_no_amount_remaining(self, gnc_with_draft_invoice):
+        """Amount Remaining is part of the payment-history table; absence
+        of payments means no remaining row either."""
+        html = _render_invoice_html(gnc_with_draft_invoice, "INV-DRAFT-001")
+        assert 'Amount Remaining' not in html
+
+
+class TestPostedInvoicesStillWork:
+    """Regression guard: posted invoices must still render with their
+    full tax breakdown and (if applicable) payment history. The fix
+    branch in invoice_to_xml gates only on `posting_txn is None`, so
+    posted invoices flow through the original code path unchanged."""
+
+    def test_posted_invoice_renders_with_unpaid_badge(self, tmp_path):
+        runner = CliRunner()
+        gnc = tmp_path / "book.gnucash"
+        fixture = _ACCOUNTS + _fixture("q012_invoice_posted_simple")
+        r = _import_new(runner, gnc, _write(tmp_path / "in.txt", fixture))
+        assert r.exit_code == 0, r.output
+
+        html = _render_invoice_html(str(gnc), "INV-POSTED-001")
+        assert '<span class="badge badge-unpaid">Unpaid</span>' in html, html
+        assert '<span class="badge badge-draft">' not in html


### PR DESCRIPTION
Reported by an external user (Cloudflare Wrangler log, 2026-05-08): their frontend asked the API to render an unposted invoice as a preview PDF and got a 500 with:

  File "services/invoice_renderer.py", line 179, in invoice_to_xml
      for i in range(posting_txn.CountSplits()):
  AttributeError: 'NoneType' object has no attribute 'CountSplits'

`inv.GetPostedTxn()` returns None for unposted invoices, and the renderer dereferenced it unconditionally; same problem one loop later on `inv.GetPostedLot().get_split_list()`. Pre-existing — flagged but deferred during the Q-011 review.

Drafts are a normal workflow: create an invoice with `posted: none`, preview the PDF, share with the client, post once approved. Posting creates AR transactions and is irreversible-ish, so forcing the user to post just to preview is real friction.

## Renderer (services/invoice_renderer.py)

Detect unposted state at the top of `invoice_to_xml`:

  posting_txn = inv.GetPostedTxn()
  is_draft = posting_txn is None

For drafts, accumulate `qty * price` per entry into `entries_subtotal` during the existing entry loop (already computed for the per-row `<amount>`), emit `<subtotal>` and `<total>` from that, and early- return. The `<tax-lines>` and `<payments>` parent elements are still created (empty) — the XSLT's existing `<xsl:if test="payments/payment">` conditional and the per-`tax-line` iteration both produce nothing for an empty parent, so the posted code path is structurally unchanged.

`is_paid = gc.gncInvoiceIsPaid(...)` is gated behind `if is_draft` because calling it on an unposted invoice is undefined.

## Known limitation (Q-012 v1)

A draft renders subtotal but **no per-tax breakdown** and no grand total inclusive of tax. Computing taxes pre-posting would require walking each entry's `tax_table` and applying PERCENT/VALUE rates per entry, then aggregating by tax account — non-trivial because `gnc_entry_get_value` / `gnc_entry_get_tax_value` SWIG bindings are unreliable across GnuCash versions (per CLAUDE.md hard-won findings). For the draft-preview use case, line items + subtotal + DRAFT badge is already a meaningful improvement over 500 Internal Server Error. A future issue can extend this.

## XSLT (services/invoice.xslt)

One `<xsl:when test="@status='draft'">` branch in the existing status `<xsl:choose>`, emitting `<span class="badge badge-draft"> Draft</span>`. New `.badge-draft` CSS rule (grey/neutral, matching the paid/unpaid colour scheme). Header comment updated to document the new status value.

Payment-history section is already conditional on `payments/payment` existing, so it naturally vanishes for drafts.

## Tests (tests/integration/test_q012_print_unposted_invoice.py)

Five cases on the unposted fixture plus one regression on a posted fixture:

  - test_print_unposted_invoice_succeeds: the original bug — exit 0 and a non-empty PDF on disk (vs. AttributeError pre-fix).
  - test_draft_badge_present: matches the active `<span>` rather than the class name alone — `.badge-paid` / `.badge-unpaid` / `.badge-draft` all appear in the `<style>` block of every rendered HTML, so the discriminator is which span is actually emitted.
  - test_entry_rows_present: both line items show up.
  - test_subtotal_matches_sum_of_entry_amounts: 100 * \$15 + 5 * \$20 = \$1,600.00 in the rendered HTML.
  - test_no_payment_history_section / test_no_amount_remaining: payment-history table and amount-remaining row both absent for drafts.
  - test_posted_invoice_renders_with_unpaid_badge: regression guard — posted invoices still render the unpaid badge and not a draft badge. The fix branches only on `posting_txn is None`, so posted invoices flow through the original code path unchanged.

Fixtures under tests/fixtures/q012_*.txt per repo convention (no inline plaintext strings in test files).

## Out of scope

  - Per-tax breakdown for drafts (see Known limitation).
  - Watermark / overlay on draft PDFs — the header DRAFT badge is sufficient signal.
  - Bill rendering — there is no `print-bill` command.