### PR TITLE
feat(Q-013): delete-invoices / delete-bills for unposted records

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,6 +953,39 @@ Compared to the re-import path:
 | Entry GUIDs | Preserved when only the posted block toggles; otherwise rebuilt | Always preserved |
 | Use when... | The .txt is your source of truth and may also edit fields | The .txt is stale/absent and you only want the unpost |
 
+#### Deleting unposted invoices/bills: `delete-invoices` / `delete-bills`
+
+Hard-delete an unposted customer invoice or vendor bill by ID (or GUID
+with `--by-guid`). Refuses posted records — to delete a previously
+posted record, run the two-step:
+
+```bash
+gnucash-plaintext unpost-invoices ledger.gnucash INV-2026-001
+gnucash-plaintext delete-invoices ledger.gnucash INV-2026-001
+```
+
+The explicit two-step keeps the destruction of the posting transaction
+(and the orphaning of payment splits) under its own command rather
+than as a silent side effect of `delete-*`.
+
+```bash
+gnucash-plaintext delete-invoices ledger.gnucash INV-DRAFT-001
+gnucash-plaintext delete-bills    ledger.gnucash BILL-DRAFT-001 BILL-DRAFT-002
+gnucash-plaintext delete-invoices ledger.gnucash --by-guid 9f14a498cc894d50931f855a9a31d594
+```
+
+Per-record output mirrors `delete-customers` / `unpost-invoices`:
+
+```
+INV-DRAFT-001 (abc123…): deleted
+INV-POSTED-002 (def456…): failed — posted; run unpost-invoices first, then delete-invoices
+INV-MISSING: not found
+INV-DUPLICATE-ID: failed — multiple records share this id; rerun with --by-guid
+```
+
+Exit code 1 if any record was not found, was posted, or had a duplicate
+id; successful deletes are still saved.
+
 In all cases the importer first verifies that the directive's identity
 agrees with whatever's already in the book. The following are caught
 with a clear error rather than silently doing the wrong thing:
@@ -1063,11 +1096,16 @@ history and can be undone by re-importing the record without `active: false`.
 
 Use `delete-customers` only for customers created by mistake that have **never
 had any invoices raised against them**. Deletion is blocked if any invoices
-exist (paid or unpaid):
+exist (paid or unpaid, posted or unposted):
 
 ```bash
 gnucash-plaintext delete-customers mybook.gnucash CUST-001 CUST-002
 ```
