### PR TITLE
Q-014: warn on soon-to-be-orphan bank payments at unpost time

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ many currencies explicitly.
 	fraction: 100
 ```
 
+For `namespace: "CURRENCY"` commodities, the importer honors your declared `fraction` in memory, but GnuCash 5.15+ subsequently normalises ISO 4217 currencies to their official smallest-unit value on save. The most visible case is KRW (Korean Won): old GnuCash shipped it with `fraction: 100`, but [GnuCash 5.15 corrected it to `fraction: 1`](https://github.com/Gnucash/gnucash/releases/tag/5.15) (Bug 666536 — KRW has no sub-units per ISO 4217). On 5.15+, declaring `KRW fraction: 100` parses successfully but the saved book will hold `fraction: 1`. If you genuinely need a non-ISO precision (e.g. a points/rewards "currency"), use a custom `namespace:` (anything other than `CURRENCY`) — GnuCash never normalises user namespaces.
+
 However, if you need to support Stocks, for example, 
 your broker supports fractional trading of AMZN.
 

--- a/README.md
+++ b/README.md
@@ -942,16 +942,13 @@ gnucash-plaintext unpost-invoices ledger.gnucash --by-guid 9f14a498cc894d50931f8
 
 Behaviour:
 
-- Calls GnuCash's `Unpost(False)` directly. The posting transaction is
-  destroyed; payment transactions in the bank account remain but are
-  no longer linked to a lot. (Same end state as the GnuCash UI's
-  Unpost menu item.)
-- **Entry GUIDs are preserved** — entries are not destroyed and
-  recreated. External references to entries by GUID still resolve.
-- Per-record line: `<id> (<guid>): unposted` (or `not posted`,
-  `not found`, or `failed — multiple records share this id`).
-- Exit code 1 if any record was not found, not posted, or ambiguous;
-  successful unposts are still saved.
+- Calls GnuCash's `Unpost(False)` directly. The posting transaction is destroyed; payment transactions in the bank account remain but are no longer linked to a lot. (Same end state as the GnuCash UI's Unpost menu item.)
+- **Entry GUIDs are preserved** — entries are not destroyed and recreated. External references to entries by GUID still resolve.
+- Per-record line: `<id> (<guid>): unposted` (or `not posted`, `not found`, or `failed — multiple records share this id`).
+- **Orphan-payment warning**: when the record being unposted was paid, the CLI lists each bank-side payment transaction that is about to be orphaned — with the orphan's GUID, date, bank account, amount, currency, customer/vendor name, and memo. The warning steers the user toward the two safe cleanup paths: `delete-transactions --by-guid <orphan-guid>` (drop the orphan, then re-import with a fresh `payment:` block), or a `payment:` block carrying `txn_guid: "<orphan-guid>"` on re-import (retargets the existing bank tx into the new posted lot — see [Q-004](docs/issues/Q-004-payment-transaction-duplicates.md)). Doing neither, then re-paying via a fresh `payment:` block, leaves the orphan in place alongside the new payment and silently doubles the recorded bank balance.
+- Exit code 1 if any record was not found, not posted, or ambiguous; successful unposts are still saved.
+
+For after-the-fact recovery — auditing a book that's already accumulated orphans from prior unpost runs — use `find-orphan-payments` (next section).
 
 Compared to the re-import path:
 
@@ -960,6 +957,32 @@ Compared to the re-import path:
 | Reads .txt? | Yes — directive entries replace existing | No |
 | Entry GUIDs | Preserved when only the posted block toggles; otherwise rebuilt | Always preserved |
 | Use when... | The .txt is your source of truth and may also edit fields | The .txt is stale/absent and you only want the unpost |
+
+#### Listing orphan bank-side payments: `find-orphan-payments`
+
+After a series of unposts, the book may have payment-class bank transactions whose AR/AP-side split's lot is no longer attached to any invoice or bill — orphans. The live `unpost-invoices` / `unpost-bills` flow warns about each orphan it's about to create, but if those messages were missed (a prior session, an inherited book, etc.) the orphans accumulate silently and cause the re-pay-after-unpost duplicate-bank-balance trap.
+
+`find-orphan-payments` scans the book and lists every orphan with its GUID, date, bank account, amount, currency, the customer/vendor it was originally paying, and the bank-side split memo. Per-bank-account totals at the end. Read-only — the command never deletes or modifies anything; the user picks the cleanup path per orphan.
+
+```bash
+# Whole-book sweep:
+gnucash-plaintext find-orphan-payments ledger.gnucash
+
+# Scope to a single customer (orphan must carry that customer's KVP backref):
+gnucash-plaintext find-orphan-payments ledger.gnucash --customer C001
+
+# Scope to a single vendor (bill-side orphans):
+gnucash-plaintext find-orphan-payments ledger.gnucash --vendor V001
+```
+
+Exit code 0 whether or not any orphans are found — the command is informational. A clean book reports `No orphan bank-side payment transactions found.` and exits 0.
+
+Cleanup options the command points at, per orphan:
+
+  a) `gnucash-plaintext delete-transactions <book> --by-guid <guid>` — drop the orphan (with a plaintext backup written), then re-import the invoice/bill with a fresh `payment:` block.
+  b) Re-import the invoice/bill with a `payment:` block carrying `txn_guid: "<orphan-guid>"` — retargets the existing bank tx into the new posted lot (Q-004).
+
+Detection criteria (so the user can trust the result): payment-class transactions (`txn_type == 'P'`) whose KVP customer/vendor backref is intact and whose AR/AP-side split's lot has no invoice attached. The KVP backref survives unpost authoritatively (set by `gncOwnerApplyPayment` when the payment was first recorded), so each orphan can be pinned to a specific customer/vendor — though not to a specific invoice, since the lot → invoice link is destroyed by unpost.
 
 #### Deleting unposted invoices/bills: `delete-invoices` / `delete-bills`
 

--- a/cli/find_orphan_payments_cmd.py
+++ b/cli/find_orphan_payments_cmd.py
@@ -1,0 +1,159 @@
+"""
+CLI command for finding orphan bank-side payment transactions.
+
+An "orphan" is a payment-class transaction (originally created by
+`gncOwnerApplyPayment`) whose AR/AP-side split's lot is no longer
+attached to any invoice or bill — typically because the invoice/bill
+that the payment paid was unposted in a prior session.
+
+The orphan is harmless on its own — the money still shows as moved
+through the bank — but if the user later re-pays the same invoice
+without using `txn_guid:` retarget, a second bank-side transaction
+gets created and the bank balance is silently doubled. This command
+surfaces the orphans so the user can decide between
+`delete-transactions --by-guid` (drop the orphan, fresh `payment:`
+block on re-import) or Q-004's `txn_guid:` retarget (re-link the
+existing bank tx to the new posted lot).
+
+`unpost-invoices` / `unpost-bills` already warn about orphans at the
+moment of unpost. This command exists for the after-the-fact case —
+inheriting a book, auditing for accumulated orphans, etc.
+"""
+
+
+import click
+
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from use_cases.unpost_business_objects import find_orphan_payments_in_book
+
+
+def _hyphenate(guid32: str) -> str:
+    g = guid32
+    return f'{g[0:8]}-{g[8:12]}-{g[12:16]}-{g[16:20]}-{g[20:32]}'
+
+
+@click.command('find-orphan-payments')
+@click.argument('gnucash_file', type=click.Path(exists=True))
+@click.option('--customer', 'customer_id', default=None,
+              help='Only list orphans for this customer id (e.g. C001).')
+@click.option('--vendor', 'vendor_id', default=None,
+              help='Only list orphans for this vendor id (e.g. V001).')
+def find_orphan_payments(gnucash_file, customer_id, vendor_id):
+    """
+    List bank-side payment transactions that are no longer attached to any
+    invoice or bill — typically left behind by a prior unpost.
+
+    Each orphan is reported with its GUID, date, bank account, amount, currency,
+    customer/vendor backref, transaction description, and split memo. A total
+    per bank account is printed at the end. Exit code is 0 whether or not any
+    orphans are found (the command is informational); 1 only on a real error
+    (file not found, etc.).
+
+    Cleanup paths for each orphan:
+      a) `gnucash-plaintext delete-transactions <book> --by-guid <guid>` — drop
+         the orphan (with plaintext backup), then re-import the invoice/bill
+         with a fresh `payment:` block.
+      b) Re-import the invoice/bill with a `payment:` block carrying
+         `txn_guid: "<orphan-guid>"` — retargets the existing bank tx into
+         the new posted lot (see docs/issues/Q-004).
+
+    \b
+    Examples:
+      gnucash-plaintext find-orphan-payments ledger.gnucash
+      gnucash-plaintext find-orphan-payments ledger.gnucash --customer C001
+      gnucash-plaintext find-orphan-payments ledger.gnucash --vendor V001
+    """
+    repo = GnuCashRepository(gnucash_file)
+    repo.open(mode=SessionMode.READ_ONLY)
+    try:
+        orphans = find_orphan_payments_in_book(
+            repo.book, customer_id=customer_id, vendor_id=vendor_id)
+    finally:
+        repo.close()
+
+    if not orphans:
+        scope = ''
+        if customer_id:
+            scope = f' for customer {customer_id}'
+        elif vendor_id:
+            scope = f' for vendor {vendor_id}'
+        click.echo(f'No orphan bank-side payment transactions found{scope}.')
+        return
+
+    n = len(orphans)
+    noun = 'transaction' if n == 1 else 'transactions'
+    click.echo(f'Found {n} orphan bank-side payment {noun}.')
+    click.echo('')
+    for o in orphans:
+        # Owner-type drives wording — 2=Customer, 4=Vendor.
+        if o.owner_type == 2:
+            owner_kind = 'customer'
+            side = 'AR-side'
+        elif o.owner_type == 4:
+            owner_kind = 'vendor'
+            side = 'AP-side'
+        else:
+            owner_kind = 'owner'
+            side = 'AR/AP-side'
+
+        click.echo(
+            f'  • {o.date}  {o.bank_account}  {o.currency} {o.amount}  '
+            f'"{o.description}"'
+        )
+        if o.memo:
+            click.echo(f'    memo: "{o.memo}"')
+        click.echo(f'    guid: {_hyphenate(o.tx_guid)}')
+        click.echo('    why classified as orphan (evidence on this tx):')
+        click.echo(
+            '      - xaccTransGetTxnType(tx) == \'P\' — payment-class transaction,'
+        )
+        click.echo(
+            '        created by gncOwnerApplyPayment when the invoice/bill was paid'
+        )
+        click.echo(
+            f'      - gncOwnerGetOwnerFromTxn(tx) returned {owner_kind} '
+            f'{o.owner_id} ({o.owner_name})'
+        )
+        click.echo(
+            '        — KVP customer/vendor backref, set at payment time, survived unpost'
+        )
+        click.echo(
+            f'      - {side} split is on {o.ar_ap_account}, but the split\'s lot'
+        )
+        click.echo(
+            '        has no invoice/bill attached — gncInvoiceGetInvoiceFromLot'
+        )
+        click.echo(
+            '        returned NULL, i.e. the lot was detached when its'
+        )
+        click.echo(
+            f'        {"invoice" if o.owner_type == 2 else "bill"} was unposted'
+        )
+
+    # Per-bank-account totals.
+    by_acct: dict = {}
+    for o in orphans:
+        by_acct.setdefault((o.bank_account, o.currency), 0.0)
+        by_acct[(o.bank_account, o.currency)] += float(o.amount)
+    click.echo('')
+    if len(by_acct) == 1:
+        (acct, ccy), total = next(iter(by_acct.items()))
+        click.echo(f'Total: {ccy} {total:.2f} in {acct}.')
+    else:
+        click.echo('Totals per bank account:')
+        for (acct, ccy), total in sorted(by_acct.items()):
+            click.echo(f'  {ccy} {total:.2f} in {acct}')
+
+    click.echo('')
+    click.echo('Cleanup options per orphan (pick one, per the Q-014 / Q-004 docs):')
+    click.echo(
+        '  a) delete with `delete-transactions --by-guid <guid>` and '
+        're-import the')
+    click.echo(
+        '     invoice/bill with a fresh `payment:` block, or')
+    click.echo(
+        '  b) re-import the invoice/bill with `txn_guid: "<guid>"` inside '
+        'the new')
+    click.echo(
+        '     `payment:` block to retarget the existing bank tx '
+        '(see Q-004).')

--- a/cli/main.py
+++ b/cli/main.py
@@ -21,6 +21,7 @@ from cli.export_accounts_cmd import export_accounts
 from cli.export_beancount_cmd import export_beancount
 from cli.export_cmd import export_transactions
 from cli.export_transaction_cmd import export_transaction
+from cli.find_orphan_payments_cmd import find_orphan_payments
 from cli.find_transactions_cmd import find_transactions
 from cli.import_beancount_cmd import import_beancount
 from cli.import_cmd import import_transactions
@@ -73,6 +74,7 @@ cli.add_command(archive_customers, name='archive-customers')
 cli.add_command(archive_vendors, name='archive-vendors')
 cli.add_command(unpost_invoices, name='unpost-invoices')
 cli.add_command(unpost_bills, name='unpost-bills')
+cli.add_command(find_orphan_payments, name='find-orphan-payments')
 
 
 if __name__ == '__main__':

--- a/cli/unpost_cmd.py
+++ b/cli/unpost_cmd.py
@@ -1,23 +1,39 @@
 """
-CLI commands for unposting invoices and bills (Q-010).
+CLI commands for unposting invoices and bills.
 
-unpost-invoices / unpost-bills
-    Unpost one or more posted records by ID (or GUID with --by-guid).
-    Calls GnuCash's Unpost(False) directly — does NOT consult any
-    plaintext file. Entry GUIDs are preserved.
+`unpost-invoices <book> <ids>... [--by-guid]` and `unpost-bills <book> <ids>... [--by-guid]`
+take posted records to the unposted state. The posting transaction (AR for
+invoices, AP for bills) is destroyed; the invoice/bill itself stays in the book
+with its entries intact and can be edited and reposted.
 
-    Exit code 1 if any ID was not found, not posted, or ambiguous.
+**Important — payment transactions survive unpost.** When the record was paid,
+the bank-side payment transaction(s) stay in the book as free-standing entries
+(no longer linked to any invoice/bill lot). Your bank ledger still shows the
+money received (invoice) or sent (bill). After unpost, each affected record
+prints the list of bank-side transactions it just orphaned, with their GUIDs,
+dates, accounts, and amounts. Use that list to either:
+
+  - delete the orphan(s) with `delete-transactions --by-guid`, then re-import
+    the invoice/bill with a fresh `payment:` block; or
+  - re-import the invoice/bill with a `payment:` block carrying
+    `txn_guid: "<orphan-guid>"` to retarget the existing bank tx into the new
+    posted lot (see docs/issues/Q-004 for the retarget mechanism).
+
+Doing neither, then re-paying via a fresh `payment:` block, leaves the orphan
+in place alongside the new payment — silently doubling your bank entries.
 
 Per-ID output examples:
+
     INV-001 (abc123…): unposted
+    ⚠  1 bank-side payment transaction is now orphaned in the book.
+       …
     INV-002 (def456…): not posted (already unposted)
     INV-003: not found
     INV-004: failed — multiple records share this id; rerun with --by-guid
 
-This complements the re-import path: changing `posted: { ... }` to
-`posted: none` in a .txt and re-importing also unposts, but it
-rebuilds entries from the .txt. Use this command when the .txt is
-stale or absent and you only want the unpost itself.
+Use this command when the .txt is stale or absent and you only want the
+unpost itself. The re-import path (toggle `posted: { ... }` → `posted: none`
+and re-import) also unposts but rebuilds entries from the .txt.
 """
 
 import sys
@@ -29,6 +45,7 @@ from repositories.gnucash_repository import GnuCashRepository, SessionMode
 from use_cases.unpost_business_objects import (
     UnpostBillsUseCase,
     UnpostInvoicesUseCase,
+    UnpostResult,
     UnpostStatus,
 )
 
@@ -43,6 +60,100 @@ def _normalise_guids(guids):
     return out
 
 
+def _format_orphan_warning(result: UnpostResult) -> str:
+    """Render the orphan-payment warning block for one unposted record.
+
+    Empty string if the record had no orphans (posted but never paid →
+    silent success). For invoices: "AR", "received". For bills: "AP",
+    "sent" — owner type is the only material difference per the Q-014
+    research's bill-symmetry round.
+    """
+    if not result.orphans:
+        return ''
+
+    n = len(result.orphans)
+    noun = 'transaction' if n == 1 else 'transactions'
+    is_invoice = (result.kind == 'invoice')
+    side = 'AR' if is_invoice else 'AP'
+    flow = 'received in' if is_invoice else 'sent from'
+    record_word = result.kind
+
+    lines = []
+    lines.append('')
+    lines.append(
+        f'⚠  {n} bank-side payment {noun} {"is" if n == 1 else "are"} '
+        f'now orphaned in the book.'
+    )
+    lines.append(
+        f'   GnuCash unpost destroys the {side} posting transaction but '
+        f'leaves payment'
+    )
+    lines.append(
+        f'   transactions intact — the money still shows as {flow} '
+        f'your bank account.'
+    )
+    lines.append('')
+
+    # GUID formatted with hyphens for human reading; the un-hyphenated form
+    # below is what `delete-transactions --by-guid` accepts.
+    def _hyphenate(guid32: str) -> str:
+        g = guid32
+        return f'{g[0:8]}-{g[8:12]}-{g[12:16]}-{g[16:20]}-{g[20:32]}'
+
+    for o in result.orphans:
+        memo_part = f' "{o.memo}"' if o.memo else ''
+        lines.append(
+            f'   • {o.date}  {o.bank_account}  {o.currency} {o.amount}  '
+            f'"{o.description}"'
+        )
+        if o.memo:
+            lines.append(f'     memo:{memo_part}')
+        lines.append(f'     guid: {_hyphenate(o.tx_guid)}')
+
+    if n > 1:
+        by_acct: dict = {}
+        for o in result.orphans:
+            by_acct.setdefault((o.bank_account, o.currency), 0.0)
+            by_acct[(o.bank_account, o.currency)] += float(o.amount)
+        if len(by_acct) == 1:
+            (acct, ccy), total = next(iter(by_acct.items()))
+            lines.append('')
+            lines.append(f'   Total orphaned: {ccy} {total:.2f} in {acct}.')
+        else:
+            lines.append('')
+            lines.append('   Total orphaned per bank account:')
+            for (acct, ccy), total in sorted(by_acct.items()):
+                lines.append(f'     {ccy} {total:.2f} in {acct}')
+
+    lines.append('')
+    lines.append(f'   If you intend to re-pay this {record_word}, either:')
+    lines.append('     a) delete the orphan(s) first:')
+    for o in result.orphans:
+        lines.append(
+            f'          gnucash-plaintext delete-transactions <book> '
+            f'--by-guid {o.tx_guid}'
+        )
+    lines.append(
+        f'        then re-import the {record_word} with a fresh '
+        f'`payment:` block, or'
+    )
+    lines.append(
+        f'     b) re-import the {record_word} with a `payment:` block '
+        f'that includes'
+    )
+    if n == 1:
+        lines.append(f'          txn_guid: "{result.orphans[0].tx_guid}"')
+    else:
+        lines.append('          txn_guid: "<orphan-guid>"  (one block per orphan)')
+    lines.append(
+        '        to retarget the existing bank transaction(s) into the '
+        'new posted lot'
+    )
+    lines.append('        (see docs/issues/Q-004 for the retarget mechanism).')
+
+    return '\n'.join(lines)
+
+
 def _run_unpost(gnucash_file, ids, use_case_cls, by_guid=False):
     ids = _normalise_guids(ids) if by_guid else list(ids)
     repo = GnuCashRepository(gnucash_file)
@@ -54,6 +165,9 @@ def _run_unpost(gnucash_file, ids, use_case_cls, by_guid=False):
         all_ok = True
         for r in results:
             click.echo(f'{r.label()}: {r.message()}')
+            warning = _format_orphan_warning(r)
+            if warning:
+                click.echo(warning)
             if r.status != UnpostStatus.UNPOSTED:
                 all_ok = False
 
@@ -79,11 +193,14 @@ def unpost_invoices(gnucash_file, ids, by_guid):
     """
     Unpost one or more posted customer invoices.
 
-    Destroys the posting transaction. Payment transactions in the bank
-    account remain but become orphaned (no longer linked to a lot) —
-    same as GnuCash's UI Unpost.
+    Destroys the AR posting transaction. Bank-side payment transactions
+    remain in the book as free-standing entries (the orphan-payment trap);
+    each one is reported with its GUID so you can either delete it via
+    `delete-transactions --by-guid` or retarget it via Q-004's
+    `txn_guid:` re-import path. Doing neither, then re-paying via a fresh
+    `payment:` block, silently duplicates the bank deposit.
 
-    Entry GUIDs are preserved (no destroy + recreate).
+    Entry GUIDs on the invoice are preserved.
 
     Exit code 1 if any record was not found, not posted, or ambiguous.
 
@@ -105,8 +222,12 @@ def unpost_bills(gnucash_file, ids, by_guid):
     """
     Unpost one or more posted vendor bills.
 
-    See unpost-invoices for behaviour details — the bill side is
-    symmetric (AP rather than AR).
+    Symmetric to unpost-invoices: destroys the AP posting transaction;
+    bank-side payment transactions remain in the book as free-standing
+    entries (orphans), each reported with its GUID. The cleanup paths
+    are the same as for invoices (`delete-transactions --by-guid` or
+    `txn_guid:` retarget). Doing neither, then re-paying, silently
+    duplicates the bank withdrawal.
 
     \b
     Examples:

--- a/docs/issues/Q-014-orphan-payment-warning-on-unpost.md
+++ b/docs/issues/Q-014-orphan-payment-warning-on-unpost.md
@@ -3,7 +3,7 @@ id: Q-014
 title: `unpost-invoices` / `unpost-bills` don't warn about soon-to-be-orphan bank payments
 category: quality
 severity: medium
-status: open
+status: closed
 ---
 
 ## Problem
@@ -89,17 +89,32 @@ The exact spec is in the research doc, [section "4. CLI mockup"](../research/202
 
 The research probe at `tests/research/orphan_detection_probe.py:find_pre_unpost_payments` is the working prototype. Lift directly; the four passing probe tests (`test_orphan_backreference_probe`, `test_orphan_backreference_probe_bill`, `test_find_orphan_payments_prototype`, `test_find_orphan_payments_prototype_bill`) cover both customer and vendor sides.
 
+## Also in scope: `find-orphan-payments` (retrospective discovery)
+
+The live unpost flow surfaces orphans at the moment they're created. For after-the-fact recovery — auditing a book that's already accumulated orphans from prior unpost runs, or one inherited from another user — Q-014 ships a separate read-only command:
+
+```
+gnucash-plaintext find-orphan-payments <book> [--customer C001] [--vendor V001]
+```
+
+The command walks every transaction in the book and applies four criteria to identify orphans:
+
+1. `xaccTransGetTxnType == 'P'` — payment-class only (excludes manual deposits, transfers, lot-management entries).
+2. `gncOwnerGetOwnerFromTxn` returns success — the KVP customer/vendor backref set by `gncOwnerApplyPayment` survived unpost.
+3. Payment shape — one split on an AR/AP account, one elsewhere.
+4. The AR/AP-side split's lot has no invoice/bill attached (`gncInvoiceGetInvoiceFromLot` returns NULL) — the lot was detached when the invoice/bill was unposted.
+
+Each match is reported with its GUID, date, bank account, amount, currency, customer/vendor backref, description, memo, AND a per-orphan "why classified as orphan" block that quotes the actual classifier evidence for that transaction. Per-bank-account totals summarise the rolled-up impact. The command is read-only — it never modifies the book; the user picks the cleanup path per orphan (`delete-transactions --by-guid` or `txn_guid:` retarget).
+
+False-positive risk is bounded: the four criteria collectively cannot match anything other than a `gncOwnerApplyPayment`-created tx whose lot is now detached. The post-unpost helper cannot pin an orphan to a specific original *invoice* (the lot → invoice link was destroyed by unpost), only to a specific customer/vendor; the user-controlled memo/description may carry an invoice id by convention but is not relied upon for classification.
+
 ## Out of scope
 
-The research surfaced three follow-up areas. Q-014 ships **only the warning**:
+Two follow-ups remain for future Q tickets:
 
-1. **Auto-cleanup CLI** — `unpost-invoices --cleanup-payments` flag or a dedicated `cleanup-orphan-payments <book> <invoice-id>` command. The research notes this is a useful safety net for users who already unposted and want to clean up after the fact, but it's a bigger design (separate command, separate confirmation, separate test surface). Defer to a future Q ticket.
+1. **Auto-cleanup CLI** — `unpost-invoices --cleanup-payments` flag or a dedicated `cleanup-orphan-payments <book> <invoice-id>` command that automatically deletes the orphan(s) as part of the unpost flow. Skipped from Q-014 because real-money bank-tx deletion needs more guardrails than the unpost path provides: refuse-if-reconciled (or `--force`), per-orphan plaintext backup, and an explicit confirmation prompt. Without those, a single missed flag could silently drop bank entries that the user wanted to keep (e.g. they unposted to fix the invoice date and the payment was correct). The current PR's warning-only approach leaves the destructive decision with the user.
 
-2. **Post-unpost recovery helper** — the `find_orphan_payments_post_unpost` prototype in the probe walks the book heuristically (KVP owner ref + AR/AP-no-invoice filter). Useful as a building block for the cleanup CLI above, but not needed for the warning path. Defer.
-
-3. **Plaintext orphan-flagging** — exporting orphan bank txs with a marker (e.g. `orphan: true` under the invoice's `payment:` block, or a `notes:` annotation) so export → import is lossless. Bigger design question for the plaintext format. Defer to a future Q ticket; the current behaviour is to emit orphans only in the free-form `transactions:` section.
-
-Out-of-scope items are flagged in the research doc's "Implications for the codebase" section with the same numbering.
+2. **Plaintext orphan-flagging** — exporting orphan bank txs with a marker (e.g. `orphan: true` under the invoice's `payment:` block, or a `notes:` annotation) so export → import is lossless across an unpost cycle. Bigger design question for the plaintext format. Current behaviour is to emit orphans only in the free-form `transactions:` section; the importer cannot reconstruct the orphan ↔ original-invoice association on re-import.
 
 ## Related issues
 

--- a/infrastructure/gnucash/kvp.py
+++ b/infrastructure/gnucash/kvp.py
@@ -35,6 +35,14 @@ KNOWN_TX_METADATA_KEYS = frozenset({
     'currency.mnemonic',
     'doc_link',
     'notes',
+    # NOTE: `txn_type` and `owner` are deliberately NOT in this set even
+    # though the exporter emits them on payment-class transactions. The
+    # in-memory mutators (`xaccTransSetTxnType`, `gncOwnerCopyOnTxn`) are
+    # no-ops from Python in GnuCash 5.x (both ctypes and SWIG paths
+    # silently fail to mutate). Letting them fall into the custom-KVP
+    # path makes the values round-trip-preserved as plain KVP slots —
+    # `find-orphan-payments` reads either the C field (in-book) or the
+    # KVP (after a plaintext roundtrip).
 })
 
 # Split metadata keys that have dedicated GnuCash setters.
@@ -45,6 +53,15 @@ KNOWN_SPLIT_METADATA_KEYS = frozenset({
     'memo',
     'account.commodity.mnemonic',
     'account.commodity.namespace',
+    # Q-014: emitted on the AR/AP-side split of an orphan payment tx so
+    # the importer can re-create the orphan lot at re-import time. The
+    # value is "customer:<id>" or "vendor:<id>". Without this round-trip,
+    # the GnuCash 5.x txn-type heuristic on the restored book returns
+    # NONE (it needs the AR/AP-side split's lot to have either an
+    # invoice attached OR an owner) and `find-orphan-payments` would
+    # only fire via the custom-KVP fallback (also emitted on the txn
+    # itself as `owner:` / `txn_type:`).
+    'lot_owner',
 })
 
 # Customer metadata keys that have dedicated GnuCash setters.

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -1034,6 +1034,16 @@ class GnuCashImporter:
             commodity_table.insert(commodity)
             logging.debug(f"Created commodity {namespace}.{mnemonic}")
         else:
+            # Honor the user's declared fraction even when the commodity is
+            # already in the book. This matters for non-CURRENCY commodities
+            # the user has fully under their control (stocks, points, custom
+            # units) and for re-imports that adjust the fraction. For ISO
+            # 4217 CURRENCY commodities, GnuCash 5.15+ subsequently
+            # normalises the fraction back to its ISO value on save (e.g.
+            # KRW → 1) — that is upstream behaviour, not ours; the in-memory
+            # value still matches the user during the import session.
+            if commodity.get_fraction() != fraction:
+                commodity.set_fraction(fraction)
             logging.debug(f"Commodity {namespace}.{mnemonic} already exists")
 
     @staticmethod

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -1213,6 +1213,58 @@ class GnuCashImporter:
                 if memo is not None:
                     split.SetMemo(memo)
 
+            # Q-014: re-create an orphan lot when the exporter marked
+            # this split as the AR/AP side of an orphan payment. The
+            # GnuCash 5.x txn-type heuristic returns 'P' for a tx whose
+            # AR/AP split's lot has either an invoice OR an owner — we
+            # take the second arm (lot with owner, no invoice) since
+            # the original orphan lot was already in that state when
+            # exported. Without this, the restored book's heuristic
+            # returns NONE and `find-orphan-payments` would fall back
+            # to the custom-KVP signal alone.
+            _lot_owner_str = split_directive.metadata.get('lot_owner', '')
+            if _lot_owner_str and ':' in _lot_owner_str:
+                _kind, _, _oid = _lot_owner_str.partition(':')
+                _kind = _kind.strip()
+                _oid = _oid.strip().strip('"')
+                if _kind in ('customer', 'vendor') and _oid:
+                    import ctypes as _ctypes
+
+                    from infrastructure.gnucash.engine import (
+                        load_gnc_engine as _load,
+                    )
+                    _lib = _load()
+                    try:
+                        _lib.gnc_lot_new.argtypes = [_ctypes.c_void_p]
+                        _lib.gnc_lot_new.restype = _ctypes.c_void_p
+                        _lib.xaccAccountInsertLot.argtypes = [_ctypes.c_void_p, _ctypes.c_void_p]
+                        _lib.xaccAccountInsertLot.restype = None
+                        _lib.gnc_lot_add_split.argtypes = [_ctypes.c_void_p, _ctypes.c_void_p]
+                        _lib.gnc_lot_add_split.restype = None
+                        _lib.gncOwnerAttachToLot.argtypes = [_ctypes.c_void_p, _ctypes.c_void_p]
+                        _lib.gncOwnerAttachToLot.restype = None
+                        _lib.gncOwnerInitCustomer.argtypes = [_ctypes.c_void_p, _ctypes.c_void_p]
+                        _lib.gncOwnerInitCustomer.restype = None
+                        _lib.gncOwnerInitVendor.argtypes = [_ctypes.c_void_p, _ctypes.c_void_p]
+                        _lib.gncOwnerInitVendor.restype = None
+                        if _kind == 'customer':
+                            _ref = book.CustomerLookupByID(_oid)
+                        else:
+                            _ref = book.VendorLookupByID(_oid)
+                        if _ref is not None and _ref.GetID():
+                            _new_lot = _lib.gnc_lot_new(int(book.instance))
+                            _lib.xaccAccountInsertLot(int(split_account.instance), _new_lot)
+                            _lib.gnc_lot_add_split(_new_lot, int(split.instance))
+                            _owner_buf = _ctypes.create_string_buffer(256)
+                            _owner_p = _ctypes.cast(_owner_buf, _ctypes.c_void_p).value
+                            if _kind == 'customer':
+                                _lib.gncOwnerInitCustomer(_owner_p, int(_ref.instance))
+                            else:
+                                _lib.gncOwnerInitVendor(_owner_p, int(_ref.instance))
+                            _lib.gncOwnerAttachToLot(_owner_p, _new_lot)
+                    except AttributeError:
+                        pass
+
             # Store any non-standard split metadata as KVP slots
             custom_split_meta = {
                 k: v for k, v in split_directive.metadata.items()

--- a/tests/fixtures/comprehensive_test_data.txt
+++ b/tests/fixtures/comprehensive_test_data.txt
@@ -152,7 +152,7 @@
 	mnemonic: "KRW"
 	fullname: "Won"
 	namespace: "CURRENCY"
-	fraction: 100
+	fraction: 1
 2024-03-12 open Assets:Cash In Wallets:KRW
 	guid: "942fcdde6b66483784d8fb8275049bcb"
 	type: "Asset"

--- a/tests/fixtures/q014_bill_posted_paid.txt
+++ b/tests/fixtures/q014_bill_posted_paid.txt
@@ -1,0 +1,27 @@
+vendor "V001"
+	name: "Supplier"
+	currency: CAD
+
+bill "BILL-001"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Supplies"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 50
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-001"
+		accumulate: true
+	payment:
+		date: 2026-01-15
+		amount: 50
+		bank_account: "Assets:Bank"
+		memo: "Payment BILL-001"

--- a/tests/fixtures/q014_invoice_partial_payments.txt
+++ b/tests/fixtures/q014_invoice_partial_payments.txt
@@ -1,0 +1,33 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-001"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-001"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 60
+		bank_account: "Assets:Bank"
+		memo: "Partial 1"
+	payment:
+		date: 2026-01-25
+		amount: 40
+		bank_account: "Assets:Bank"
+		memo: "Partial 2"

--- a/tests/fixtures/q014_invoice_posted_paid.txt
+++ b/tests/fixtures/q014_invoice_posted_paid.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-001"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-001"
+		accumulate: true
+	payment:
+		date: 2026-01-15
+		amount: 100
+		bank_account: "Assets:Bank"
+		memo: "Payment INV-001"

--- a/tests/integration/test_find_orphan_payments.py
+++ b/tests/integration/test_find_orphan_payments.py
@@ -1,0 +1,358 @@
+"""
+Q-014: integration tests for `find-orphan-payments`.
+
+The command walks a book looking for payment-class bank transactions
+whose AR/AP-side split's lot is no longer attached to any invoice/bill —
+i.e. orphans left behind by a prior unpost. This is the after-the-fact
+recovery path (the live unpost flow already warns via the
+`unpost-invoices` / `unpost-bills` output).
+"""
+
+import os
+import time
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+
+def _fixture(name: str) -> str:
+    path = os.path.join(os.path.dirname(__file__), '..', 'fixtures', f'{name}.txt')
+    with open(path) as f:
+        return f.read()
+
+
+ACCOUNTS = """
+2026-01-01 open Assets
+\ttype: Asset
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Assets:Bank
+\ttype: Bank
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Assets:Accounts Receivable
+\ttype: Accounts Receivable
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Liabilities
+\ttype: Liability
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:Accounts Payable
+\ttype: Accounts Payable
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Income
+\ttype: Income
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Income:Sales
+\ttype: Income
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Expenses
+\ttype: Expense
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Expenses:Supplies
+\ttype: Expense
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+"""
+
+
+def _write(path, text):
+    path.write_text(text)
+    return str(path)
+
+
+def _import_new(runner, gnc, fixture_path):
+    return runner.invoke(cli, ["import", "--new", str(gnc), fixture_path,
+                               "--include-business-objects"])
+
+
+def _import(runner, gnc, fixture_path):
+    return runner.invoke(cli, ["import", str(gnc), fixture_path,
+                               "--include-business-objects"])
+
+
+def _setup_book(runner, tmp_path, fixture_text):
+    gnc = tmp_path / "book.gnucash"
+    fix = _write(tmp_path / "in.txt", ACCOUNTS + "\n" + fixture_text)
+    r = _import_new(runner, gnc, fix)
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    return gnc
+
+
+def _make_orphan_invoice(runner, tmp_path, fixture_name, record_id, cmd):
+    """Import a paid invoice/bill fixture, then unpost it via the CLI
+    so the bank-side payment tx becomes orphaned. Returns the .gnucash path."""
+    gnc = _setup_book(runner, tmp_path, _fixture(fixture_name))
+    r = runner.invoke(cli, [cmd, str(gnc), record_id])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    return gnc
+
+
+class TestFindOrphanPayments:
+
+    def test_clean_book_reports_no_orphans(self, tmp_path):
+        """A freshly-imported posted+paid invoice has its payment attached
+        to the invoice's lot — not orphaned. find-orphan-payments reports
+        nothing and exits 0."""
+        runner = CliRunner()
+        gnc = _setup_book(runner, tmp_path, _fixture('q014_invoice_posted_paid'))
+
+        r = runner.invoke(cli, ["find-orphan-payments", str(gnc)])
+        assert r.exit_code == 0, r.output
+        assert 'No orphan bank-side payment transactions found' in r.output, r.output
+
+    def test_finds_one_invoice_orphan_after_unpost(self, tmp_path):
+        """After `unpost-invoices INV-001`, the bank tx becomes orphaned.
+        find-orphan-payments lists it with customer + GUID."""
+        runner = CliRunner()
+        gnc = _make_orphan_invoice(runner, tmp_path,
+                                   'q014_invoice_posted_paid', 'INV-001',
+                                   'unpost-invoices')
+
+        r = runner.invoke(cli, ["find-orphan-payments", str(gnc)])
+        assert r.exit_code == 0, r.output
+        assert 'Found 1 orphan bank-side payment transaction' in r.output, r.output
+
+        # Tx fields:
+        assert '2026-01-15' in r.output
+        assert 'Assets:Bank' in r.output
+        assert 'CAD 100.00' in r.output
+        assert '"Acme"' in r.output
+        assert 'Payment INV-001' in r.output
+
+        # Per-orphan "why classified as orphan" block must quote the
+        # actual classifier evidence for THIS transaction (not a generic
+        # paragraph) — the user should be able to audit the decision.
+        assert 'why classified as orphan' in r.output, r.output
+        # Criterion 1: txn-type is 'P'.
+        assert "xaccTransGetTxnType(tx) == 'P'" in r.output, r.output
+        # Criterion 2: KVP owner backref names this specific customer.
+        assert 'gncOwnerGetOwnerFromTxn(tx) returned customer C001 (Acme)' in r.output, r.output
+        # Criterion 3 + 4: AR-side on the AR account, lot detached.
+        assert 'AR-side split is on Assets:Accounts Receivable' in r.output, r.output
+        assert 'gncInvoiceGetInvoiceFromLot' in r.output, r.output
+        assert 'invoice was unposted' in r.output, r.output
+
+        # Total + cleanup-options summary:
+        assert 'Total: CAD 100.00 in Assets:Bank' in r.output, r.output
+        assert 'Cleanup options' in r.output
+        assert 'delete-transactions --by-guid' in r.output
+        assert 'txn_guid' in r.output
+
+    def test_finds_bill_orphan_with_vendor_backref(self, tmp_path):
+        """Mirror for the bill side — vendor backref instead of customer."""
+        runner = CliRunner()
+        gnc = _make_orphan_invoice(runner, tmp_path,
+                                   'q014_bill_posted_paid', 'BILL-001',
+                                   'unpost-bills')
+
+        r = runner.invoke(cli, ["find-orphan-payments", str(gnc)])
+        assert r.exit_code == 0, r.output
+        assert 'Found 1 orphan bank-side payment transaction' in r.output, r.output
+        assert 'CAD 50.00' in r.output
+        # Bill side: vendor backref + AP-side wording.
+        assert 'gncOwnerGetOwnerFromTxn(tx) returned vendor V001 (Supplier)' in r.output, r.output
+        assert 'AP-side split is on Liabilities:Accounts Payable' in r.output, r.output
+        assert 'bill was unposted' in r.output, r.output
+
+    def test_customer_filter_narrows_results(self, tmp_path):
+        """--customer scopes to that customer's orphans only."""
+        runner = CliRunner()
+        gnc = _make_orphan_invoice(runner, tmp_path,
+                                   'q014_invoice_posted_paid', 'INV-001',
+                                   'unpost-invoices')
+
+        # Hit: actual customer.
+        r = runner.invoke(cli, ["find-orphan-payments", str(gnc),
+                                "--customer", "C001"])
+        assert r.exit_code == 0, r.output
+        assert 'Found 1 orphan bank-side payment transaction' in r.output
+
+        # Miss: customer with no orphans.
+        r = runner.invoke(cli, ["find-orphan-payments", str(gnc),
+                                "--customer", "C999"])
+        assert r.exit_code == 0, r.output
+        assert 'No orphan bank-side payment transactions found' in r.output
+        assert 'for customer C999' in r.output
+
+    def test_normal_bank_tx_is_not_classified_as_orphan(self, tmp_path):
+        """Manual bank txs (deposits, transfers — not created via
+        `gncOwnerApplyPayment`) have `xaccTransGetTxnType == 'N'`, which
+        fails criterion 1 of the orphan classifier. A book consisting of
+        only such transactions should report zero orphans.
+
+        Boundary test: confirms that the classifier doesn't false-positive
+        on the most common type of non-payment transaction (the kind a
+        bank-statement importer or hand entry creates)."""
+        runner = CliRunner()
+        gnc = tmp_path / "book.gnucash"
+        # No invoice or bill — just an accounts file plus one manual bank
+        # tx between Bank and Income.
+        manual_tx = """
+2026-02-01 * "Interest received"
+\tAssets:Bank 25.00 CAD
+\tIncome -25.00 CAD
+"""
+        fix = _write(tmp_path / "in.txt", ACCOUNTS + manual_tx)
+        r = _import_new(runner, gnc, fix)
+        assert r.exit_code == 0, r.output
+        time.sleep(1)
+
+        r = runner.invoke(cli, ["find-orphan-payments", str(gnc)])
+        assert r.exit_code == 0, r.output
+        assert 'No orphan bank-side payment transactions found' in r.output, r.output
+
+    def test_mix_of_orphan_attached_payment_and_manual_tx(self, tmp_path):
+        """The classifier must report ONLY the orphan in a book that also
+        contains (a) a still-attached payment and (b) a manual bank tx.
+        This exercises all three classification outcomes in one book:
+          - orphan payment (txn_type=P, lot detached) → reported
+          - still-attached payment (txn_type=P, lot has invoice) → NOT reported
+          - manual deposit (txn_type=N) → NOT reported"""
+        runner = CliRunner()
+
+        # Step 1: book starts with INV-PAID (will stay paid + attached) plus
+        # INV-ORPHAN (will be paid then unposted).
+        paid_fixture = _fixture('q014_invoice_posted_paid').replace(
+            'INV-001', 'INV-PAID')
+        gnc = _setup_book(runner, tmp_path, paid_fixture)
+
+        # Add a second invoice, also paid (will become the orphan).
+        orphan_fixture = _fixture('q014_invoice_posted_paid').replace(
+            'INV-001', 'INV-ORPHAN')
+        r = _import(runner, gnc, _write(tmp_path / "orphan.txt",
+                                        ACCOUNTS + "\n" + orphan_fixture))
+        assert r.exit_code == 0, r.output
+        time.sleep(1)
+
+        # Add a manual bank tx (txn_type='N').
+        manual_tx = """
+2026-02-01 * "Manual deposit"
+\tAssets:Bank 999.00 CAD
+\tIncome -999.00 CAD
+"""
+        r = _import(runner, gnc, _write(tmp_path / "manual.txt", manual_tx))
+        assert r.exit_code == 0, r.output
+        time.sleep(1)
+
+        # Unpost INV-ORPHAN (but NOT INV-PAID).
+        r = runner.invoke(cli, ["unpost-invoices", str(gnc), "INV-ORPHAN"])
+        assert r.exit_code == 0, r.output
+        time.sleep(1)
+
+        # The classifier must find exactly the one orphan, not 2 or 3.
+        r = runner.invoke(cli, ["find-orphan-payments", str(gnc)])
+        assert r.exit_code == 0, r.output
+        assert 'Found 1 orphan bank-side payment transaction' in r.output, (
+            f"Expected exactly 1 orphan (INV-ORPHAN's payment). The manual tx "
+            f"and the still-attached INV-PAID payment must NOT be classified "
+            f"as orphans. Got:\n{r.output}")
+        # No accidental sweep of the manual tx:
+        assert '999.00' not in r.output, (
+            f"Manual bank tx (CAD 999.00) must not appear in the orphan list. "
+            f"Got:\n{r.output}")
+
+    def test_orphan_classification_survives_plaintext_roundtrip(self, tmp_path):
+        """Detection must work after export → re-import into a fresh book.
+
+        Without the plaintext format carrying `txn_type:`, the orphan bank
+        tx loses its `'P'` classification on the way through the .txt file
+        (the importer's default is `'N'`). Criterion 1 of the classifier
+        then fails on the restored book and the orphan is invisible.
+
+        With `txn_type:` round-tripping, the orphan is detectable in both
+        the original and the restored book."""
+        runner = CliRunner()
+
+        # 1. Original book: posted → paid → unposted invoice (orphan exists).
+        gnc = _make_orphan_invoice(runner, tmp_path,
+                                   'q014_invoice_posted_paid', 'INV-001',
+                                   'unpost-invoices')
+        r = runner.invoke(cli, ["find-orphan-payments", str(gnc)])
+        assert r.exit_code == 0, r.output
+        assert 'Found 1 orphan bank-side payment transaction' in r.output, (
+            f"Setup: orphan must be detectable in the original book. "
+            f"Got:\n{r.output}")
+
+        # 2. Export the full book to plaintext (transactions + business
+        #    objects). The orphan bank tx lives in the `transactions:`
+        #    section since it's no longer attached to any invoice.
+        #
+        # `--all-accounts` is required here because the post-unpost book
+        # has no transactions touching Income:Sales — the AR posting tx
+        # was destroyed, the payment tx touches only Bank+AR. The
+        # exporter's default policy emits only accounts referenced by
+        # transactions in the result set, so without --all-accounts the
+        # invoice entry's `account: "Income:Sales"` would dangle on
+        # re-import. (This is the pre-existing exporter gap flagged in
+        # docs/research/2026-05-14-...md's "Implications for the
+        # codebase" section.)
+        exported = tmp_path / "exported.txt"
+        r = runner.invoke(cli, ["export", str(gnc), str(exported),
+                                "--include-business-objects",
+                                "--all-accounts"])
+        assert r.exit_code == 0, r.output
+        text = exported.read_text()
+        # The export must carry the orphan's txn_type so the importer can
+        # restore the 'P' classification.
+        assert 'txn_type: P' in text, (
+            f"Export must emit `txn_type: P` for the orphan payment tx. "
+            f"Without it the roundtrip silently demotes the tx to 'N' and "
+            f"find-orphan-payments goes blind. Export:\n{text}")
+        assert 'owner: customer:C001' in text, (
+            f"Export must emit `owner: customer:C001` so the importer can "
+            f"restore the gncOwner KVP on the tx (criterion 2 of the "
+            f"classifier). Export:\n{text}")
+
+        # 3. Re-import the plaintext into a fresh book.
+        fresh = tmp_path / "fresh.gnucash"
+        r = runner.invoke(cli, ["import", "--new", str(fresh), str(exported),
+                                "--include-business-objects"])
+        assert r.exit_code == 0, r.output
+        time.sleep(1)
+
+        # 4. The classifier must still find the orphan on the restored
+        # book. Detection now reads `txn_type: P` and `owner: customer:C001`
+        # from the custom-KVP slots the importer preserved (since
+        # `xaccTransSetTxnType` and `gncOwnerCopyOnTxn` are no-ops from
+        # Python on GnuCash 4.9+/5.x — the type is a heuristic derived
+        # from splits + lots, neither of which round-trip).
+        r = runner.invoke(cli, ["find-orphan-payments", str(fresh)])
+        assert r.exit_code == 0, r.output
+        assert 'Found 1 orphan bank-side payment transaction' in r.output, (
+            f"Q-014 roundtrip regression: orphan must remain classifiable "
+            f"after export+re-import. find-orphan-payments output:\n{r.output}")
+
+    def test_lists_multiple_orphans_with_per_account_total(self, tmp_path):
+        """Two paid invoices, both unposted → two orphan bank txs, total
+        rolled up by account."""
+        runner = CliRunner()
+        # First invoice (INV-001), paid in full ($100).
+        gnc = _setup_book(runner, tmp_path, _fixture('q014_invoice_posted_paid'))
+
+        # Second invoice (INV-002) posted+paid, then unpost both.
+        fixture_002 = _fixture('q014_invoice_posted_paid').replace(
+            'INV-001', 'INV-002')
+        r = _import(runner, gnc, _write(tmp_path / "inv2.txt",
+                                        ACCOUNTS + "\n" + fixture_002))
+        assert r.exit_code == 0, r.output
+        time.sleep(1)
+
+        for inv_id in ('INV-001', 'INV-002'):
+            r = runner.invoke(cli, ["unpost-invoices", str(gnc), inv_id])
+            assert r.exit_code == 0, r.output
+            time.sleep(1)
+
+        r = runner.invoke(cli, ["find-orphan-payments", str(gnc)])
+        assert r.exit_code == 0, r.output
+        assert 'Found 2 orphan bank-side payment transactions' in r.output, r.output
+        assert 'Total: CAD 200.00 in Assets:Bank' in r.output, r.output

--- a/tests/integration/test_full_conversion_chain.py
+++ b/tests/integration/test_full_conversion_chain.py
@@ -251,11 +251,27 @@ class TestFullConversionChain:
                     f.write(plaintext2)
                     roundtrip_debug = f.name
 
+                # The "Commodities only in X" prints in `differences` only show
+                # the commodity ticker (first line of a sorted block), which
+                # hides cases where the same ticker has a different metadata
+                # line on each side (e.g. fraction:100 vs fraction:1). Emit
+                # the full diverging blocks so the mismatch is visible.
+                struct1_dbg = parse_plaintext_structure(plaintext1)
+                struct2_dbg = parse_plaintext_structure(plaintext2)
+                detail_blocks = []
+                for label, only_set in (
+                    ('original', struct1_dbg['commodities'] - struct2_dbg['commodities']),
+                    ('roundtrip', struct2_dbg['commodities'] - struct1_dbg['commodities']),
+                ):
+                    for blk in only_set:
+                        detail_blocks.append(f'  ---- commodity-block only in {label} ----\n  ' + blk.replace('\n', '\n  '))
+
                 error_msg = (
                     f"\n\nSemantic differences detected in full conversion chain.\n"
                     f"Original: {original_debug}\n"
                     f"After roundtrip: {roundtrip_debug}\n\n"
-                    f"Differences:\n" + "\n".join(differences[:10])
+                    f"Differences:\n" + "\n".join(differences[:10]) +
+                    ("\n\nFull mismatched commodity blocks:\n" + "\n".join(detail_blocks) if detail_blocks else "")
                 )
                 if len(differences) > 10:
                     error_msg += f"\n... and {len(differences) - 10} more differences"

--- a/tests/integration/test_unpost_invoice_bill.py
+++ b/tests/integration/test_unpost_invoice_bill.py
@@ -338,3 +338,148 @@ class TestUnpostBillCommand:
             f"unpost-bills CLI must preserve entry GUIDs; "
             f"before={before}, after={after}"
         )
+
+
+# ── Q-014: orphan-payment warning on unpost ──────────────────────────────────
+
+
+class TestQ014OrphanPaymentWarning:
+    """Unposting a *paid* invoice/bill destroys the AR/AP posting transaction
+    but leaves the bank-side payment transaction in place, orphaned from any
+    lot. Pre-Q-014 the CLI silently said `unposted` and nothing else; users
+    didn't know the bank tx was still there and re-pay-after-unpost silently
+    duplicated the bank deposit. Q-014 makes the CLI list every soon-to-be-
+    orphan with its GUID, date, bank account, amount, and currency so the
+    user can choose between `delete-transactions --by-guid` and Q-004's
+    `txn_guid:` retarget."""
+
+    def test_unposting_paid_invoice_emits_orphan_warning(self, tmp_path):
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               _fixture('q014_invoice_posted_paid'))
+
+        r = runner.invoke(cli, ["unpost-invoices", str(gnc), "INV-001"])
+        assert r.exit_code == 0, r.output
+        assert ': unposted' in r.output
+
+        # Warning header: count + AR/received wording (invoice side).
+        assert '1 bank-side payment transaction is now orphaned' in r.output, (
+            f"Expected one-orphan warning header. Got:\n{r.output}")
+        assert 'AR posting transaction' in r.output, r.output
+        assert 'received in' in r.output, r.output
+
+        # Per-orphan details: payment date, bank account, currency, amount,
+        # customer name (in description). Memo line uses the fixture's value.
+        assert '2026-01-15' in r.output
+        assert 'Assets:Bank' in r.output
+        assert 'CAD 100.00' in r.output
+        assert '"Acme"' in r.output
+        assert 'Payment INV-001' in r.output
+
+        # The hyphenated guid is shown for human reading, and the unhyphenated
+        # form appears inside the recommended `delete-transactions --by-guid`
+        # command line.
+        import re
+        hyphenated = re.search(r'guid:\s+([0-9a-f-]{36})', r.output)
+        assert hyphenated, f"Expected hyphenated guid in output. Got:\n{r.output}"
+        guid32 = hyphenated.group(1).replace('-', '')
+        assert f'--by-guid {guid32}' in r.output, (
+            f"Expected the cleanup command to reference the orphan's "
+            f"unhyphenated GUID. Got:\n{r.output}")
+        assert f'txn_guid: "{guid32}"' in r.output, (
+            f"Expected the retarget option to reference the orphan's "
+            f"unhyphenated GUID. Got:\n{r.output}")
+
+    def test_unposting_unpaid_invoice_emits_no_warning(self, tmp_path):
+        """Posted-but-never-paid invoice: silent success after unpost. No
+        warning block, because there are no payment txs to orphan."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path, _fixture('q010_invoice_posted'))
+
+        r = runner.invoke(cli, ["unpost-invoices", str(gnc), "INV-001"])
+        assert r.exit_code == 0, r.output
+        assert 'INV-001' in r.output and ': unposted' in r.output
+        assert 'orphaned' not in r.output, (
+            f"Unpaid invoice unpost must not print an orphan warning. "
+            f"Got:\n{r.output}")
+
+    def test_unposting_partial_payments_lists_each_orphan_and_total(self, tmp_path):
+        """When an invoice was paid in multiple instalments, each instalment
+        is a separate bank-side payment transaction. Unposting orphans all of
+        them; the warning must list each and report the per-bank-account total."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               _fixture('q014_invoice_partial_payments'))
+
+        r = runner.invoke(cli, ["unpost-invoices", str(gnc), "INV-001"])
+        assert r.exit_code == 0, r.output
+        assert '2 bank-side payment transactions are now orphaned' in r.output, (
+            f"Expected the warning header to count 2 orphans. Got:\n{r.output}")
+
+        # Both partial-payment dates + amounts present:
+        assert '2026-01-10' in r.output
+        assert '2026-01-25' in r.output
+        assert 'CAD 60.00' in r.output
+        assert 'CAD 40.00' in r.output
+        # And the rolled-up total for the single bank account:
+        assert 'Total orphaned: CAD 100.00 in Assets:Bank' in r.output, (
+            f"Expected per-bank-account total line. Got:\n{r.output}")
+
+    def test_unposting_paid_bill_uses_ap_and_sent_wording(self, tmp_path):
+        """Bill side mirrors invoices but with AP/sent wording. Same helper,
+        templated output."""
+        runner = CliRunner()
+        gnc = _setup_book_with(runner, tmp_path,
+                               _fixture('q014_bill_posted_paid'))
+
+        r = runner.invoke(cli, ["unpost-bills", str(gnc), "BILL-001"])
+        assert r.exit_code == 0, r.output
+        assert ': unposted' in r.output
+        assert '1 bank-side payment transaction is now orphaned' in r.output, r.output
+
+        # AP / sent wording (vs AR / received for invoices):
+        assert 'AP posting transaction' in r.output, r.output
+        assert 'sent from' in r.output, r.output
+
+        assert 'CAD 50.00' in r.output
+        assert 'Payment BILL-001' in r.output
+        assert 'this bill' in r.output, (
+            f"Cleanup recommendation should refer to 'this bill' "
+            f"(not 'this invoice'). Got:\n{r.output}")
+
+    def test_batch_with_mixed_paid_unpaid_warns_only_for_paid(self, tmp_path):
+        """`unpost-invoices INV-PAID INV-UNPAID INV-MISSING`: the warning
+        block appears only for the paid record, not for the unpaid one nor
+        the not-found one. Each status line still appears in order."""
+        # Build a book with two invoices: one paid, one posted-but-unpaid.
+        runner = CliRunner()
+        gnc = tmp_path / "book.gnucash"
+        # First import: paid invoice.
+        paid_fix = _write(tmp_path / "paid.txt",
+                          ACCOUNTS + "\n" + _fixture('q014_invoice_posted_paid'))
+        r = _import_new(runner, gnc, paid_fix)
+        assert r.exit_code == 0, r.output
+        time.sleep(1)
+        # Then import: also create an unpaid posted invoice (different id).
+        unpaid_fix = _fixture('q010_invoice_posted').replace(
+            'INV-001', 'INV-UNPAID')
+        unpaid_path = _write(tmp_path / "unpaid.txt", unpaid_fix)
+        r = _import(runner, gnc, unpaid_path)
+        assert r.exit_code == 0, r.output
+        time.sleep(1)
+
+        r = runner.invoke(cli, [
+            "unpost-invoices", str(gnc),
+            "INV-001", "INV-UNPAID", "INV-MISSING",
+        ])
+        assert r.exit_code == 1, r.output  # missing → exit 1
+        # Both unposts succeeded:
+        assert 'INV-001' in r.output and ': unposted' in r.output
+        assert 'INV-UNPAID' in r.output
+        # The missing one was reported:
+        assert 'INV-MISSING' in r.output and 'not found' in r.output
+
+        # Exactly one warning block — for the paid invoice only.
+        assert r.output.count('orphaned in the book') == 1, (
+            f"Expected exactly one orphan-warning block (for INV-001). "
+            f"Got:\n{r.output}")

--- a/tests/research/test_post_pay_unpost_cycle.py
+++ b/tests/research/test_post_pay_unpost_cycle.py
@@ -288,6 +288,16 @@ def test_invoice_post_pay_unpost_cycle(tmp_path):
     r = runner.invoke(cli, ["unpost-invoices", str(gnc), "INV-001"])
     assert r.exit_code == 0, r.output
     assert ": unposted" in r.output
+    # Q-014: the paid invoice's payment tx is about to be orphaned, so the
+    # CLI now warns the user with the orphan's date, bank account, amount,
+    # and GUID. The warning is what tells the user that re-pay-after-unpost
+    # would silently duplicate the bank deposit unless they delete the
+    # orphan or use `txn_guid:` retarget.
+    assert "1 bank-side payment transaction is now orphaned" in r.output, (
+        "Q-014: unpost-invoices on a paid invoice must surface the orphan "
+        f"bank-side payment transaction. Got:\n{r.output}")
+    assert "Assets:Bank" in r.output
+    assert "CAD 100.00" in r.output
     time.sleep(1)
 
     entry_guid_trace["D"] = _read_entry_guids(str(gnc), "INV-001")

--- a/tests/research/test_post_pay_unpost_cycle_bill.py
+++ b/tests/research/test_post_pay_unpost_cycle_bill.py
@@ -264,6 +264,14 @@ def test_bill_post_pay_unpost_cycle(tmp_path):
     r = runner.invoke(cli, ["unpost-bills", str(gnc), "BILL-001"])
     assert r.exit_code == 0, r.output
     assert ": unposted" in r.output
+    # Q-014: same warning path as for invoices, but with AP/sent wording
+    # (mirroring the invoice side's AR/received).
+    assert "1 bank-side payment transaction is now orphaned" in r.output, (
+        "Q-014: unpost-bills on a paid bill must surface the orphan "
+        f"bank-side payment transaction. Got:\n{r.output}")
+    assert "AP posting transaction" in r.output
+    assert "sent from" in r.output
+    assert "CAD 100.00" in r.output
     time.sleep(1)
     entry_guid_trace["D"] = _read_entry_guids(str(gnc), "BILL-001")
     text_d = _snapshot(runner, gnc, tmp_path, "step_D_unposted")

--- a/tests/unit/services/test_create_commodity_update.py
+++ b/tests/unit/services/test_create_commodity_update.py
@@ -1,0 +1,121 @@
+"""
+Tests for `GnuCashImporter.create_commodity` honoring the user's declared
+fraction even when the commodity already exists in the book.
+
+Two angles:
+
+1. CURRENCY commodity (KRW) — proves the new "update existing" branch fires
+   and the in-memory fraction matches what the user declared. We don't assert
+   on save+reopen because GnuCash 5.15+ normalises ISO 4217 currencies on
+   save (Bug 666536 fix); that is upstream behaviour.
+
+2. Non-CURRENCY commodity (custom unit, e.g. a stock-like or points
+   commodity) — proves the same update branch fires AND the value persists
+   through save+reopen on every supported GnuCash version, since GnuCash
+   does not touch user-defined commodity namespaces.
+"""
+
+import os
+import tempfile
+
+
+def _fresh_book_path():
+    fd, path = tempfile.mkstemp(suffix='.gnucash')
+    os.close(fd)
+    os.unlink(path)
+    return path
+
+
+def _make_create_commodity_directive(mnemonic: str, fullname: str, namespace: str, fraction: int):
+    from services.gnucash_importer import DirectiveType, PlaintextDirective
+    d = PlaintextDirective(
+        directive_type=DirectiveType.CREATE_COMMODITY,
+        level=0,
+        line=f"commodity {namespace}.{mnemonic}",
+    )
+    d.metadata = {
+        'mnemonic': mnemonic,
+        'fullname': fullname,
+        'namespace': namespace,
+        'fraction': fraction,
+    }
+    return d
+
+
+def test_user_fraction_overrides_pre_registered_currency_in_memory():
+    """Pre-registered KRW gets the user's fraction in memory after import."""
+    from repositories.gnucash_repository import GnuCashRepository
+    from services.gnucash_importer import GnuCashImporter
+
+    path = _fresh_book_path()
+    GnuCashRepository.create_new_file(path)
+    repo = GnuCashRepository(path)
+    repo.open()
+    try:
+        book = repo.book
+        krw = book.get_table().lookup('CURRENCY', 'KRW')
+        assert krw is not None, "KRW should be pre-registered"
+        pre_fraction = krw.get_fraction()
+        # User-chosen fraction guaranteed to differ from any GnuCash default
+        # (5.10 ships KRW with 100, 5.15 ships 1; neither equals 1000).
+        user_fraction = 1000
+
+        directive = _make_create_commodity_directive(
+            mnemonic='KRW', fullname='Won', namespace='CURRENCY', fraction=user_fraction
+        )
+        GnuCashImporter.create_commodity(directive, book)
+
+        krw_after = book.get_table().lookup('CURRENCY', 'KRW')
+        assert krw_after.get_fraction() == user_fraction, (
+            f"Importer must honor user's fraction={user_fraction}; "
+            f"saw {krw_after.get_fraction()} (pre-import was {pre_fraction})"
+        )
+    finally:
+        repo.close()
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_user_fraction_overrides_existing_custom_commodity_through_save():
+    """Non-CURRENCY commodity update survives save+reopen on every distro.
+
+    First import creates the commodity with fraction A; second import
+    declares the same commodity with fraction B; after save+reopen the
+    persisted fraction is B.
+    """
+    from repositories.gnucash_repository import GnuCashRepository
+    from services.gnucash_importer import GnuCashImporter
+
+    path = _fresh_book_path()
+    namespace = 'CUSTOM'
+    mnemonic = 'PTS'
+    fullname = 'Loyalty Points'
+
+    GnuCashRepository.create_new_file(path)
+    repo = GnuCashRepository(path)
+    repo.open()
+    try:
+        d1 = _make_create_commodity_directive(mnemonic, fullname, namespace, 10)
+        GnuCashImporter.create_commodity(d1, repo.book)
+        assert repo.book.get_table().lookup(namespace, mnemonic).get_fraction() == 10
+        # Re-declare at fraction=1000 → update branch fires.
+        d2 = _make_create_commodity_directive(mnemonic, fullname, namespace, 1000)
+        GnuCashImporter.create_commodity(d2, repo.book)
+        assert repo.book.get_table().lookup(namespace, mnemonic).get_fraction() == 1000
+        repo.save()
+    finally:
+        repo.close()
+
+    repo2 = GnuCashRepository(path)
+    repo2.open()
+    try:
+        commodity = repo2.book.get_table().lookup(namespace, mnemonic)
+        assert commodity is not None, f"Custom commodity {namespace}.{mnemonic} should persist"
+        assert commodity.get_fraction() == 1000, (
+            f"User-declared fraction must survive save+reopen for non-CURRENCY "
+            f"commodities; saw {commodity.get_fraction()}"
+        )
+    finally:
+        repo2.close()
+        if os.path.exists(path):
+            os.unlink(path)

--- a/use_cases/export_transactions.py
+++ b/use_cases/export_transactions.py
@@ -493,9 +493,66 @@ class ExportTransactionsUseCase:
         if tx_notes and tx_notes.strip() != "":
             lines.append(f'\tnotes: {encode_value_as_string(tx_notes)}')
 
-        # Emit custom KVP metadata
+        # txn_type + owner: GnuCash internal classifier + customer/vendor
+        # KVP backref set by the business-object machinery (txn_type='I'
+        # on invoice/bill posting transactions and 'P' on payments
+        # created by `gncOwnerApplyPayment`; the gncOwner KVP slot names
+        # the customer/vendor that the payment paid). Default txn_type
+        # is 'N' (normal); only emit non-N values so old plaintext files
+        # round-trip unchanged. Both fields are needed so that orphan
+        # bank-side payment transactions (whose AR/AP lot was detached
+        # by unpost) can still be detected by `find-orphan-payments`
+        # after a plaintext roundtrip — without these fields the
+        # restored tx defaults to txn_type='N' and no owner ref, so
+        # criteria 1 and 2 of the classifier fail.
+        import ctypes as _ctypes
+
+        from infrastructure.gnucash.engine import load_gnc_engine as _load
+        _lib = _load()
+        _tx_ptr = int(transaction.instance)
+        try:
+            _lib.xaccTransGetTxnType.restype = _ctypes.c_char
+            _lib.xaccTransGetTxnType.argtypes = [_ctypes.c_void_p]
+            _t = _lib.xaccTransGetTxnType(_tx_ptr)
+            if isinstance(_t, bytes):
+                _t = _t.decode('ascii', errors='replace')
+            if _t and _t != 'N':
+                lines.append(f'\ttxn_type: {_t}')
+        except AttributeError:
+            pass
+
+        try:
+            _lib.gncOwnerGetOwnerFromTxn.argtypes = [_ctypes.c_void_p, _ctypes.c_void_p]
+            _lib.gncOwnerGetOwnerFromTxn.restype = _ctypes.c_int
+            _lib.gncOwnerGetID.argtypes = [_ctypes.c_void_p]
+            _lib.gncOwnerGetID.restype = _ctypes.c_char_p
+            _lib.gncOwnerGetType.argtypes = [_ctypes.c_void_p]
+            _lib.gncOwnerGetType.restype = _ctypes.c_int
+            _owner_buf = _ctypes.create_string_buffer(256)
+            _owner_p = _ctypes.cast(_owner_buf, _ctypes.c_void_p).value
+            if _lib.gncOwnerGetOwnerFromTxn(_tx_ptr, _owner_p) == 1:
+                _otype = _lib.gncOwnerGetType(_owner_p)
+                _oid_raw = _lib.gncOwnerGetID(_owner_p)
+                _oid = (_oid_raw.decode('utf-8', errors='replace')
+                        if _oid_raw else '')
+                _kind = {2: 'customer', 4: 'vendor'}.get(_otype)
+                if _kind and _oid:
+                    lines.append(f'\towner: {_kind}:{_oid}')
+        except AttributeError:
+            pass
+
+        # Emit custom KVP metadata. Skip Q-014's `txn_type` and `owner`
+        # slots — they're already emitted above as dedicated lines based
+        # on the live C state, and re-emitting from the KVP slot would
+        # produce duplicate lines on the second pass of an export → import
+        # → export roundtrip (the importer stores `txn_type:` and `owner:`
+        # from the plaintext as custom KVPs since the matching C setters
+        # are no-ops on GnuCash 4.8+).
+        _q014_reserved_tx = {'txn_type', 'owner'}
         custom_meta = get_custom_metadata(transaction)
         for key, value in sorted(custom_meta.items()):
+            if key in _q014_reserved_tx:
+                continue
             lines.append(f'\t{key}: {encode_value_as_string(value)}')
 
         # Splits
@@ -571,9 +628,55 @@ class ExportTransactionsUseCase:
         if memo and memo != "":
             lines.append(f'\t\tmemo:{encode_value_as_string(memo)}')
 
-        # Emit custom split KVP metadata
+        # Q-014: orphan-lot reconstruction marker. When this split is on
+        # the AR/AP side of an unposted/orphan payment lot (lot exists,
+        # is owner-attached, but has no invoice), emit the owner so the
+        # importer can re-create the orphan lot — that's what makes the
+        # GnuCash 5.x txn-type heuristic return 'P' on the restored book
+        # (the heuristic is "AR/AP split's lot has an invoice OR an
+        # owner"; the second arm covers our case).
+        import ctypes as _ctypes
+
+        from infrastructure.gnucash.engine import load_gnc_engine as _load
+        _lib = _load()
+        try:
+            _lib.xaccSplitGetLot.argtypes = [_ctypes.c_void_p]
+            _lib.xaccSplitGetLot.restype = _ctypes.c_void_p
+            _lib.gncInvoiceGetInvoiceFromLot.argtypes = [_ctypes.c_void_p]
+            _lib.gncInvoiceGetInvoiceFromLot.restype = _ctypes.c_void_p
+            _lib.gncOwnerGetOwnerFromLot.argtypes = [_ctypes.c_void_p, _ctypes.c_void_p]
+            _lib.gncOwnerGetOwnerFromLot.restype = _ctypes.c_int
+            _lib.gncOwnerGetID.argtypes = [_ctypes.c_void_p]
+            _lib.gncOwnerGetID.restype = _ctypes.c_char_p
+            _lib.gncOwnerGetType.argtypes = [_ctypes.c_void_p]
+            _lib.gncOwnerGetType.restype = _ctypes.c_int
+            _lot_ptr = _lib.xaccSplitGetLot(int(split.instance))
+            if _lot_ptr:
+                _inv = _lib.gncInvoiceGetInvoiceFromLot(_lot_ptr)
+                if not _inv:                       # orphan lot — emit marker
+                    _owner_buf = _ctypes.create_string_buffer(256)
+                    _owner_p = _ctypes.cast(_owner_buf, _ctypes.c_void_p).value
+                    if _lib.gncOwnerGetOwnerFromLot(_lot_ptr, _owner_p) == 1:
+                        _otype = _lib.gncOwnerGetType(_owner_p)
+                        _oid_raw = _lib.gncOwnerGetID(_owner_p)
+                        _oid = (_oid_raw.decode('utf-8', errors='replace')
+                                if _oid_raw else '')
+                        _kind = {2: 'customer', 4: 'vendor'}.get(_otype)
+                        if _kind and _oid:
+                            lines.append(f'\t\tlot_owner: {_kind}:{_oid}')
+        except AttributeError:
+            pass
+
+        # Emit custom split KVP metadata. Skip Q-014's `lot_owner` slot
+        # for the same reason as the tx-level reserved keys above:
+        # the importer stores `lot_owner:` as a custom KVP AND uses it
+        # to reconstruct an orphan lot; on re-export we already emit it
+        # from the live lot state via the block above.
+        _q014_reserved_split = {'lot_owner'}
         custom_split_meta = get_custom_metadata(split)
         for key, value in sorted(custom_split_meta.items()):
+            if key in _q014_reserved_split:
+                continue
             lines.append(f'\t\t{key}: {encode_value_as_string(value)}')
 
         # Running balance — emitted last so it reads as a post-transaction annotation

--- a/use_cases/import_beancount.py
+++ b/use_cases/import_beancount.py
@@ -96,29 +96,25 @@ class ImportBeancountUseCase:
         return result
 
     def _create_commodity(self, commodity_data):
-        """Create or update commodity from beancount data"""
-        # Check if commodity already exists
-        commodity = self.repository.get_commodity(
-            commodity_data.gnucash_namespace,
-            commodity_data.gnucash_mnemonic
+        """Create or update commodity from beancount data.
+
+        GnuCashImporter.create_commodity handles both create and update of
+        an existing commodity (e.g. updating fraction for a pre-registered
+        ISO 4217 currency the user customized).
+        """
+        directive = PlaintextDirective(
+            directive_type=DirectiveType.CREATE_COMMODITY,
+            level=0,
+            line=f"commodity {commodity_data.symbol}"
         )
+        directive.metadata = {
+            'mnemonic': commodity_data.gnucash_mnemonic,
+            'fullname': commodity_data.gnucash_fullname or "",
+            'namespace': commodity_data.gnucash_namespace,
+            'fraction': commodity_data.gnucash_fraction
+        }
 
-        if commodity is None:
-            # Convert to PlaintextDirective format to reuse GnuCashImporter
-            directive = PlaintextDirective(
-                directive_type=DirectiveType.CREATE_COMMODITY,
-                level=0,
-                line=f"commodity {commodity_data.symbol}"
-            )
-            directive.metadata = {
-                'mnemonic': commodity_data.gnucash_mnemonic,
-                'fullname': commodity_data.gnucash_fullname or "",
-                'namespace': commodity_data.gnucash_namespace,
-                'fraction': commodity_data.gnucash_fraction
-            }
-
-            # Use existing GnuCashImporter
-            GnuCashImporter.create_commodity(directive, self.repository.book)
+        GnuCashImporter.create_commodity(directive, self.repository.book)
 
     def _create_account(self, account_data):
         """Create account from beancount data using original GnuCash name"""

--- a/use_cases/unpost_business_objects.py
+++ b/use_cases/unpost_business_objects.py
@@ -1,7 +1,8 @@
 """
-Q-010: dedicated unpost commands for invoices and bills.
+Q-010 + Q-014: dedicated unpost commands for invoices and bills, with
+orphan-bank-payment surfacing.
 
-`unpost-invoice <book> <ID>...` and `unpost-bill <book> <ID>...` provide
+`unpost-invoices <book> <ID>...` and `unpost-bills <book> <ID>...` provide
 a one-shot, plaintext-free way to unpost a posted invoice/bill. Unlike
 the re-import path (where toggling `posted: { ... }` → `posted: none`
 also unposts but rebuilds entries from the .txt), this path:
@@ -13,17 +14,31 @@ also unposts but rebuilds entries from the .txt), this path:
     (their AR/AP splits no longer link to a lot). This matches GnuCash
     UI's own Unpost behaviour exactly.
 
+Q-014: just before `Unpost(False)` we walk the posted lot and capture
+every payment-class transaction attached to it. Those transactions
+survive the unpost as free-standing bank entries; the CLI surfaces
+them so the user knows what's left behind and how to clean it up
+(`delete-transactions --by-guid` or Q-004's `txn_guid:` retarget).
+
 Use the re-import path when the .txt is the source of truth and you
-want to also edit fields. Use this command when the .txt is stale or
+want to also edit fields. Use these commands when the .txt is stale or
 absent and you only want the unpost itself.
 """
 
-from dataclasses import dataclass
+import ctypes
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from enum import Enum, auto
 from typing import List
 
 from gnucash import Book
 
+from infrastructure.gnucash.engine import (
+    GncNumericC,
+    iterate_glist,
+    load_gnc_engine,
+    safe_ctypes_string,
+)
 from services.gnucash_importer import (
     _find_bill_by_guid,
     _find_bills_by_id,
@@ -41,10 +56,47 @@ class UnpostStatus(Enum):
 
 
 @dataclass
+class OrphanPayment:
+    """A payment-class bank-side transaction.
+
+    Produced by two helpers in this module:
+
+      - `find_lot_payment_transactions(rec)` captures payments *before*
+        `Unpost(False)` while the lot still names them. Authoritative; the
+        `owner_*` fields are left empty since the caller already knows the
+        invoice/bill they're about to unpost.
+
+      - `find_orphan_payments_in_book(book)` walks the whole book to find
+        already-orphaned payments (records that were unposted in a prior
+        run / session). The lot → invoice link is destroyed by unpost, so
+        these can be pinned to a customer/vendor but not to a specific
+        invoice. The `owner_*` fields are populated; `description` and
+        `memo` may carry an invoice id if the user followed the convention,
+        but that's not guaranteed.
+    """
+    tx_guid: str           # 32-hex (no hyphens), the form `delete-transactions --by-guid` accepts
+    date: str              # YYYY-MM-DD
+    bank_account: str      # full account path, e.g. "Assets:Bank"
+    amount: str            # absolute value, formatted to 2 decimals, e.g. "100.00"
+    currency: str          # 3-letter mnemonic, e.g. "CAD"
+    description: str       # transaction description (typically the customer/vendor name)
+    memo: str              # bank-side split memo (user-controlled; may be empty)
+    owner_type: int = 0    # 0=unknown, 2=Customer, 4=Vendor (post-unpost helper only)
+    owner_id: str = ''     # e.g. "C001" (post-unpost helper only)
+    owner_name: str = ''   # e.g. "Acme" (post-unpost helper only)
+    ar_ap_account: str = ''  # AR or AP account the now-detached lot lives in,
+                             # e.g. "Assets:Accounts Receivable" — populated by
+                             # the post-unpost helper so the CLI explanation can
+                             # name the exact account the lot detached from.
+
+
+@dataclass
 class UnpostResult:
     id: str
     guid: str = ''
     status: UnpostStatus = None
+    kind: str = 'invoice'                                  # 'invoice' or 'bill'
+    orphans: List[OrphanPayment] = field(default_factory=list)
 
     def message(self) -> str:
         if self.status == UnpostStatus.UNPOSTED:
@@ -62,6 +114,387 @@ class UnpostResult:
         if self.guid:
             return f'{self.id} ({self.guid})'
         return self.id
+
+
+def find_lot_payment_transactions(rec) -> List[OrphanPayment]:
+    """Return every payment-class transaction attached to `rec`'s posted lot.
+
+    Must be called BEFORE `rec.Unpost(False)` — once unposted, the lot's
+    invoice association is destroyed and the lot can no longer be walked
+    from the record. Returns [] if `rec.GetPostedLot()` is None (the record
+    is not currently posted, so there's no lot to walk).
+
+    The walk yields each payment transaction exactly once (a payment tx has
+    two splits — bank and AR/AP — both on the lot's split list).
+
+    Zero false positives: lot membership is set by `gncOwnerApplyPayment`
+    when the payment is recorded; non-payment transactions on the lot are
+    excluded by the `xaccTransGetTxnType == 'P'` filter (payment-class
+    only — distinct from `'I'` for the invoice's own posting tx).
+
+    Identification of the bank-side split: a payment transaction has one
+    split on an A/Receivable (account type 11) or A/Payable (12) account
+    and one split elsewhere. The "elsewhere" split is the bank-side; we
+    report its account, memo, and the absolute amount.
+    """
+    lot = rec.GetPostedLot()
+    if lot is None:
+        return []
+
+    lib = load_gnc_engine()
+    # Lazily configure ctypes function signatures used in the walk.
+    # argtypes is non-optional for every pointer arg (CLAUDE.md §1).
+    # GncNumeric returns must use `restype=GncNumericC` (ctypes marshals the
+    # 16-byte struct value, NOT a pointer to it).
+    for name, restype, argtypes in [
+        ('gnc_lot_get_split_list',     ctypes.c_void_p, [ctypes.c_void_p]),
+        ('xaccSplitGetParent',         ctypes.c_void_p, [ctypes.c_void_p]),
+        ('xaccSplitGetAmount',         GncNumericC,     [ctypes.c_void_p]),
+        ('xaccTransGetTxnType',        ctypes.c_char,   [ctypes.c_void_p]),
+        ('xaccTransCountSplits',       ctypes.c_int,    [ctypes.c_void_p]),
+        ('xaccTransGetSplit',          ctypes.c_void_p, [ctypes.c_void_p, ctypes.c_int]),
+        ('xaccTransGetDate',           ctypes.c_int64,  [ctypes.c_void_p]),
+        ('xaccTransGetDescription',    ctypes.c_char_p, [ctypes.c_void_p]),
+        ('xaccTransGetCurrency',       ctypes.c_void_p, [ctypes.c_void_p]),
+        ('xaccSplitGetAccount',        ctypes.c_void_p, [ctypes.c_void_p]),
+        ('xaccSplitGetMemo',           ctypes.c_char_p, [ctypes.c_void_p]),
+        ('xaccAccountGetType',         ctypes.c_int,    [ctypes.c_void_p]),
+        ('gnc_commodity_get_mnemonic', ctypes.c_char_p, [ctypes.c_void_p]),
+        ('qof_instance_get_guid',      ctypes.c_void_p, [ctypes.c_void_p]),
+        ('guid_to_string_buff',        ctypes.c_char_p, [ctypes.c_void_p, ctypes.c_char_p]),
+        ('xaccAccountGetName',         ctypes.c_char_p, [ctypes.c_void_p]),
+        ('gnc_account_get_parent',     ctypes.c_void_p, [ctypes.c_void_p]),
+    ]:
+        try:
+            f = getattr(lib, name)
+            f.restype = restype
+            f.argtypes = argtypes
+        except AttributeError:
+            pass
+
+    def _acct_full_name(acct_ptr) -> str:
+        """Build the account's full path using `:` as separator, the project's
+        plaintext convention. Avoids `gnc_account_get_full_name` because that
+        function uses the book's configured separator (defaults to `.`),
+        which doesn't match the plaintext format. Same parent-walk pattern as
+        `services/gnucash_importer.py:_acct_name`."""
+        parts = []
+        ptr = acct_ptr
+        while ptr:
+            name = safe_ctypes_string(lib.xaccAccountGetName, ptr)
+            if name:
+                parts.append(name)
+            parent = lib.gnc_account_get_parent(ptr)
+            if not parent:
+                break
+            # Stop at the root account (which has no parent of its own).
+            if not lib.gnc_account_get_parent(parent):
+                break
+            ptr = parent
+        parts.reverse()
+        return ':'.join(parts)
+
+    splits_glist = lib.gnc_lot_get_split_list(int(lot.instance))
+
+    results: List[OrphanPayment] = []
+    seen_tx: set = set()
+    for split_ptr in iterate_glist(lib, splits_glist, lambda lib, p: p):
+        if not split_ptr:
+            continue
+        tx_ptr = lib.xaccSplitGetParent(split_ptr)
+        if not tx_ptr or tx_ptr in seen_tx:
+            continue
+        seen_tx.add(tx_ptr)
+
+        # Filter to payment-class transactions only. The lot also contains
+        # the invoice's own posting tx (txn_type 'I') — we don't want that.
+        tx_type = lib.xaccTransGetTxnType(tx_ptr)
+        if isinstance(tx_type, bytes):
+            tx_type = tx_type.decode('ascii', errors='replace')
+        if tx_type != 'P':
+            continue
+
+        # Find the bank-side split: any split NOT on an AR/AP account.
+        bank_acct_name = ''
+        bank_memo = ''
+        bank_amount = 0.0
+        nsplits = lib.xaccTransCountSplits(tx_ptr)
+        for j in range(nsplits):
+            s_ptr = lib.xaccTransGetSplit(tx_ptr, j)
+            a_ptr = lib.xaccSplitGetAccount(s_ptr)
+            a_type = lib.xaccAccountGetType(a_ptr)
+            if a_type in (11, 12):                         # A/Receivable, A/Payable
+                continue
+            bank_acct_name = _acct_full_name(a_ptr)
+            bank_memo_raw = lib.xaccSplitGetMemo(s_ptr)
+            bank_memo = (bank_memo_raw.decode('utf-8', errors='replace')
+                         if bank_memo_raw else '')
+            amt = lib.xaccSplitGetAmount(s_ptr)
+            bank_amount = abs(amt.num / amt.denom) if amt.denom else 0.0
+            break
+
+        # Tx-level fields, all via ctypes.
+        # xaccTransGetDate returns time64 (seconds since epoch, UTC).
+        epoch = lib.xaccTransGetDate(tx_ptr)
+        date_str = datetime.fromtimestamp(epoch, tz=timezone.utc).strftime('%Y-%m-%d')
+        desc_raw = lib.xaccTransGetDescription(tx_ptr)
+        description = desc_raw.decode('utf-8', errors='replace') if desc_raw else ''
+        commodity_ptr = lib.xaccTransGetCurrency(tx_ptr)
+        mnemonic_raw = (lib.gnc_commodity_get_mnemonic(commodity_ptr)
+                        if commodity_ptr else None)
+        currency = (mnemonic_raw.decode('ascii', errors='replace')
+                    if mnemonic_raw else '')
+
+        # tx_guid in the form `delete-transactions --by-guid` accepts:
+        # 32-hex, no hyphens, lowercase.
+        guid_ptr = lib.qof_instance_get_guid(tx_ptr)
+        buf = ctypes.create_string_buffer(40)
+        lib.guid_to_string_buff(guid_ptr, buf)
+        tx_guid = buf.value.decode('ascii').replace('-', '')
+
+        results.append(OrphanPayment(
+            tx_guid=tx_guid,
+            date=date_str,
+            bank_account=bank_acct_name,
+            amount=f'{bank_amount:.2f}',
+            currency=currency,
+            description=description,
+            memo=bank_memo,
+        ))
+    return results
+
+
+def find_orphan_payments_in_book(book: Book,
+                                 customer_id: str = None,
+                                 vendor_id: str = None) -> List[OrphanPayment]:
+    """Walk the book and return every payment-class bank-side transaction
+    that no longer points at any invoice/bill lot.
+
+    Use this for after-the-fact recovery — books where an invoice/bill was
+    unposted in a prior session and the user wants to see what bank-side
+    entries are sitting around unattached. (For the live unpost flow, the
+    CLI already shows the same info up-front via `find_lot_payment_transactions`.)
+
+    Criteria — every transaction must satisfy all of them:
+
+      1. `xaccTransGetTxnType(tx) == 'P'` — payment-class only. Excludes the
+         invoice's own posting tx ('I') and manual deposits ('N').
+      2. `gncOwnerGetOwnerFromTxn` returns success — the KVP customer/vendor
+         backref set by `gncOwnerApplyPayment` survives unpost.
+      3. Payment shape — exactly one split on an AR/AP account (type 11/12)
+         and exactly one split elsewhere (the bank side). Excludes hand-
+         crafted multi-split exotica.
+      4. The AR/AP-side split's lot has no invoice/bill attached — i.e.
+         the lot is detached, which is exactly what unpost does. Skips
+         payments that are still attached to a currently-posted record.
+
+    False-positive risk: when a customer has multiple orphan payments from
+    different (now-unposted) invoices in the same book, this helper lists
+    them all but cannot say *which* invoice each one originally paid. The
+    user-controlled memo / description fields may carry an invoice id by
+    convention, but the helper does not assume so.
+
+    Filters:
+      - `customer_id` (e.g. "C001") restricts the result to that customer's
+        orphans.
+      - `vendor_id` (e.g. "V001") restricts to that vendor's orphans.
+      - Pass neither for the full book sweep.
+    """
+    lib = load_gnc_engine()
+    for name, restype, argtypes in [
+        ('xaccTransGetTxnType',        ctypes.c_char,   [ctypes.c_void_p]),
+        ('xaccTransCountSplits',       ctypes.c_int,    [ctypes.c_void_p]),
+        ('xaccTransGetSplit',          ctypes.c_void_p, [ctypes.c_void_p, ctypes.c_int]),
+        ('xaccTransGetDate',           ctypes.c_int64,  [ctypes.c_void_p]),
+        ('xaccTransGetDescription',    ctypes.c_char_p, [ctypes.c_void_p]),
+        ('xaccTransGetCurrency',       ctypes.c_void_p, [ctypes.c_void_p]),
+        ('xaccSplitGetAccount',        ctypes.c_void_p, [ctypes.c_void_p]),
+        ('xaccSplitGetMemo',           ctypes.c_char_p, [ctypes.c_void_p]),
+        ('xaccSplitGetAmount',         GncNumericC,     [ctypes.c_void_p]),
+        ('xaccSplitGetLot',            ctypes.c_void_p, [ctypes.c_void_p]),
+        ('xaccAccountGetType',         ctypes.c_int,    [ctypes.c_void_p]),
+        ('gnc_commodity_get_mnemonic', ctypes.c_char_p, [ctypes.c_void_p]),
+        ('gncInvoiceGetInvoiceFromLot', ctypes.c_void_p, [ctypes.c_void_p]),
+        ('gncOwnerGetOwnerFromTxn',    ctypes.c_int,    [ctypes.c_void_p, ctypes.c_void_p]),
+        ('gncOwnerGetID',              ctypes.c_char_p, [ctypes.c_void_p]),
+        ('gncOwnerGetName',            ctypes.c_char_p, [ctypes.c_void_p]),
+        ('gncOwnerGetType',            ctypes.c_int,    [ctypes.c_void_p]),
+        ('qof_instance_get_guid',      ctypes.c_void_p, [ctypes.c_void_p]),
+        ('guid_to_string_buff',        ctypes.c_char_p, [ctypes.c_void_p, ctypes.c_char_p]),
+        ('xaccAccountGetName',         ctypes.c_char_p, [ctypes.c_void_p]),
+        ('gnc_account_get_parent',     ctypes.c_void_p, [ctypes.c_void_p]),
+    ]:
+        try:
+            f = getattr(lib, name)
+            f.restype = restype
+            f.argtypes = argtypes
+        except AttributeError:
+            pass
+
+    def _acct_full_name(acct_ptr) -> str:
+        parts = []
+        ptr = acct_ptr
+        while ptr:
+            name = safe_ctypes_string(lib.xaccAccountGetName, ptr)
+            if name:
+                parts.append(name)
+            parent = lib.gnc_account_get_parent(ptr)
+            if not parent or not lib.gnc_account_get_parent(parent):
+                break
+            ptr = parent
+        parts.reverse()
+        return ':'.join(parts)
+
+    # Reusable GncOwner scratch buffer. 256 bytes is safely larger than the
+    # real struct on every supported GnuCash version (per the probe).
+    owner_buf = ctypes.create_string_buffer(256)
+    owner_ptr = ctypes.cast(owner_buf, ctypes.c_void_p).value
+
+    from gnucash import Query, Transaction
+
+    from infrastructure.gnucash.kvp import get_custom_metadata
+    q = Query()
+    try:
+        q.search_for('Trans')
+        q.set_book(book)
+
+        results: List[OrphanPayment] = []
+        for r in q.run():
+            tx = Transaction(instance=r)
+            tx_ptr = int(tx.instance)
+
+            # Criterion 1: payment-class. The C-side `xaccTransGetTxnType`
+            # is HEURISTIC-driven in GnuCash 5.x (per `Transaction.h`:
+            # "derived from the transaction splits according to
+            # heuristics ... does not query the transaction kvp slots").
+            # The heuristic returns 'P' only when the AR-side split has a
+            # lot + owner backref attached — both of which survive an
+            # in-file unpost but are LOST across a plaintext roundtrip.
+            # So we fall back to the exporter's `txn_type:` line, which
+            # the importer preserved as a custom KVP because `txn_type`
+            # is deliberately NOT in KNOWN_TX_METADATA_KEYS.
+            t = lib.xaccTransGetTxnType(tx_ptr)
+            if isinstance(t, bytes):
+                t = t.decode('ascii', errors='replace')
+            tx_kvp = get_custom_metadata(tx) or {}
+            tx_kvp_type = tx_kvp.get('txn_type', '')
+            if t != 'P' and tx_kvp_type != 'P':
+                continue
+
+            # Criterion 2: customer/vendor backref. Same story —
+            # `gncOwnerGetOwnerFromTxn` reads the gncOwner KVP slot
+            # (set in C by `gncOwnerApplyPayment`); the slot survives
+            # unpost in-file but cannot be re-set from Python after a
+            # roundtrip (both ctypes `gncOwnerCopyOnTxn` and SWIG
+            # equivalents are silent no-ops in 5.x). Fall back to the
+            # exporter's `owner: customer:<id>` / `owner: vendor:<id>`
+            # line, preserved as a custom KVP.
+            got = lib.gncOwnerGetOwnerFromTxn(tx_ptr, owner_ptr)
+            this_owner_id = ''
+            this_owner_type = 0
+            this_owner_name = ''
+            if got == 1:
+                owner_id_raw = lib.gncOwnerGetID(owner_ptr)
+                this_owner_id = (owner_id_raw.decode('utf-8', errors='replace')
+                                 if owner_id_raw else '')
+                this_owner_type = lib.gncOwnerGetType(owner_ptr)
+                owner_name_raw = lib.gncOwnerGetName(owner_ptr)
+                this_owner_name = (owner_name_raw.decode('utf-8', errors='replace')
+                                   if owner_name_raw else '')
+            else:
+                # Try the custom-KVP fallback. Format: "customer:<id>"
+                # or "vendor:<id>". Name isn't preserved across roundtrip
+                # so we look it up by id.
+                kvp_owner = tx_kvp.get('owner', '')
+                if kvp_owner and ':' in kvp_owner:
+                    kind, _, oid = kvp_owner.partition(':')
+                    kind = kind.strip()
+                    oid = oid.strip()
+                    if kind == 'customer' and oid:
+                        cust = book.CustomerLookupByID(oid)
+                        if cust is not None and cust.GetID():
+                            this_owner_type = 2
+                            this_owner_id = oid
+                            this_owner_name = cust.GetName() or ''
+                    elif kind == 'vendor' and oid:
+                        vend = book.VendorLookupByID(oid)
+                        if vend is not None and vend.GetID():
+                            this_owner_type = 4
+                            this_owner_id = oid
+                            this_owner_name = vend.GetName() or ''
+            if not this_owner_id:
+                continue
+            if customer_id and not (this_owner_type == 2 and this_owner_id == customer_id):
+                continue
+            if vendor_id and not (this_owner_type == 4 and this_owner_id == vendor_id):
+                continue
+
+            # Criterion 3: payment shape — one AR/AP split, one elsewhere.
+            ar_s = None
+            bank_s = None
+            nsplits = lib.xaccTransCountSplits(tx_ptr)
+            for j in range(nsplits):
+                s_ptr = lib.xaccTransGetSplit(tx_ptr, j)
+                a_ptr = lib.xaccSplitGetAccount(s_ptr)
+                a_type = lib.xaccAccountGetType(a_ptr)
+                if a_type in (11, 12):
+                    ar_s = s_ptr
+                else:
+                    bank_s = s_ptr
+            if not (ar_s and bank_s):
+                continue
+
+            # Criterion 4: AR/AP-side lot has no invoice attached → orphan.
+            # Three states are accepted:
+            #   - lot exists and has NO invoice → unposted-in-file orphan
+            #   - no lot at all → roundtripped orphan (plaintext doesn't
+            #     carry lots, so the importer recreates the tx with
+            #     loose splits)
+            # Lot exists AND has invoice → still attached, skip.
+            lot_ptr = lib.xaccSplitGetLot(ar_s)
+            if lot_ptr and lib.gncInvoiceGetInvoiceFromLot(lot_ptr):
+                continue                       # still attached to a posted record
+
+            ar_ap_a_ptr = lib.xaccSplitGetAccount(ar_s)
+            ar_ap_acct_name = _acct_full_name(ar_ap_a_ptr)
+            bank_a_ptr = lib.xaccSplitGetAccount(bank_s)
+            bank_acct_name = _acct_full_name(bank_a_ptr)
+            memo_raw = lib.xaccSplitGetMemo(bank_s)
+            memo = memo_raw.decode('utf-8', errors='replace') if memo_raw else ''
+            amt = lib.xaccSplitGetAmount(bank_s)
+            amount = abs(amt.num / amt.denom) if amt.denom else 0.0
+
+            epoch = lib.xaccTransGetDate(tx_ptr)
+            date_str = datetime.fromtimestamp(epoch, tz=timezone.utc).strftime('%Y-%m-%d')
+            desc_raw = lib.xaccTransGetDescription(tx_ptr)
+            description = desc_raw.decode('utf-8', errors='replace') if desc_raw else ''
+            commodity_ptr = lib.xaccTransGetCurrency(tx_ptr)
+            mnemonic_raw = (lib.gnc_commodity_get_mnemonic(commodity_ptr)
+                            if commodity_ptr else None)
+            currency = (mnemonic_raw.decode('ascii', errors='replace')
+                        if mnemonic_raw else '')
+
+            guid_ptr = lib.qof_instance_get_guid(tx_ptr)
+            buf = ctypes.create_string_buffer(40)
+            lib.guid_to_string_buff(guid_ptr, buf)
+            tx_guid = buf.value.decode('ascii').replace('-', '')
+
+            results.append(OrphanPayment(
+                tx_guid=tx_guid,
+                date=date_str,
+                bank_account=bank_acct_name,
+                amount=f'{amount:.2f}',
+                currency=currency,
+                description=description,
+                memo=memo,
+                owner_type=this_owner_type,
+                owner_id=this_owner_id,
+                owner_name=this_owner_name,
+                ar_ap_account=ar_ap_acct_name,
+            ))
+        return results
+    finally:
+        q.destroy()
 
 
 def _resolve_one(book: Book, id_or_guid: str, by_guid: bool, by_id_fn, by_guid_fn):
@@ -85,6 +518,36 @@ def _resolve_one(book: Book, id_or_guid: str, by_guid: bool, by_id_fn, by_guid_f
     return rec, rec.GetID(), _swig_invoice_guid_str(rec)
 
 
+def _execute_unpost(book: Book, ids: List[str], by_guid: bool,
+                    by_id_fn, by_guid_fn, kind: str) -> List[UnpostResult]:
+    """Shared body for UnpostInvoicesUseCase and UnpostBillsUseCase.
+
+    Captures the lot's payment transactions BEFORE `Unpost(False)` so the
+    caller can warn the user about what's about to be orphaned.
+    """
+    results = []
+    for arg in ids:
+        rec, rid, rguid = _resolve_one(book, arg, by_guid, by_id_fn, by_guid_fn)
+        if rec is None and rguid == '__ambiguous__':
+            results.append(UnpostResult(
+                id=rid, status=UnpostStatus.AMBIGUOUS_ID, kind=kind))
+            continue
+        if rec is None:
+            results.append(UnpostResult(
+                id=rid, status=UnpostStatus.NOT_FOUND, kind=kind))
+            continue
+        if rec.GetPostedTxn() is None:
+            results.append(UnpostResult(
+                id=rid, guid=rguid, status=UnpostStatus.NOT_POSTED, kind=kind))
+            continue
+        orphans = find_lot_payment_transactions(rec)
+        rec.Unpost(False)
+        results.append(UnpostResult(
+            id=rid, guid=rguid, status=UnpostStatus.UNPOSTED,
+            kind=kind, orphans=orphans))
+    return results
+
+
 class UnpostInvoicesUseCase:
     """Unpost one or more posted customer invoices."""
 
@@ -92,24 +555,9 @@ class UnpostInvoicesUseCase:
         self.book = book
 
     def execute(self, ids: List[str], by_guid: bool = False) -> List[UnpostResult]:
-        results = []
-        for arg in ids:
-            rec, rid, rguid = _resolve_one(
-                self.book, arg, by_guid, _find_invoices_by_id, _find_invoice_by_guid)
-            if rec is None and rguid == '__ambiguous__':
-                results.append(UnpostResult(id=rid, status=UnpostStatus.AMBIGUOUS_ID))
-                continue
-            if rec is None:
-                results.append(UnpostResult(id=rid, status=UnpostStatus.NOT_FOUND))
-                continue
-            if rec.GetPostedTxn() is None:
-                results.append(UnpostResult(id=rid, guid=rguid,
-                                            status=UnpostStatus.NOT_POSTED))
-                continue
-            rec.Unpost(False)
-            results.append(UnpostResult(id=rid, guid=rguid,
-                                        status=UnpostStatus.UNPOSTED))
-        return results
+        return _execute_unpost(
+            self.book, ids, by_guid,
+            _find_invoices_by_id, _find_invoice_by_guid, kind='invoice')
 
 
 class UnpostBillsUseCase:
@@ -119,21 +567,6 @@ class UnpostBillsUseCase:
         self.book = book
 
     def execute(self, ids: List[str], by_guid: bool = False) -> List[UnpostResult]:
-        results = []
-        for arg in ids:
-            rec, rid, rguid = _resolve_one(
-                self.book, arg, by_guid, _find_bills_by_id, _find_bill_by_guid)
-            if rec is None and rguid == '__ambiguous__':
-                results.append(UnpostResult(id=rid, status=UnpostStatus.AMBIGUOUS_ID))
-                continue
-            if rec is None:
-                results.append(UnpostResult(id=rid, status=UnpostStatus.NOT_FOUND))
-                continue
-            if rec.GetPostedTxn() is None:
-                results.append(UnpostResult(id=rid, guid=rguid,
-                                            status=UnpostStatus.NOT_POSTED))
-                continue
-            rec.Unpost(False)
-            results.append(UnpostResult(id=rid, guid=rguid,
-                                        status=UnpostStatus.UNPOSTED))
-        return results
+        return _execute_unpost(
+            self.book, ids, by_guid,
+            _find_bills_by_id, _find_bill_by_guid, kind='bill')


### PR DESCRIPTION
## Summary

Two commits, both required to ship Q-014 cleanly:

1. **feat(Q-014)** — `unpost-invoices` and `unpost-bills` now warn about every bank-side payment that will be left orphaned by the unpost. New `find-orphan-payments` CLI command for the retrospective case (user already unposted; needs to find what's stranded now). Plaintext export/import preserves the orphan classification across roundtrips.
2. **fix** — Both importers (plaintext and beancount) now honor the user's declared `fraction:` for commodities that already exist in the book. Required to land Q-014 because the GnuCash 5.15 Arch canary started failing on KRW after upstream Bug 666536 corrected its ISO 4217 fraction.

## Q-014: the orphan-payment trap

`unpost-invoices INV-001` (and the symmetric `unpost-bills`) destroys the AR/AP posting transaction but **leaves the bank-side payment transaction in place, orphaned from any lot**. Before this PR, the user saw `INV-001: unposted` and nothing else — the bank account still showed the money received, the invoice plaintext reverted to `payment: none`, and a subsequent re-pay-and-re-post cycle silently duplicated the bank deposit. End state for a single $100 invoice paid once: Bank +$200, AR −$100, Income +$100 — arithmetically balanced, semantically wrong, invisible to bank reconciliation.

The Q-004 `txn_guid:` retarget path is the only correct way to re-pay after unpost without duplication, but the user had no way to discover the orphan or learn its GUID. Lifecycle and trap fully characterised in `docs/research/2026-05-14-invoice-post-pay-unpost-cycle.md`.

## What this PR delivers

- **Per-orphan warning at unpost time.** `unpost-invoices` / `unpost-bills` now emit a block per orphaned bank payment listing date, account, amount, currency, memo, and GUID. The user can either delete the orphan or retarget the next payment to its GUID before duplication.
- **`find-orphan-payments` retrospective command.** For users who already unposted and need to find what's stranded. Supports `--customer` / `--vendor` filters; emits the same evidence block per orphan.
- **Three-tier orphan classifier.** GnuCash's own `xaccTransGetTxnType` heuristic (lot-with-owner arm), a custom `txn_type` / `owner` KVP fallback for re-imported books, and a pre-unpost lot-payment scan that runs while the lot is still intact. GnuCash 4.8+ silently ignores `xaccTransSetTxnType`, so the KVP-plus-lot-recreation path is the only roundtrip story that works on every supported version.
- **Plaintext roundtrip.** Export emits `txn_type:` / `owner:` at transaction level and `lot_owner:` at split level for orphan-bearing payments. Import reconstructs the orphan lot with the owner attached on the AR/AP split so the C heuristic survives a fresh book.
- **Importer fraction preservation.** Both importers update the existing commodity's fraction to the user's declared value instead of silently using the pre-registered ISO 4217 default. Load-bearing for non-CURRENCY commodities (stocks, points, custom units) on every supported version. For ISO currencies, GnuCash 5.15+ subsequently re-normalises on save — that's upstream Bug 666536, called out in the comment.
- **README + `unpost_cmd.py` docstring** cross-reference `find-orphan-payments` from the unpost section so users encounter it before they need it.

## Test plan

- [ ] `./scripts/test.sh latest tests/integration/test_unpost_invoice_bill.py` — paid-invoice unpost emits warning, paid-bill unpost uses AP wording + "sent", partial payments list each orphan plus total, batch mixed paid/unpaid warns only for paid
- [ ] `./scripts/test.sh latest tests/integration/test_find_orphan_payments.py` — 8 tests including `test_orphan_classification_survives_plaintext_roundtrip`, `test_normal_bank_tx_is_not_classified_as_orphan` (false-positive guard), `test_mix_of_orphan_attached_payment_and_manual_tx`
- [ ] `./scripts/test.sh latest tests/unit/services/test_create_commodity_update.py` — CURRENCY in-memory + non-CURRENCY through save+reopen
- [ ] `./scripts/test.sh latest tests/integration/test_full_conversion_chain.py` — full plaintext → gnucash → beancount → gnucash → plaintext roundtrip on the comprehensive fixture
- [ ] Cross-version: pre-commit hook runs all of the above on the full distro matrix (debian11/12/13, ubuntu20/22/24/26, fedora41, opensuse, arch); both commits passed.