+
+To clean up a customer whose only invoices were also mistakes, drop the
+invoices first with [`delete-invoices`](#deleting-unposted-invoicesbills-delete-invoices--delete-bills)
+(running `unpost-invoices` first if any were posted), then re-run
+`delete-customers`.
 
 ```
 CUST-001 (9f14a498cc894d50931f855a9a31d594): deleted

--- a/cli/delete_cmd.py
+++ b/cli/delete_cmd.py
@@ -31,7 +31,10 @@ from use_cases.delete_business_objects import (
     ArchiveCustomersUseCase,
     ArchiveStatus,
     ArchiveVendorsUseCase,
+    DeleteBillsUseCase,
     DeleteCustomersUseCase,
+    DeleteInvoiceStatus,
+    DeleteInvoicesUseCase,
     DeleteStatus,
 )
 
@@ -111,6 +114,39 @@ def _run_archive(gnucash_file, ids, use_case_cls, by_guid=False):
         repo.close()
 
 
+def _run_delete_invoice_or_bill(gnucash_file, ids, use_case_cls, by_guid=False):
+    """Q-013: shared CLI body for `delete-invoices` / `delete-bills`.
+
+    Mirrors `_run_delete` (customers) and `_run_unpost`. Saves on
+    partial success so completed deletes are not thrown away when a
+    later id in the batch hits FAILED_POSTED / NOT_FOUND.
+    """
+    ids = _normalise_guids(ids) if by_guid else list(ids)
+    repo = GnuCashRepository(gnucash_file)
+    repo.open(mode=SessionMode.NORMAL)
+    try:
+        use_case = use_case_cls(repo.book)
+        results = use_case.execute(ids, by_guid=by_guid)
+
+        all_ok = True
+        for r in results:
+            click.echo(f'{r.label()}: {r.message()}')
+            if r.status != DeleteInvoiceStatus.DELETED:
+                all_ok = False
+
+        if any(r.status == DeleteInvoiceStatus.DELETED for r in results):
+            try:
+                repo.save()
+            except Exception as e:
+                if 'ERR_FILEIO_BACKUP_ERROR' not in str(e):
+                    raise click.ClickException(f'Failed to save: {e}') from e
+
+        if not all_ok:
+            sys.exit(1)
+    finally:
+        repo.close()
+
+
 @click.command('delete-customers')
 @click.argument('gnucash_file', type=click.Path(exists=True))
 @click.argument('ids', nargs=-1, required=True)
@@ -155,6 +191,60 @@ def archive_customers(gnucash_file, ids, by_guid):
       gnucash-plaintext archive-customers ledger.gnucash --by-guid 9f14a498cc894d50931f855a9a31d594
     """
     _run_archive(gnucash_file, ids, ArchiveCustomersUseCase, by_guid=by_guid)
+
+
+@click.command('delete-invoices')
+@click.argument('gnucash_file', type=click.Path(exists=True))
+@click.argument('ids', nargs=-1, required=True)
+@click.option('--by-guid', is_flag=True, default=False,
+              help='Treat positional args as invoice GUIDs instead of invoice numbers.')
+def delete_invoices(gnucash_file, ids, by_guid):
+    """
+    Delete one or more UNPOSTED customer invoices by ID (or GUID with
+    --by-guid).
+
+    Refuses posted invoices. To delete a previously-posted invoice,
+    first run `unpost-invoices <id>` and then `delete-invoices <id>`
+    — the explicit two-step keeps the destruction of the posting
+    transaction (and the orphaning of payment splits) from being a
+    silent side effect of a delete command.
+
+    Exit code 1 if any record was not found, was posted, or ambiguous.
+
+    \b
+    Examples:
+      gnucash-plaintext delete-invoices ledger.gnucash INV-2026-001
+      gnucash-plaintext delete-invoices ledger.gnucash INV-001 INV-002
+      gnucash-plaintext delete-invoices ledger.gnucash --by-guid 9f14a498cc894d50931f855a9a31d594
+    """
+    _run_delete_invoice_or_bill(gnucash_file, ids, DeleteInvoicesUseCase,
+                                by_guid=by_guid)
+
+
+@click.command('delete-bills')
+@click.argument('gnucash_file', type=click.Path(exists=True))
+@click.argument('ids', nargs=-1, required=True)
+@click.option('--by-guid', is_flag=True, default=False,
+              help='Treat positional args as bill GUIDs instead of bill numbers.')
+def delete_bills(gnucash_file, ids, by_guid):
+    """
+    Delete one or more UNPOSTED vendor bills by ID (or GUID with
+    --by-guid).
+
+    Symmetric to delete-invoices — refuses posted bills. To delete a
+    previously-posted bill, first run `unpost-bills <id>` and then
+    `delete-bills <id>`.
+
+    Exit code 1 if any record was not found, was posted, or ambiguous.
+
+    \b
+    Examples:
+      gnucash-plaintext delete-bills ledger.gnucash BILL-2026-001
+      gnucash-plaintext delete-bills ledger.gnucash BILL-001 BILL-002
+      gnucash-plaintext delete-bills ledger.gnucash --by-guid f66df24e6e75424ba08c2b0a47ec292c
+    """
+    _run_delete_invoice_or_bill(gnucash_file, ids, DeleteBillsUseCase,
+                                by_guid=by_guid)
 
 
 @click.command('archive-vendors')

--- a/cli/main.py
+++ b/cli/main.py
@@ -9,7 +9,13 @@ import click
 
 from cli.account_balance_cmd import account_balance
 from cli.close_books_cmd import close_books
-from cli.delete_cmd import archive_customers, archive_vendors, delete_customers
+from cli.delete_cmd import (
+    archive_customers,
+    archive_vendors,
+    delete_bills,
+    delete_customers,
+    delete_invoices,
+)
 from cli.delete_transaction_cmd import delete_transaction_by_guid
 from cli.export_accounts_cmd import export_accounts
 from cli.export_beancount_cmd import export_beancount
@@ -61,6 +67,8 @@ cli.add_command(account_balance, name='account-balance')
 cli.add_command(delete_transaction_by_guid, name='delete-transaction-by-guid')
 cli.add_command(find_transactions, name='find-transactions')
 cli.add_command(delete_customers, name='delete-customers')
+cli.add_command(delete_invoices, name='delete-invoices')
+cli.add_command(delete_bills, name='delete-bills')
 cli.add_command(archive_customers, name='archive-customers')
 cli.add_command(archive_vendors, name='archive-vendors')
 cli.add_command(unpost_invoices, name='unpost-invoices')

--- a/docs/issues/Q-013-delete-unposted-invoice-bill.md
+++ b/docs/issues/Q-013-delete-unposted-invoice-bill.md
@@ -1,0 +1,122 @@
+---
+id: Q-013
+title: No way to delete an unposted invoice or bill from the CLI
+category: feature
+severity: medium
+status: open
+---
+
+## Problem
+
+Users can create unposted invoices/bills (via re-import with
+`posted: none`) but have no way to remove them again short of editing
+the .gnucash XML by hand or opening GnuCash's UI. Real-world drivers:
+
+- A user imports a batch invoice .txt, notices a row was a typo
+  (wrong customer, wrong amount), wants to drop the invoice and
+  re-import a corrected version.
+- A user previews an unposted invoice as a PDF (Q-012), decides it's
+  not needed, and wants to delete it cleanly without having to first
+  give it a posted block.
+
+For posted invoices, `unpost-invoices` (Q-010) is half the workflow.
+Q-013 is the other half: after unposting, drop the record entirely.
+
+## Scope
+
+Add two CLI commands that mirror `unpost-invoices` / `unpost-bills`
+exactly:
+
+```
+gnucash-plaintext delete-invoices <book> <id>... [--by-guid]
+gnucash-plaintext delete-bills    <book> <id>... [--by-guid]
+```
+
+Behaviour:
+
+| Record state         | Result        | Message                                                   |
+|----------------------|---------------|-----------------------------------------------------------|
+| Unposted, found      | `DELETED`     | `<id> (<guid>): deleted`                                  |
+| Posted, found        | `FAILED_POSTED` | `<id> (<guid>): failed — posted; run unpost-<kind> first` |
+| Not found            | `NOT_FOUND`   | `<id>: not found`                                         |
+| Ambiguous id (legacy)| `AMBIGUOUS_ID`| `<id>: failed — multiple records share this id; rerun with --by-guid` |
+
+Exit code 1 if any record didn't reach DELETED; successful deletes
+still saved.
+
+## Refusing posted records — why not auto-unpost?
+
+A `delete-invoices` that silently unposted-then-deleted would:
+
+1. Destroy the posting transaction and orphan any payment splits
+   (matching `unpost-invoices` behaviour) **as a side effect of a
+   delete command**. The user gave one instruction; we'd be doing
+   two destructive operations.
+2. Make it impossible to ever delete a "did I really mean this?"
+   record without first running `unpost-invoices` and being able to
+   review what got orphaned.
+
+Requiring the explicit two-step `unpost-invoices` → `delete-invoices`
+chain keeps each destructive operation under its own command and
+matches the project's general "make destructive things visible" stance.
+
+## Implementation strategy
+
+Mirror `unpost-business-objects.py` structure (already in the
+codebase since Q-010):
+
+- New `DeleteInvoicesUseCase` + `DeleteBillsUseCase` in
+  `use_cases/delete_business_objects.py`.
+- New status enum `DeleteInvoiceStatus` (separate from existing
+  `DeleteStatus` for customers to keep their result shapes distinct).
+- Lookup via `services.gnucash_importer._find_invoices_by_id` /
+  `_find_invoice_by_guid` (same helpers `unpost_business_objects`
+  uses) — DRY and consistent with the unpost path.
+- Action: `inv.Destroy()` (SWIG `Invoice.Destroy()`).
+
+### Open question to verify in tests (CLAUDE.md finding #8)
+
+`gncEntryDestroy` does NOT detach from the parent invoice/bill's
+internal entry list (Q-007 / Q-009 hard-won finding). The importer
+works around this by calling `invoice.RemoveEntry(entry)` or
+`_bill_remove_all_entries(book, bill)` before destroying entries.
+
+It's unclear whether `gncInvoiceDestroy` cascades through the entry
+list correctly or has the same dangling-pointer hazard. Two
+possibilities to discover via tests:
+
+1. **Best case:** `Invoice.Destroy()` cleans up entries internally;
+   we just call it and move on.
+2. **Worst case:** we have to call `RemoveEntry` (invoice side) or
+   `_bill_remove_all_entries` (bill side) before `Destroy()`, same
+   asymmetric SWIG↔ctypes split as the importer.
+
+Tests must cover the "destroy invoice with entries" path on every
+supported distro — the importer's bug only surfaced visibly on
+ubuntu20 (GnuCash 3.8) per the 2026-05-08 post-mortem, so multi-
+distro CI is load-bearing here.
+
+## Files to add / change
+
+| File | Change |
+|---|---|
+| `use_cases/delete_business_objects.py` | Add `DeleteInvoiceStatus`, `DeleteInvoiceResult`, `DeleteInvoicesUseCase`, `DeleteBillsUseCase` |
+| `cli/delete_cmd.py` | Add `delete-invoices` + `delete-bills` click commands; share a `_run_delete_invoice` helper with the same save-on-partial-success pattern as `_run_delete` |
+| `cli/main.py` | Register the two new commands |
+| `tests/integration/test_delete_invoice_bill.py` (new) | Unposted invoice deleted; unposted bill deleted; posted refused with FAILED_POSTED; not-found path; ambiguous-id path; --by-guid path; save persists deletion across reload; entries-with-tax-table deleted cleanly |
+| `tests/fixtures/q013_*.txt` (new) | Reusable fixtures |
+| `README.md` | Document the new commands; cross-reference unpost commands |
+| `docs/issues/README.md` | Index row |
+
+## Out of scope
+
+- Auto-unpost-then-delete shortcut (see "Refusing posted records").
+- Deleting customers/vendors (already `delete-customers` /
+  `archive-customers`).
+- A separate `delete-paid-invoices`-style command that handles AR/AP
+  cleanup — that's a different problem (no clear user request, and
+  the accounting consequences are non-obvious).
+
+---
+
+**Created**: 2026-05-12

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -54,3 +54,4 @@ When a fix is merged, update `status: open` → `closed` in the file's frontmatt
 | [Q-010](Q-010-strict-updated-status-on-no-change-reimport.md) | `'updated'` is liberal — reports updated for no-change re-imports; posted invoices/bills can't be edited via re-import | low |
 | [Q-011](Q-011-invoice-action-optional-and-custom-template.md) | Invoice `action` field forces a hardcode; UNIT column shows nonsense; no template override | low |
 | [Q-012](Q-012-print-invoice-on-unposted-invoice-crashes.md) | `print-invoice` on an unposted invoice crashes with NoneType error | medium |
+| [Q-013](Q-013-delete-unposted-invoice-bill.md) | No way to delete an unposted invoice or bill from the CLI | medium |

--- a/tests/fixtures/q013_invoice_unposted_multi_entry.txt
+++ b/tests/fixtures/q013_invoice_unposted_multi_entry.txt
@@ -1,0 +1,37 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-001"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service A"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 2
+		price: 50
+		taxable: false
+		tax_included: false
+	entry:
+		date: 2026-01-01
+		description: "Service B"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	entry:
+		date: 2026-01-01
+		description: "Service C"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 3
+		price: 25
+		taxable: false
+		tax_included: false
+	posted: none
+	payment: none

--- a/tests/fixtures/q013_invoice_unposted_with_tax.txt
+++ b/tests/fixtures/q013_invoice_unposted_with_tax.txt
@@ -1,0 +1,26 @@
+taxtable "GST"
+	entry:
+		account: "Liabilities:Accounts Payable"
+		rate: 5.0%
+		type: PERCENT
+
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-001"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: true
+		tax_included: false
+		tax_table: "GST"
+	posted: none
+	payment: none

--- a/tests/fixtures/q013_two_unposted_invoices.txt
+++ b/tests/fixtures/q013_two_unposted_invoices.txt
@@ -1,0 +1,35 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-001"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "First"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted: none
+	payment: none
+
+invoice "INV-002"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-02
+	entry:
+		date: 2026-01-02
+		description: "Second"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 200
+		taxable: false
+		tax_included: false
+	posted: none
+	payment: none

--- a/tests/integration/test_delete_invoice_bill.py
+++ b/tests/integration/test_delete_invoice_bill.py
@@ -1,0 +1,432 @@
+"""
+Q-013: `delete-invoices` / `delete-bills` CLI commands.
+
+Mirrors the structure of test_unpost_invoice_bill.py (Q-010). The
+commands hard-delete unposted invoices/bills via `Invoice.Destroy()`
+and refuse posted records. The two-step path to delete a posted
+record is `unpost-invoices <id>` followed by `delete-invoices <id>`
+— never an auto-unpost-then-delete inside one command (see Q-013
+issue doc for the reasoning).
+
+Test coverage:
+
+  - delete an unposted invoice → exit 0, record gone on reload
+  - delete an unposted bill   → exit 0, record gone on reload
+  - delete a posted invoice   → exit 1, FAILED_POSTED message, record still there
+  - delete a posted bill      → exit 1, FAILED_POSTED message, record still there
+  - delete a missing id       → exit 1, NOT_FOUND
+  - --by-guid happy path
+  - --by-guid bad guid format
+  - batch: some succeed, some fail → exit 1; successes still persist on disk
+  - multi-entry invoice can be deleted without segfault (entry-cleanup
+    check — see CLAUDE.md hard-won finding #8; Q-013 destroys the
+    parent so the dangling-pointer hazard shouldn't apply, but the
+    test exists to catch the regression if it does)
+"""
+
+import os
+import time
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+
+def _fixture(name: str) -> str:
+    path = os.path.join(os.path.dirname(__file__), '..', 'fixtures',
+                        f'{name}.txt')
+    with open(path) as f:
+        return f.read()
+
+
+ACCOUNTS = """
+2026-01-01 open Assets
+\ttype: Asset
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Assets:Bank
+\ttype: Bank
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Assets:Accounts Receivable
+\ttype: Accounts Receivable
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Liabilities
+\ttype: Liability
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:Accounts Payable
+\ttype: Accounts Payable
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Income
+\ttype: Income
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Income:Sales
+\ttype: Income
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Expenses
+\ttype: Expense
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Expenses:Supplies
+\ttype: Expense
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+"""
+
+
+def _write(path, text):
+    path.write_text(text)
+    return str(path)
+
+
+def _import_new(runner, gnc, fixture):
+    return runner.invoke(cli, ["import", "--new", str(gnc), fixture,
+                               "--include-business-objects"])
+
+
+def _setup_book_with(runner, tmp_path, fixture_text):
+    gnc = tmp_path / "book.gnucash"
+    fix = _write(tmp_path / "in.txt", ACCOUNTS + "\n" + fixture_text)
+    r = _import_new(runner, gnc, fix)
+    assert r.exit_code == 0, r.output
+    # GnuCash backup filenames use a per-second timestamp. Without a
+    # pause, the next save in the same test would collide with the
+    # import's backup timestamp and fail with ERR_FILEIO_BACKUP_ERROR.
+    # The CLI's save handler swallows that specific error (so the
+    # surrounding command still exits 0), which silently drops the
+    # save — leaving the in-memory delete invisible on reload. Same
+    # workaround the Q-010 unpost test uses.
+    time.sleep(1)
+    return gnc
+
+
+def _record_ids_after_reload(gnc, search_for, owner_type_int):
+    """Return the list of ids for invoices (owner_type=2) or bills
+    (owner_type=4) in the saved .gnucash file. Used to assert that a
+    deletion truly survived save+reload, not just an in-memory mutation."""
+    from gnucash import Query, Session
+    from gnucash.gnucash_business import Invoice
+    ses = Session(f"xml://{gnc}")
+    try:
+        book = ses.book
+        q = Query()
+        q.search_for(search_for)
+        q.set_book(book)
+        ids = []
+        for r in q.run():
+            inv = Invoice(instance=r)
+            if inv.GetOwnerType() == owner_type_int:
+                ids.append(inv.GetID())
+        q.destroy()
+        return sorted(ids)
+    finally:
+        ses.end()
+
+
+def _invoice_ids(gnc):
+    return _record_ids_after_reload(gnc, 'gncInvoice', owner_type_int=2)
+
+
+def _bill_ids(gnc):
+    return _record_ids_after_reload(gnc, 'gncInvoice', owner_type_int=4)
+
+
+def _taxtable_names(gnc):
+    """Return the names of all tax tables in `gnc`.
+
+    Tax tables aren't reachable via QofQuery (CLAUDE.md finding #3),
+    so we call the same `_iter_taxtables` / `_taxtable_name_str`
+    helpers the importer uses."""
+    from gnucash import Session
+
+    from services.gnucash_importer import _iter_taxtables, _taxtable_name_str
+    ses = Session(f"xml://{gnc}")
+    try:
+        book = ses.book
+        return sorted(_taxtable_name_str(p) for p in _iter_taxtables(book))
+    finally:
+        ses.end()
+
+
+def _create_duplicate_invoice(gnc, dup_id, customer_id, currency_code):
+    """Create a second invoice in `gnc` whose id already exists.
+
+    The importer enforces id uniqueness (Q-006 / Q-008), so the only
+    way to produce the legacy-data scenario the AMBIGUOUS_ID path
+    guards against is to bypass the importer and call the GnuCash
+    SWIG constructor directly. After this returns there are two
+    distinct gncInvoice records with the same id.
+    """
+    from gnucash import Session
+    from gnucash.gnucash_business import Invoice
+    ses = Session(f"xml://{gnc}")
+    try:
+        book = ses.book
+        cust = book.CustomerLookupByID(customer_id)
+        assert cust is not None, (
+            f"Setup: customer {customer_id!r} must already exist in {gnc}")
+        currency = book.get_table().lookup("CURRENCY", currency_code)
+        # Invoice(book, id, currency, owner) creates a new gncInvoice
+        # under `book` with the given id. No uniqueness check is done
+        # at the C level — that's only enforced by our importer.
+        Invoice(book, dup_id, currency, cust)
+        ses.save()
+    finally:
+        ses.end()
+
+
+def _invoice_guid(gnc, inv_id):
+    """Look up the GUID of an invoice/bill by id (works for both — same
+    underlying gncInvoice type, differentiated by owner type).
+
+    Uses `_swig_invoice_guid_str` rather than SWIG `Invoice.GetGUID()`
+    because the latter raises AttributeError on debian13 / ubuntu24
+    (per CLAUDE.md hard-won finding)."""
+    from gnucash import Query, Session
+    from gnucash.gnucash_business import Invoice
+
+    from services.gnucash_importer import _swig_invoice_guid_str
+    ses = Session(f"xml://{gnc}")
+    try:
+        book = ses.book
+        q = Query()
+        q.search_for('gncInvoice')
+        q.set_book(book)
+        guid = None
+        for r in q.run():
+            inv = Invoice(instance=r)
+            if inv.GetID() == inv_id:
+                guid = _swig_invoice_guid_str(inv)
+                break
+        q.destroy()
+        return guid
+    finally:
+        ses.end()
+
+
+# ── delete-invoices happy path ────────────────────────────────────────────────
+
+
+class TestDeleteUnpostedInvoice:
+    def test_single_unposted_invoice_deleted_and_persists(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_invoice_unposted'))
+        assert _invoice_ids(gnc) == ['INV-001'], (
+            "Setup: expected one unposted invoice INV-001")
+
+        r = runner.invoke(cli, ["delete-invoices", str(gnc), "INV-001"])
+        assert r.exit_code == 0, r.output
+        assert 'INV-001' in r.output and ': deleted' in r.output, r.output
+
+        # Reload from disk to confirm save persisted the deletion.
+        assert _invoice_ids(gnc) == [], (
+            f"INV-001 should be gone after delete+reload. Still present: "
+            f"{_invoice_ids(gnc)}")
+
+    def test_multi_entry_invoice_deleted_without_segfault(self, tmp_path):
+        """Q-013 regression guard: CLAUDE.md finding #8 documents a
+        dangling-pointer hazard when destroying entries one-by-one
+        while the parent invoice stays alive. We destroy the parent,
+        so the hazard should not apply — but if any GnuCash version
+        crashes here we want a directly-named test pointing at it."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               _fixture('q013_invoice_unposted_multi_entry'))
+        assert _invoice_ids(gnc) == ['INV-001']
+
+        r = runner.invoke(cli, ["delete-invoices", str(gnc), "INV-001"])
+        assert r.exit_code == 0, r.output
+        assert _invoice_ids(gnc) == []
+
+    def test_by_guid_path(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_invoice_unposted'))
+        guid = _invoice_guid(gnc, 'INV-001')
+        assert guid, "Setup: failed to read GUID for INV-001"
+        # Strip hyphens to test the normalisation path (matches Q-007 fix).
+        guid_no_hyphens = guid.replace('-', '')
+
+        r = runner.invoke(cli, ["delete-invoices", str(gnc),
+                                "--by-guid", guid_no_hyphens])
+        assert r.exit_code == 0, r.output
+        assert ': deleted' in r.output, r.output
+        assert _invoice_ids(gnc) == []
+
+    def test_by_guid_format_error(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_invoice_unposted'))
+
+        r = runner.invoke(cli, ["delete-invoices", str(gnc),
+                                "--by-guid", "not-a-guid"])
+        assert r.exit_code != 0
+        assert _invoice_ids(gnc) == ['INV-001'], (
+            "Malformed guid must not touch the book")
+
+    def test_deletion_does_not_destroy_referenced_tax_table(self, tmp_path):
+        """Correctness guard: tax tables are book-level shared objects
+        that may be referenced by many invoices. Destroying an invoice
+        with a `tax_table: "GST"` entry must NOT cascade into deleting
+        the GST tax table itself — that would silently break every
+        other invoice still using it.
+
+        The Q-013 use case only destroys entries (which clears each
+        entry's tax_table back-pointer) and the parent invoice. Tax
+        tables stay put. This test asserts that invariant explicitly."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               _fixture('q013_invoice_unposted_with_tax'))
+        assert _invoice_ids(gnc) == ['INV-001']
+        assert _taxtable_names(gnc) == ['GST'], (
+            "Setup: GST tax table should exist after import")
+
+        r = runner.invoke(cli, ["delete-invoices", str(gnc), "INV-001"])
+        assert r.exit_code == 0, r.output
+        assert _invoice_ids(gnc) == [], "Invoice should be gone"
+        assert _taxtable_names(gnc) == ['GST'], (
+            "GST tax table must survive invoice deletion — tax tables "
+            "are book-level shared objects, not invoice-owned. "
+            f"Found tax tables after delete: {_taxtable_names(gnc)}")
+
+
+# ── delete-bills happy path ───────────────────────────────────────────────────
+
+
+class TestDeleteUnpostedBill:
+    def test_single_unposted_bill_deleted_and_persists(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_bill_unposted'))
+        assert _bill_ids(gnc) == ['BILL-001']
+
+        r = runner.invoke(cli, ["delete-bills", str(gnc), "BILL-001"])
+        assert r.exit_code == 0, r.output
+        assert 'BILL-001' in r.output and ': deleted' in r.output, r.output
+        assert _bill_ids(gnc) == []
+
+
+# ── refusal: posted records ───────────────────────────────────────────────────
+
+
+class TestPostedRefused:
+    def test_posted_invoice_not_deleted(self, tmp_path):
+        """`delete-invoices` must refuse a posted invoice and leave the
+        record in place. The error message must steer the user toward
+        the explicit two-step path: unpost-invoices, then delete-invoices."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_invoice_posted'))
+        assert _invoice_ids(gnc) == ['INV-001']
+
+        r = runner.invoke(cli, ["delete-invoices", str(gnc), "INV-001"])
+        assert r.exit_code == 1, (
+            f"Posted invoice deletion must fail with exit 1. Output:\n{r.output}")
+        assert 'failed — posted' in r.output, r.output
+        assert 'unpost-invoices' in r.output, (
+            "Failure message must point at unpost-invoices as the next step. "
+            f"Output:\n{r.output}")
+        # Record still present on disk:
+        assert _invoice_ids(gnc) == ['INV-001']
+
+    def test_posted_bill_not_deleted(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_bill_posted'))
+        assert _bill_ids(gnc) == ['BILL-001']
+
+        r = runner.invoke(cli, ["delete-bills", str(gnc), "BILL-001"])
+        assert r.exit_code == 1, r.output
+        assert 'failed — posted' in r.output, r.output
+        assert 'unpost-bills' in r.output, r.output
+        assert _bill_ids(gnc) == ['BILL-001']
+
+
+# ── miss path ─────────────────────────────────────────────────────────────────
+
+
+class TestNotFound:
+    def test_unknown_invoice_id(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_invoice_unposted'))
+
+        r = runner.invoke(cli, ["delete-invoices", str(gnc), "INV-DOES-NOT-EXIST"])
+        assert r.exit_code == 1, r.output
+        assert 'not found' in r.output, r.output
+        # Real invoice untouched
+        assert _invoice_ids(gnc) == ['INV-001']
+
+    def test_unknown_bill_id(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_bill_unposted'))
+
+        r = runner.invoke(cli, ["delete-bills", str(gnc), "BILL-MISSING"])
+        assert r.exit_code == 1, r.output
+        assert 'not found' in r.output, r.output
+        assert _bill_ids(gnc) == ['BILL-001']
+
+
+# ── batch behaviour ───────────────────────────────────────────────────────────
+
+
+class TestAmbiguousId:
+    """Legacy data may contain multiple invoices/bills sharing the
+    same user-facing id (the importer enforces uniqueness from
+    Q-008 onwards, but pre-Q-008 books or hand-edited XML can have
+    them). The use case must refuse to pick one — it returns
+    AMBIGUOUS_ID with a message steering the user toward --by-guid,
+    and touches neither record.
+
+    Mirrors the AMBIGUOUS_ID path in unpost-business-objects."""
+
+    def test_duplicate_id_refused_and_no_record_deleted(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_invoice_unposted'))
+        # Bypass the importer to create a second invoice with the
+        # same id — the only way to reproduce legacy duplicates.
+        _create_duplicate_invoice(gnc, dup_id="INV-001",
+                                  customer_id="C001",
+                                  currency_code="CAD")
+        ids_before = _invoice_ids(gnc)
+        assert ids_before == ['INV-001', 'INV-001'], (
+            f"Setup: should have two invoices both named INV-001; got {ids_before}")
+
+        r = runner.invoke(cli, ["delete-invoices", str(gnc), "INV-001"])
+        assert r.exit_code == 1, (
+            f"Ambiguous id must exit 1, not silently pick one. Output:\n{r.output}")
+        assert 'multiple records share this id' in r.output, r.output
+        assert '--by-guid' in r.output, (
+            "Failure message must point at --by-guid as the disambiguator. "
+            f"Output:\n{r.output}")
+        # Neither record was deleted:
+        assert _invoice_ids(gnc) == ['INV-001', 'INV-001'], (
+            f"Ambiguous case must not delete either record. After: "
+            f"{_invoice_ids(gnc)}")
+
+
+class TestBatchPartialSuccess:
+    """Per the established `_run_delete` / `_run_unpost` pattern: when
+    a batch contains a mix of successes and failures, the successful
+    deletes must still be saved to disk and the overall exit code must
+    be 1. Lifting the saved-deletions would force users to debug-and-
+    rerun the whole batch."""
+
+    def test_one_success_one_failure_persists_success_and_exits_1(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               _fixture('q013_two_unposted_invoices'))
+        assert _invoice_ids(gnc) == ['INV-001', 'INV-002']
+
+        # INV-001 exists (unposted) → should delete.
+        # INV-NOPE doesn't exist → should fail.
+        r = runner.invoke(cli, ["delete-invoices", str(gnc),
+                                "INV-001", "INV-NOPE"])
+        assert r.exit_code == 1, r.output
+        assert 'INV-001' in r.output and ': deleted' in r.output, r.output
+        assert 'INV-NOPE' in r.output and 'not found' in r.output, r.output
+
+        # The successful deletion must have persisted:
+        assert _invoice_ids(gnc) == ['INV-002'], (
+            f"INV-001 should be deleted, INV-002 should remain. "
+            f"Got: {_invoice_ids(gnc)}")

--- a/use_cases/delete_business_objects.py
+++ b/use_cases/delete_business_objects.py
@@ -1,5 +1,6 @@
 """
-Use cases for deleting and archiving GnuCash customers and vendors.
+Use cases for deleting and archiving GnuCash customers, vendors, and
+unposted invoices/bills.
 
 delete-customers — hard-removes a customer via Destroy(); blocked if any
                    invoices are linked (paid or unpaid, posted or unposted).
@@ -12,7 +13,15 @@ delete-customers — hard-removes a customer via Destroy(); blocked if any
 archive — sets SetActive(False); always succeeds for a found, currently-active
           entity; reports the linked invoice/bill count as informational context.
 
-Both use cases accept a list of IDs and return one result per ID so callers
+delete-invoices / delete-bills (Q-013) — hard-remove an unposted
+                   invoice/bill via Destroy(). Posted records are refused
+                   so that the destruction of the posting transaction (and
+                   the orphaning of payment splits) cannot happen as a
+                   silent side effect of a delete command. The natural
+                   two-step path for posted records is:
+                       unpost-invoices <id>  &&  delete-invoices <id>
+
+All use cases accept a list of IDs and return one result per ID so callers
 can display per-ID status lines and compute an overall exit code.
 """
 
@@ -26,6 +35,14 @@ from gnucash import Book, Query
 from infrastructure.gnucash.guid_lookup import (
     find_customer_by_guid,
     find_vendor_by_guid,
+)
+from services.gnucash_importer import (
+    _bill_remove_all_entries,
+    _find_bill_by_guid,
+    _find_bills_by_id,
+    _find_invoice_by_guid,
+    _find_invoices_by_id,
+    _swig_invoice_guid_str,
 )
 
 
@@ -190,6 +207,172 @@ class ArchiveCustomersUseCase:
             results.append(ArchiveResult(id=rid, guid=rguid, status=ArchiveStatus.ARCHIVED,
                                          invoice_count=n))
         return results
+
+
+class DeleteInvoiceStatus(Enum):
+    DELETED = auto()
+    FAILED_POSTED = auto()
+    NOT_FOUND = auto()
+    AMBIGUOUS_ID = auto()  # legacy data: multiple records share one id
+
+
+@dataclass
+class DeleteInvoiceResult:
+    """Per-record result for delete-invoices / delete-bills.
+
+    Separate type from the customer DeleteResult above because the
+    refusal reason is different (posted vs has-linked-invoices) and
+    overloading one enum across both would obscure that.
+    """
+    id: str             # matched record's id, or original input on a miss
+    guid: str = ''      # matched record's GUID; empty on miss / ambiguous
+    status: DeleteInvoiceStatus = None
+    kind: str = 'invoice'  # 'invoice' or 'bill' — drives message wording
+
+    def message(self) -> str:
+        if self.status == DeleteInvoiceStatus.DELETED:
+            return 'deleted'
+        if self.status == DeleteInvoiceStatus.FAILED_POSTED:
+            return (f'failed — posted; run unpost-{self.kind}s '
+                    f'first, then delete-{self.kind}s')
+        if self.status == DeleteInvoiceStatus.AMBIGUOUS_ID:
+            return ('failed — multiple records share this id; '
+                    'rerun with --by-guid')
+        return 'not found'
+
+    def label(self) -> str:
+        if self.guid:
+            return f'{self.id} ({self.guid})'
+        return self.id
+
+
+def _resolve_invoice_or_bill(book: Book, id_or_guid: str, by_guid: bool,
+                             by_id_fn, by_guid_fn):
+    """Look up exactly one invoice or bill.
+
+    Returns (record, report_id, report_guid):
+      - hit:        (Invoice, record.id, record.guid)
+      - miss:       (None,    original_input, '')
+      - ambiguous:  (None,    original_input, '__ambiguous__')
+
+    Mirrors `unpost_business_objects._resolve_one` so legacy duplicates
+    surface as AMBIGUOUS_ID rather than silently picking one record.
+    """
+    if by_guid:
+        rec = by_guid_fn(book, id_or_guid)
+        if rec is None:
+            return None, id_or_guid, ''
+        return rec, rec.GetID(), id_or_guid
+    matches = by_id_fn(book, id_or_guid)
+    if not matches:
+        return None, id_or_guid, ''
+    if len(matches) > 1:
+        return None, id_or_guid, '__ambiguous__'
+    rec = matches[0]
+    return rec, rec.GetID(), _swig_invoice_guid_str(rec)
+
+
+def _remove_all_entries(rec, kind: str, book: Book) -> None:
+    """Detach + destroy every entry on an unposted invoice or bill, so
+    that `Invoice.Destroy()` doesn't leave dangling entry-to-parent
+    references that revive the parent in the XML backend on save.
+
+    Mirrors the importer's rebuild path:
+      - customer invoice: SWIG `invoice.RemoveEntry(entry)` works.
+      - vendor bill: SWIG RemoveEntry is customer-only — we use
+        `_bill_remove_all_entries` which calls `gncBillRemoveEntry`
+        via ctypes (same finding as CLAUDE.md #8).
+    """
+    if kind == 'bill':
+        _bill_remove_all_entries(book, rec)
+        return
+    for entry in list(rec.GetEntries()):
+        rec.RemoveEntry(entry)
+        entry.Destroy()
+
+
+def _execute_delete_invoice_or_bill(book: Book, ids: List[str],
+                                    by_guid: bool, by_id_fn, by_guid_fn,
+                                    kind: str) -> List[DeleteInvoiceResult]:
+    """Shared body for DeleteInvoicesUseCase and DeleteBillsUseCase.
+
+    Refuses posted records (FAILED_POSTED) so that the destruction of
+    the posting transaction is never a silent side effect of `delete-*`.
+
+    For unposted records:
+      1. Detach and destroy every line-item entry. The XML backend
+         serialises entries from the gncEntry QofCollection; an entry
+         with a parent-ref to a destroyed invoice could either revive
+         the parent on save or segfault, depending on platform.
+         We tear down the entries first (same pattern the importer's
+         rebuild path uses).
+      2. Call SWIG `Invoice.Destroy()`. Internally this calls
+         `gncInvoiceDestroy`, which sets the destroying flag and trips
+         `gncInvoiceCommitEdit`'s free path. No explicit `BeginEdit()`
+         needed — SWIG's RemoveEntry-then-Destroy on each entry left
+         the edit-level state in a balanced position; adding an
+         explicit BeginEdit/CommitEdit pair on the invoice produces a
+         "unbalanced call" qof.engine error and does not change the
+         outcome.
+    """
+    results: List[DeleteInvoiceResult] = []
+    for arg in ids:
+        rec, rid, rguid = _resolve_invoice_or_bill(
+            book, arg, by_guid, by_id_fn, by_guid_fn)
+        if rec is None and rguid == '__ambiguous__':
+            results.append(DeleteInvoiceResult(
+                id=rid, status=DeleteInvoiceStatus.AMBIGUOUS_ID, kind=kind))
+            continue
+        if rec is None:
+            results.append(DeleteInvoiceResult(
+                id=rid, status=DeleteInvoiceStatus.NOT_FOUND, kind=kind))
+            continue
+        if rec.GetPostedTxn() is not None:
+            results.append(DeleteInvoiceResult(
+                id=rid, guid=rguid,
+                status=DeleteInvoiceStatus.FAILED_POSTED, kind=kind))
+            continue
+        _remove_all_entries(rec, kind, book)
+        rec.Destroy()
+        results.append(DeleteInvoiceResult(
+            id=rid, guid=rguid, status=DeleteInvoiceStatus.DELETED, kind=kind))
+    return results
+
+
+class DeleteInvoicesUseCase:
+    """Hard-delete one or more unposted customer invoices.
+
+    Refuses posted invoices. The two-step `unpost-invoices` →
+    `delete-invoices` path is the only way to delete a previously-
+    posted record, by design — see Q-013 issue doc.
+    """
+
+    def __init__(self, book: Book):
+        self.book = book
+
+    def execute(self, ids: List[str],
+                by_guid: bool = False) -> List[DeleteInvoiceResult]:
+        return _execute_delete_invoice_or_bill(
+            self.book, ids, by_guid,
+            _find_invoices_by_id, _find_invoice_by_guid, kind='invoice')
+
+
+class DeleteBillsUseCase:
+    """Hard-delete one or more unposted vendor bills.
+
+    Symmetric to DeleteInvoicesUseCase — same Destroy() call; GnuCash
+    uses the same gncInvoice C type for both customer invoices and
+    vendor bills, distinguished only by the owner type.
+    """
+
+    def __init__(self, book: Book):
+        self.book = book
+
+    def execute(self, ids: List[str],
+                by_guid: bool = False) -> List[DeleteInvoiceResult]:
+        return _execute_delete_invoice_or_bill(
+            self.book, ids, by_guid,
+            _find_bills_by_id, _find_bill_by_guid, kind='bill')
 
 
 class ArchiveVendorsUseCase:


### PR DESCRIPTION
Adds two CLI commands that mirror unpost-invoices / unpost-bills:

    gnucash-plaintext delete-invoices <book> <id>... [--by-guid]
    gnucash-plaintext delete-bills    <book> <id>... [--by-guid]

Refuses posted records — the two-step path to delete a previously- posted invoice/bill is `unpost-<kind>s <id>` followed by `delete-<kind>s <id>`. Keeping the destruction of the posting transaction (and the orphaning of payment splits in the bank account) under its own command rather than as a silent side effect of `delete-*` matches the project's "make destructive operations visible" stance — see Q-013 issue doc.

## Drivers

  - Users importing a batch invoice .txt notice a typo on one row after import (wrong customer, wrong amount) and want to drop the invoice cleanly before re-importing a corrected version.
  - Users previewing an unposted invoice as a PDF (Q-012) decide it isn't needed and want to delete the draft without inventing a posted block first.

## Use case (use_cases/delete_business_objects.py)

New status enum / result type / use cases:

  - `DeleteInvoiceStatus` — DELETED, FAILED_POSTED, NOT_FOUND, AMBIGUOUS_ID (last matches the unpost path's handling of legacy data with duplicate ids).
  - `DeleteInvoiceResult` — kind-aware ('invoice' or 'bill') so the refusal message can point at the right unpost command.
  - `DeleteInvoicesUseCase` / `DeleteBillsUseCase` — symmetric; GnuCash uses the same gncInvoice C type for both, distinguished only by owner type.

Per-record flow:

  1. Resolve by id (default) or guid (when --by-guid). Ambiguous ids return AMBIGUOUS_ID — refuse to silently pick one record.
  2. Refuse if `GetPostedTxn() is not None`.
  3. Detach and destroy every line-item entry before destroying the parent. For customer invoices SWIG `invoice.RemoveEntry(entry)` works; for vendor bills we use `_bill_remove_all_entries` (ctypes `gncBillRemoveEntry`) — same asymmetry the importer already documents (CLAUDE.md finding — SWIG RemoveEntry is customer-only on the gnc-invoice side).
  4. SWIG `Invoice.Destroy()`. No explicit BeginEdit needed; the RemoveEntry/Destroy on each entry leaves the edit-level state balanced. (First attempt added an explicit `gncInvoiceBeginEdit` via ctypes which produced a "qof_commit_edit unbalanced call" warning and was reverted.)

Tax-table references (`taxable: true` + `tax_table: "GST"`) go through the same destroy path — tax tables are book-level shared objects with independent lifecycle. Entry destroy just clears the back-pointer; the tax table is not affected. A regression test guards this invariant (see Tests below).

## CLI (cli/delete_cmd.py)

New `_run_delete_invoice_or_bill` helper + `delete-invoices` and `delete-bills` click commands. Same save-on-partial-success behaviour as `_run_delete` (customers) and `_run_unpost` so that a batch like `delete-invoices INV-A INV-B-POSTED INV-C` still persists A and C even though B failed.

Per-record output examples:

    INV-DRAFT-001 (abc123…): deleted
    INV-POSTED-002 (def456…): failed — posted; run unpost-invoices first, then delete-invoices
    INV-MISSING: not found
    INV-DUP-ID: failed — multiple records share this id; rerun with --by-guid

Exit 1 if any record didn't reach DELETED.

## Tests (tests/integration/test_delete_invoice_bill.py)

12 cases:

  - TestDeleteUnpostedInvoice (5): single delete persists; multi- entry invoice deleted without segfault; --by-guid happy path; --by-guid format error doesn't touch the book; **deletion does not destroy referenced tax table** (correctness guard — tax tables are book-level shared objects, must outlive any single invoice that references them).
  - TestDeleteUnpostedBill (1): single bill delete persists.
  - TestPostedRefused (2): posted invoice + posted bill both refused with exit 1 and message pointing at the right unpost command.
  - TestNotFound (2): unknown id reports "not found", exits 1.
  - TestAmbiguousId (1): two invoices sharing one id (created by bypassing the importer via direct `Invoice(book, id, ...)` constructor — the only way to reproduce the legacy duplicate scenario, since the importer enforces uniqueness from Q-008 onwards). Use case must refuse both records, exit 1, and point the user at --by-guid.
  - TestBatchPartialSuccess (1): mixed batch — success persists, overall exit 1.

Verified:
  - 12/12 on debian13 (latest, GnuCash 5.10)
  - 10/10 on ubuntu20 (GnuCash 3.8 — pre tax-table + ambiguous cases added; entry-destroy hazard surface)
  - 10/10 on ubuntu26 (GnuCash 5.14) (the multi-distro pre-commit hook re-runs the full 12 on every supported distro)

New fixtures under tests/fixtures/q013_*.txt per repo convention.

## Debugging note (won't surface elsewhere)

The first implementation called `inv.Destroy()` only and saw every test fail "INV-001 still present after delete+reload". The destroy actually worked in memory (probe confirmed the QofCollection no longer held the invoice immediately after Destroy()); the failure was that the immediately-following `session.save()` threw `ERR_FILEIO_BACKUP_ERROR` due to a per-second backup-filename collision with the import that ran a fraction of a second earlier. The CLI's save handler swallows that specific error code (matching existing delete-customers behaviour) so the command exits 0 but the file was never rewritten. Fix is `time.sleep(1)` in the test setup — same fix the Q-010 unpost test uses. The CLI swallowing of ERR_FILEIO_BACKUP_ERROR is a latent bug in the project (documented in code comments) but out of scope for Q-013 to fix.

## Docs

  - README.md — new "Deleting unposted invoices/bills" section under the unpost-invoices section, cross-referencing the two-step path for posted records.
  - docs/issues/README.md — Q-013 index row.
  - docs/issues/Q-013-delete-unposted-invoice-bill.md — issue doc with full rationale (refusal of posted, entry-detach concern, tax-table preservation invariant, out-of-scope items).