### PR TITLE
feat(Q-015): incremental + overpayment + credit-consumption payment workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,123 @@ invoice "INV-2026-004"
     memo: "Second instalment"
 ```
 
+**Adding a payment via re-import is incremental.** If a posted invoice is already in the book with one `payment:` block, editing the plaintext to append a second `payment:` block and re-importing applies *only* the new payment on the still-posted invoice. Two sub-paths, both incremental:
+
+* The new payment block has no `txn_guid:` — the importer calls `ApplyPayment` to create a fresh bank-side transaction.
+* The new payment block has `txn_guid: "..."` pointing at a pre-existing bank transaction (e.g. one already loaded from a QFX import) — the importer retargets that transaction's counter-split into the invoice's posted lot (the Q-004 mechanism), no new bank transaction created. Original tx GUID, notes, and KVP preserved.
+
+Either way the posting transaction, every entry, and the original bank-side payment transactions already on the invoice's lot are left untouched (same GUIDs throughout) — no orphan is created and the bank balance reflects exactly the payments the user recorded. Any other shape of diff (entry add/remove/modify, posted block change, payment field edited or removed) still takes the GnuCash-UI-equivalent unpost-rebuild-repost path, and any payment-side bank transactions about to be orphaned by that rebuild are listed in the import output with the same warning block `unpost-invoices` / `unpost-bills` emit (see the unpost section below).
+
+#### Overpayment / pre-payment credit: `prepayment:`
+
+When the customer pays more than the invoice total, GnuCash splits the single payment into two AR-side splits and routes them to two separate lots on the AR account, [exactly as the GnuCash manual describes](https://www.gnucash.org/docs/v5/C/gnucash-manual/busnss-ar-payment.html): the invoice lot (closes at $0) and a new pre-payment lot that stays open as a credit available against the next invoice.
+
+For a $100 invoice paid $150 the plaintext is:
+
+```
+invoice "INV-2026-005"
+  ...
+  posted:
+    date: 2026-03-01
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-2026-005"
+    accumulate: true
+  payment:
+    date: 2026-03-10
+    amount: 150
+    bank_account: "Assets:Bank"
+    memo: "Overpaid by 50"
+    prepayment: 50
+```
+
+What that creates in the book (one payment transaction, three splits across two accounts and two AR lots):
+
+```
+Transaction 2026-03-10 — "Acme Customer" (payment)
+  Assets:Bank                    +$150.00   (the cash you received)
+  Assets:Accounts Receivable     -$100.00   (in invoice lot — closes INV-2026-005)
+  Assets:Accounts Receivable      -$50.00   (in NEW pre-payment lot — customer credit)
+```
+
+After the payment, `Assets:Accounts Receivable` shows a net **-$50** for this customer — that's the pre-payment credit. The invoice itself is marked paid (its lot's balance is zero). The next invoice you post for the same customer can consume the credit via Process Payment in GnuCash's UI, or via a `payment:` block on the next invoice that uses `txn_guid:` to retarget the customer's existing pre-payment bank tx into the new invoice's lot.
+
+For the `txn_guid:` retarget path (Q-004), when the pre-existing bank transaction's counter-split is larger than the invoice's remaining balance, the `prepayment:` field is **required**. The importer splits the counter-split into the invoice-portion (closes the lot) and the residual (new pre-payment lot on AR/AP). Omitting `prepayment:` on an over-sized retarget is rejected with an explicit error that names the bank tx, the counter-split amount, the invoice's remaining, and the expected `prepayment` value.
+
+The same applies symmetrically to bills (AP, opposite signs): overpaying a $100 bill by $50 produces an open AP lot with **+$50** balance — a vendor credit you can apply against the next bill from the same supplier.
+
+#### Consuming an existing credit on the next invoice / bill: `auto_apply_credit:`
+
+When the customer (or vendor) already has an open pre-payment credit on AR/AP, the *next* invoice or bill for that owner can consume the credit automatically — add `auto_apply_credit: true` to the invoice/bill header:
+
+```
+invoice "INV-2026-006"
+  customer_id: "C001"
+  currency: CAD
+  date_opened: 2026-04-01
+  auto_apply_credit: true
+  entry:
+    date: 2026-04-01
+    description: "Service C"
+    action: "Hours"
+    account: "Income:Sales"
+    quantity: 1
+    price: 30
+    taxable: false
+    tax_included: false
+  posted:
+    date: 2026-04-01
+    due: 2026-04-30
+    ar_account: "Assets:Accounts Receivable"
+    memo: "Invoice INV-2026-006"
+    accumulate: true
+```
+
+On import the invoice is posted normally, then `gncInvoiceAutoApplyPayments` runs and takes from the open prepay lot(s) toward the invoice's outstanding balance. If credit ≥ invoice the lot closes via consumption; the residual stays open as a smaller credit (split in-place by GnuCash). If credit < invoice the full credit consumes; the invoice stays partially open. The flag composes with cash `payment:` blocks — cash goes first, credit auto-applies for any remainder. The exporter detects the post-auto-apply book state and emits `auto_apply_credit: true` again on round-trip; identical re-import is a no-op.
+
+#### Listing open credits: `find-prepayments`
+
+After a series of overpayments (or standalone pre-payments), the book may carry open AR / AP credit lots that aren't yet attached to any invoice or bill. `find-prepayments` walks the book and lists them — read-only, parallel to `find-orphan-payments`:
+
+```bash
+gnucash-plaintext find-prepayments ledger.gnucash
+gnucash-plaintext find-prepayments ledger.gnucash --customer C001
+gnucash-plaintext find-prepayments ledger.gnucash --vendor V001
+```
+
+Example output for a book where Acme (C001) overpaid INV-001 by $50:
+
+```
+Found 1 open pre-payment credit.
+
+  • customer C001 (Acme)  CAD 50.00  in Assets:Accounts Receivable
+    source bank tx: 2026-01-10 on Assets:Bank  "Acme"
+      memo: "Overpaid"
+      guid: e9a2b1c4-3f6d-4a17-b218-c47e85d290f3
+      NOTE: this is the parent bank tx of the credit lot's split.
+      Deleting it via `delete-transactions --by-guid` may also remove other
+      splits on the same tx (e.g. the original invoice payment if this credit
+      came from an overpayment). Consuming via `auto_apply_credit` on the next
+      invoice/bill is the non-destructive option.
+    why classified as a pre-payment (AR credit):
+      - the lot lives on an AR/AP account and is open (balance != 0),
+      - gncInvoiceGetInvoiceFromLot returned NULL — no invoice / bill
+        owns this lot, so the credit is unconsumed,
+      - parent tx owner backref points at customer C001.
+
+Total credit available: CAD 50.00 for customer C001 (Acme).
+```
+
+The `guid` field is the **source bank transaction** of the credit lot — i.e. the original payment that left the residual. For a customer overpayment, that's the same tx that paid the original invoice, so deleting it would also drop the invoice payment. For a standalone customer pre-payment (no invoice attached at the time the payment was recorded), the bank tx only carries this credit, so deleting it cleanly refunds.
+
+The same shape applies to vendor credits (`AP credit`, account is `Liabilities:Accounts Payable`, owner is the vendor). Per-owner totals at the end. Exit code is 0 whether or not any credits are found.
+
+What to do with each credit:
+
+  a) **Consume** against the next invoice/bill for that owner — add `auto_apply_credit: true` to that invoice/bill (above). Non-destructive; the only safe option for credits that came from invoice overpayment.
+  b) **Refund** — only safe for standalone-payment credits (the source bank tx has just the bank-side split and the AR/AP credit split, nothing else). In that case `delete-transactions --by-guid <source-bank-tx>` drops the tx and produces a plaintext backup. For overpayment-residual credits, a clean refund is a *new* bank transaction (bank -50 / AR +50) — record it in plaintext and re-import; this closes the prepay lot without touching the original payment.
+
+When the book and the plaintext have diverged (the user hand-edited the `.gnucash` file in the GnuCash UI, or hand-edited the `.txt` file before re-importing, or a third-party tool modified the book), the importer's recovery behaviour per scenario is documented in [`docs/payment-manual-edit-behavior.md`](docs/payment-manual-edit-behavior.md).
+
 ### Identity and round-trip: `guid:`, `customer_guid:`, `vendor_guid:`
 
 Every business-object block (`customer`, `vendor`, `taxtable`, `invoice`,

--- a/cli/find_prepayments_cmd.py
+++ b/cli/find_prepayments_cmd.py
@@ -1,0 +1,158 @@
+"""
+CLI command for listing open customer/vendor credit lots (pre-payments).
+
+A pre-payment is an open AR/AP lot that holds a balance NOT attached to
+any invoice or bill. Two ways one gets created:
+
+  * Customer overpayment: `payment: 150` on a $100 invoice produces a
+    closed invoice lot ($0) plus an open AR lot with balance −$50 — the
+    customer credit. Symmetric for vendor bills (AP, opposite signs).
+  * Standalone payment recorded without an invoice — e.g. a customer
+    pre-payment received before any invoice is issued.
+
+Either way the credit is invisible in plaintext until consumed. This
+command surfaces every credit lot in the book (or filtered to a single
+customer / vendor) so the user can decide whether to apply it against
+an upcoming invoice (via `auto_apply_credit: true` on that invoice) or
+refund it (drop the lot's source bank tx via
+`delete-transactions --by-guid`).
+"""
+
+import click
+
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from use_cases.unpost_business_objects import find_prepayments_in_book
+
+
+def _hyphenate(guid32: str) -> str:
+    g = guid32
+    return f'{g[0:8]}-{g[8:12]}-{g[12:16]}-{g[16:20]}-{g[20:32]}'
+
+
+@click.command('find-prepayments')
+@click.argument('gnucash_file', type=click.Path(exists=True))
+@click.option('--customer', 'customer_id', default=None,
+              help='Only list credits held for this customer id (e.g. C001).')
+@click.option('--vendor', 'vendor_id', default=None,
+              help='Only list credits held for this vendor id (e.g. V001).')
+def find_prepayments(gnucash_file, customer_id, vendor_id):
+    """
+    List open customer / vendor credit lots (pre-payments) — open AR/AP
+    lots that are NOT attached to any invoice or bill.
+
+    Each credit is reported with the owner (customer or vendor), credit
+    amount, currency, source bank transaction (the original payment that
+    produced the credit), and the AR/AP account holding it. A total per
+    owner is printed at the end. Exit code is 0 whether or not any
+    credits are found (the command is informational).
+
+    What to do with each credit:
+      a) Apply against the next invoice/bill — add `auto_apply_credit: true`
+         to that invoice/bill on import. GnuCash's `gncInvoiceAutoApplyPayments`
+         consumes the credit toward the new posted lot.
+      b) Refund — drop the source bank transaction via
+         `delete-transactions --by-guid <source-bank-tx>` (writes a
+         plaintext backup first).
+
+    \b
+    Examples:
+      gnucash-plaintext find-prepayments ledger.gnucash
+      gnucash-plaintext find-prepayments ledger.gnucash --customer C001
+      gnucash-plaintext find-prepayments ledger.gnucash --vendor V001
+    """
+    repo = GnuCashRepository(gnucash_file)
+    repo.open(mode=SessionMode.READ_ONLY)
+    try:
+        credits_ = find_prepayments_in_book(
+            repo.book, customer_id=customer_id, vendor_id=vendor_id)
+    finally:
+        repo.close()
+
+    if not credits_:
+        scope = ''
+        if customer_id:
+            scope = f' for customer {customer_id}'
+        elif vendor_id:
+            scope = f' for vendor {vendor_id}'
+        click.echo(f'No pre-payment credits found{scope}.')
+        return
+
+    n = len(credits_)
+    noun = 'credit' if n == 1 else 'credits'
+    click.echo(f'Found {n} open pre-payment {noun}.')
+    click.echo('')
+    for c in credits_:
+        if c.owner_type == 2:
+            owner_kind = 'customer'
+            ar_ap = 'AR'
+        elif c.owner_type == 4:
+            owner_kind = 'vendor'
+            ar_ap = 'AP'
+        else:
+            owner_kind = 'owner'
+            ar_ap = 'AR/AP'
+
+        click.echo(
+            f'  • {owner_kind} {c.owner_id} ({c.owner_name})  '
+            f'{c.currency} {c.amount}  in {c.ar_ap_account}'
+        )
+        click.echo(
+            f'    source bank tx: {c.date} on {c.bank_account}  "{c.description}"'
+        )
+        if c.memo:
+            click.echo(f'      memo: "{c.memo}"')
+        click.echo(f'      guid: {_hyphenate(c.tx_guid)}')
+        click.echo(
+            '      NOTE: this is the parent bank tx of the credit lot\'s split.'
+        )
+        click.echo(
+            '      Deleting it via `delete-transactions --by-guid` may also '
+            'remove other'
+        )
+        click.echo(
+            '      splits on the same tx (e.g. the original invoice payment if '
+            'this credit'
+        )
+        click.echo(
+            '      came from an overpayment). Consuming via `auto_apply_credit` '
+            'on the next'
+        )
+        click.echo(
+            '      invoice/bill is the non-destructive option.'
+        )
+        click.echo(f'    why classified as a pre-payment ({ar_ap} credit):')
+        click.echo(
+            '      - the lot lives on an AR/AP account and is open '
+            '(balance != 0),')
+        click.echo(
+            '      - gncInvoiceGetInvoiceFromLot returned NULL — no invoice / bill '
+        )
+        click.echo(
+            '        owns this lot, so the credit is unconsumed,')
+        click.echo(
+            f'      - parent tx owner backref points at {owner_kind} {c.owner_id}.'
+        )
+
+    # Per-owner totals.
+    by_owner: dict = {}
+    for c in credits_:
+        key = (c.owner_type, c.owner_id, c.owner_name, c.currency)
+        by_owner.setdefault(key, 0.0)
+        by_owner[key] += float(c.amount)
+    click.echo('')
+    if len(by_owner) == 1:
+        (otype, oid, oname, ccy), total = next(iter(by_owner.items()))
+        kind = 'customer' if otype == 2 else ('vendor' if otype == 4 else 'owner')
+        click.echo(f'Total credit available: {ccy} {total:.2f} for {kind} {oid} ({oname}).')
+    else:
+        click.echo('Totals per owner:')
+        for (otype, oid, oname, ccy), total in sorted(by_owner.items()):
+            kind = 'customer' if otype == 2 else ('vendor' if otype == 4 else 'owner')
+            click.echo(f'  {ccy} {total:.2f} for {kind} {oid} ({oname})')
+
+    click.echo('')
+    click.echo('To consume a credit toward an upcoming invoice/bill, post the')
+    click.echo('new invoice/bill with `auto_apply_credit: true` in its header —')
+    click.echo('GnuCash will then close the invoice/bill from the existing credit')
+    click.echo('via gncInvoiceAutoApplyPayments. Residual credit (if any) stays')
+    click.echo('open for the next invoice/bill.')

--- a/cli/import_cmd.py
+++ b/cli/import_cmd.py
@@ -12,6 +12,7 @@ from services.gnucash_importer import GnuCashImporter
 from services.plaintext_parser import DirectiveType, PlaintextParser
 from use_cases.export_transactions import ExportTransactionsUseCase
 from use_cases.import_transactions import ImportTransactionsUseCase
+from use_cases.unpost_business_objects import format_orphan_warning_block
 
 
 @click.command()
@@ -159,6 +160,10 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
                     parser.root_directive.children, repo.book,
                     on_directive_status=lambda kind, ident, status: click.echo(
                         f'{kind} "{ident}": {status}'
+                    ),
+                    on_orphan_warning=lambda kind, ident, orphans: click.echo(
+                        format_orphan_warning_block(kind, orphans, ident=ident),
+                        err=True,
                     ),
                 )
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -22,6 +22,7 @@ from cli.export_beancount_cmd import export_beancount
 from cli.export_cmd import export_transactions
 from cli.export_transaction_cmd import export_transaction
 from cli.find_orphan_payments_cmd import find_orphan_payments
+from cli.find_prepayments_cmd import find_prepayments
 from cli.find_transactions_cmd import find_transactions
 from cli.import_beancount_cmd import import_beancount
 from cli.import_cmd import import_transactions
@@ -75,6 +76,7 @@ cli.add_command(archive_vendors, name='archive-vendors')
 cli.add_command(unpost_invoices, name='unpost-invoices')
 cli.add_command(unpost_bills, name='unpost-bills')
 cli.add_command(find_orphan_payments, name='find-orphan-payments')
+cli.add_command(find_prepayments, name='find-prepayments')
 
 
 if __name__ == '__main__':

--- a/cli/unpost_cmd.py
+++ b/cli/unpost_cmd.py
@@ -47,6 +47,7 @@ from use_cases.unpost_business_objects import (
     UnpostInvoicesUseCase,
     UnpostResult,
     UnpostStatus,
+    format_orphan_warning_block,
 )
 
 
@@ -63,95 +64,12 @@ def _normalise_guids(guids):
 def _format_orphan_warning(result: UnpostResult) -> str:
     """Render the orphan-payment warning block for one unposted record.
 
-    Empty string if the record had no orphans (posted but never paid →
-    silent success). For invoices: "AR", "received". For bills: "AP",
-    "sent" — owner type is the only material difference per the Q-014
-    research's bill-symmetry round.
+    Thin adapter over `format_orphan_warning_block` so the same warning
+    text is emitted from both the unpost CLI commands and the importer
+    (Q-015), which calls the shared formatter when its own `Unpost(False)`
+    is about to orphan one or more bank txs.
     """
-    if not result.orphans:
-        return ''
-
-    n = len(result.orphans)
-    noun = 'transaction' if n == 1 else 'transactions'
-    is_invoice = (result.kind == 'invoice')
-    side = 'AR' if is_invoice else 'AP'
-    flow = 'received in' if is_invoice else 'sent from'
-    record_word = result.kind
-
-    lines = []
-    lines.append('')
-    lines.append(
-        f'⚠  {n} bank-side payment {noun} {"is" if n == 1 else "are"} '
-        f'now orphaned in the book.'
-    )
-    lines.append(
-        f'   GnuCash unpost destroys the {side} posting transaction but '
-        f'leaves payment'
-    )
-    lines.append(
-        f'   transactions intact — the money still shows as {flow} '
-        f'your bank account.'
-    )
-    lines.append('')
-
-    # GUID formatted with hyphens for human reading; the un-hyphenated form
-    # below is what `delete-transactions --by-guid` accepts.
-    def _hyphenate(guid32: str) -> str:
-        g = guid32
-        return f'{g[0:8]}-{g[8:12]}-{g[12:16]}-{g[16:20]}-{g[20:32]}'
-
-    for o in result.orphans:
-        memo_part = f' "{o.memo}"' if o.memo else ''
-        lines.append(
-            f'   • {o.date}  {o.bank_account}  {o.currency} {o.amount}  '
-            f'"{o.description}"'
-        )
-        if o.memo:
-            lines.append(f'     memo:{memo_part}')
-        lines.append(f'     guid: {_hyphenate(o.tx_guid)}')
-
-    if n > 1:
-        by_acct: dict = {}
-        for o in result.orphans:
-            by_acct.setdefault((o.bank_account, o.currency), 0.0)
-            by_acct[(o.bank_account, o.currency)] += float(o.amount)
-        if len(by_acct) == 1:
-            (acct, ccy), total = next(iter(by_acct.items()))
-            lines.append('')
-            lines.append(f'   Total orphaned: {ccy} {total:.2f} in {acct}.')
-        else:
-            lines.append('')
-            lines.append('   Total orphaned per bank account:')
-            for (acct, ccy), total in sorted(by_acct.items()):
-                lines.append(f'     {ccy} {total:.2f} in {acct}')
-
-    lines.append('')
-    lines.append(f'   If you intend to re-pay this {record_word}, either:')
-    lines.append('     a) delete the orphan(s) first:')
-    for o in result.orphans:
-        lines.append(
-            f'          gnucash-plaintext delete-transactions <book> '
-            f'--by-guid {o.tx_guid}'
-        )
-    lines.append(
-        f'        then re-import the {record_word} with a fresh '
-        f'`payment:` block, or'
-    )
-    lines.append(
-        f'     b) re-import the {record_word} with a `payment:` block '
-        f'that includes'
-    )
-    if n == 1:
-        lines.append(f'          txn_guid: "{result.orphans[0].tx_guid}"')
-    else:
-        lines.append('          txn_guid: "<orphan-guid>"  (one block per orphan)')
-    lines.append(
-        '        to retarget the existing bank transaction(s) into the '
-        'new posted lot'
-    )
-    lines.append('        (see docs/issues/Q-004 for the retarget mechanism).')
-
-    return '\n'.join(lines)
+    return format_orphan_warning_block(result.kind, result.orphans)
 
 
 def _run_unpost(gnucash_file, ids, use_case_cls, by_guid=False):

--- a/docs/issues/Q-015-incremental-payment-reimport-rebuilds-destructively.md
+++ b/docs/issues/Q-015-incremental-payment-reimport-rebuilds-destructively.md
@@ -1,0 +1,125 @@
+---
+id: Q-015
+title: Incremental + overpayment + credit-consumption payment workflows on re-import — no orphans, full prepayment-credit support, importer-side orphan warnings, find-prepayments CLI
+category: quality
+severity: high
+status: closed
+---
+
+## Problem
+
+Seven closely-related gaps on the import / export path that together broke the "customer pays in instalments / overpays / uses credit toward next invoice" workflow — every real-world payment shape beyond "one cash payment exactly matching invoice total". Three were silent data-corruption defects (rooted in `Unpost(False)` rebuilds and matcher iteration-order dependence); four were missing-feature gaps where overpayment credits and credit consumption couldn't be expressed in plaintext at all.
+
+### 1. Adding a `payment:` block re-imports destructively
+
+Adding a partial payment to a posted invoice/bill through the most natural workflow — edit the plaintext to append another `payment:` block, re-import — silently corrupted the bank balance and broke external references. `services/gnucash_importer.py` classified the directive via `_invoice_matches_directive`; any divergence (including "directive appends one payment to the existing list") fell through to:
+
+```python
+existing.Unpost(False)        # destroys posting tx, orphans bank-side splits
+# ... full rebuild + repost
+```
+
+On a $100 invoice paid $60, then re-imported with `payment: 60` + `payment: 40` added:
+
+| | Before re-import | After re-import |
+|---|---|---|
+| Bank txs in `Assets:Bank` | 1 ($60) | **3** ($60 orphan + new $60 + new $40) |
+| Posting tx GUID | `d711836b…` | `81aaed4e…` (changed) |
+| Entry GUIDs | `d17255a0…` | `f7728687…` (changed) |
+| Lot payments | original $60 tx | two new $60 + $40 (original orphaned) |
+
+Bank reconciliation surfaces a $60 deposit it can't match; invoice display reads "$40 outstanding" on a paid invoice.
+
+### 2. Every importer-side `Unpost(False)` was silent about the orphan it created
+
+Q-014 shipped a per-record orphan-payment warning from the `unpost-invoices` / `unpost-bills` CLI commands. The same `Unpost(False)` call was made by the importer from **four** other places — Q-010 minimal-unpost (invoice and bill `posted: none` path) and the destructive rebuild (invoice and bill, fired by entry / posted / payment field changes). None warned. A user re-importing a paid invoice with a typo in the entry description silently orphaned the bank tx with no indication.
+
+### 3. Overpayment (pre-payment credit) had no plaintext representation, and the matcher silently duplicated bill overpayments on roundtrip
+
+GnuCash's `ApplyPayment(amount=150)` on a $100 invoice correctly creates two AR lots (invoice closed at $0, pre-payment lot open at -$50). The exporter only emitted `payment: 150`; the $50 credit on AR was invisible. Round-trip preserved it by luck on invoices (the matcher's "find non-AR-split-by-exclusion" heuristic happened to pick the bank split first); on bills the iteration order put the +$50 AP split first, mis-identified it as bank, returned False, fired the destructive rebuild, and **silently duplicated the bank tx**. Retarget (`payment: txn_guid:`) with an over-sized counter-split silently left the invoice lot at balance -$50, semantically malformed.
+
+### 4. The `txn_guid:` retarget path silently malformed lots on overpayment
+
+`_retarget_counter_split_to_lot` moved the entire counter-split into the invoice's lot, regardless of size. For a $150 bank tx retargeted to a $100 invoice, the invoice's lot ended at balance -$50 (overpaid; GnuCash had no auto-split). No error, no warning — just a broken lot the user couldn't see.
+
+### 5. Customer / vendor credits couldn't be consumed via plaintext
+
+A customer with an existing $50 credit on AR (from a prior overpayment) had no way to express "apply the credit toward the next invoice" in plaintext. Manual `ApplyPayment` calls don't auto-consume credit. The user had to fall back to GnuCash UI's Process Payment → "Apply credit" — defeating the plaintext-as-source-of-truth model.
+
+### 6. No way to see open credits without exporting the whole book
+
+A user asking "what credits do I have on file for Acme?" had to export the entire book to plaintext and grep through it, or open the GnuCash UI. No focused CLI for the question.
+
+### 7. Bank-side split lookup was iteration-order-dependent
+
+`_single_payment_matches` walked `tx.GetSplitList()` and picked "the first split that isn't the in-lot AR/AP split" as the bank side. For overpayment txs (bank + invoice-lot AR + prepayment-lot AR = 3 splits) this picked whichever split came first in iteration order — luck on invoices, wrong on bills. The "Defect 3" duplication was just one symptom; any tx with 3+ splits was at risk.
+
+## Reproduction
+
+All seven defects are covered by **58 dedicated integration tests** across seven files (see "Tests" below). Each test is self-contained, uses a per-scenario fixture under `tests/fixtures/q015_*.txt`, and asserts on the user-visible outcome (lot balances, bank tx count, GUID preservation, output text) rather than on internal split identity.
+
+## Fix
+
+### Defect #1 — add-payment fast path
+
+New classifier `_is_only_added_payment_diff_invoice` / `_is_only_added_payment_diff_bill` that returns True iff:
+
+- entries match byte-for-byte (`_invoice_non_payment_matches` / `_bill_non_payment_matches`),
+- the `posted:` block matches,
+- the directive's payments are a *prefix-preserving superset* of the record's lot payments (every existing payment matches the corresponding directive 1:1; the directive has K > N tail entries).
+
+When True, the caller walks the trailing K-N payment directives and calls `_apply_payment_directive(record, pay_dir, book, is_bill)` on the still-posted record — no Unpost, no rebuild. Posting tx, entry, and existing payment GUIDs are preserved; no orphan; no double bank balance. The bill side mirrors the invoice via `_is_only_added_payment_diff_bill`. The negated-amount `ApplyPayment(-N)` mechanic for AP is factored into `_apply_payment_directive`, which also handles the `txn_guid:` retarget branch.
+
+### Defect #2 — importer-side orphan warning
+
+New helper `_emit_orphan_warning_before_unpost(record, kind, ident, on_orphan_warning)`: called immediately before every `existing.Unpost(False)` in `import_invoice` / `import_bill` (4 callsites). Captures the about-to-be-orphaned payments via the existing Q-014 `find_lot_payment_transactions(rec)` helper and invokes a callback. New plumbing in `import_business_objects` carries an `on_orphan_warning(kind, id, orphans)` callback alongside the existing `on_directive_status`. `cli/import_cmd.py` passes a callback that renders the warning block to stderr.
+
+`format_orphan_warning_block(kind, orphans, ident='')` is factored out of `cli/unpost_cmd.py` into `use_cases/unpost_business_objects.py` so the unpost CLI and the import CLI emit identical warning text.
+
+### Defects #3 + #4 — `prepayment:` field
+
+New optional `prepayment: N` field inside `payment:` blocks. Exporter (`_format_payment`) emits it when a payment tx has AR/AP-side splits outside the invoice/bill's posted lot. Matcher (`_single_payment_matches`) compares the declared value to the actual residual computed from the book.
+
+The importer treats `prepayment:` differently depending on path:
+
+- **`ApplyPayment` path** (no `txn_guid`): GnuCash auto-creates the pre-payment lot when `amount > invoice_remaining`. `prepayment:` is informational and validated by the matcher on re-import.
+- **Retarget path** (`txn_guid:`): if `counter_split_amount > invoice_remaining`, `prepayment:` is **required**. The new `_retarget_with_prepayment_split` helper reduces the existing counter-split to `invoice_remaining` (re-accounts to AR/AP, attaches to the invoice lot) and creates a new split for the residual on the same tx, in a fresh lot on the same AR/AP account. Missing `prepayment:` → explicit error naming the bank tx, the counter-split amount, the invoice remaining, and the expected `prepayment` value.
+
+`test_overpayment_path_equivalence.py` (4 tests) asserts the two paths produce **semantically identical end-state** across initial import + double roundtrip — same bank tx amounts, AR lot count, lot balances, lot members. The internal split-identity differs (which physical split keeps which GUID after split-the-counter-split) but nothing in the user-visible surface or the round-trip distinguishes them.
+
+### Defect #5 — `auto_apply_credit:` flag
+
+New optional `auto_apply_credit: true` field on `invoice` / `bill` directives. When set, after `PostToAccount` runs, the importer calls `inv.AutoApplyPayments()` — GnuCash's canonical mechanism for consuming customer / vendor pre-payment lots. Composes cleanly with cash `payment:` blocks: cash applies first; auto-apply consumes credit toward whatever balance remains. The exporter detects the post-auto-apply state (any payment-tx split in this invoice's lot whose parent tx has other splits in another invoice/bill's lot for the same owner) and emits the flag for round-trip stability.
+
+### Defect #6 — `find-prepayments` CLI
+
+New read-only command parallel to Q-014's `find-orphan-payments`. Walks the book for open AR/AP lots that are not attached to any invoice/bill and have non-zero balance; reports per-credit owner, amount, currency, source bank tx, and AR/AP account. Supports `--customer` / `--vendor` filters. Implementation in `use_cases/unpost_business_objects.py` (`find_prepayments_in_book`) reuses Q-014's lot-walking plumbing with the inverse filter.
+
+### Defect #7 — matcher bank-side lookup by account match
+
+`_single_payment_matches` now finds the bank-side split by `bank_account` name match (the directive's declared field is authoritative), not by exclusion of the in-lot AR/AP split. Deterministic, version-stable, robust to any tx-split count.
+
+## Tests
+
+58 integration tests across seven files, all passing on every supported distro (debian11/12/13, ubuntu20/22/24/26, fedora41, opensuse, arch):
+
+- `tests/integration/test_incremental_payment_reimport.py` (6) — add-payment fast path preserves posting/entry GUIDs and the original bank tx; identical re-import is still `unchanged`; modify/remove an existing payment correctly falls through to the rebuild path.
+- `tests/integration/test_payment_roundtrip_no_orphan.py` (11) — single/double roundtrip on paid and partial-paid invoices and bills creates zero orphans; pre-existing orphans survive roundtrip and double-roundtrip without duplication.
+- `tests/integration/test_importer_destructive_orphan.py` (12) — every importer-side `Unpost(False)` path emits an orphan warning that mentions the orphan's tx GUID and the word "orphan"; idempotent re-runs don't accumulate orphans; negative controls confirm the `unchanged` and add-payment fast paths emit no warning.
+- `tests/integration/test_overpayment_handling.py` (11) — invoice and bill overpayment via `ApplyPayment` roundtrips with the new `prepayment:` field; double-roundtrip stable; retarget with explicit `prepayment:` succeeds and creates the right two-lot structure; retarget without `prepayment:` on an oversized counter-split fails with a clear error; exact and underpaying retargets remain unchanged.
+- `tests/integration/test_overpayment_path_equivalence.py` (4) — ApplyPayment-overpayment and retarget-with-prepayment produce semantically identical book state across initial import + double roundtrip on four scenarios (basic overpayment, exact, partial, two overpayments).
+- `tests/integration/test_auto_apply_credit.py` (7) — `auto_apply_credit: true` consumes existing customer/vendor credit; composes with cash `payment:`; over-consume case partially pays the invoice; roundtrip emits the flag and re-import is idempotent; bill counterparts.
+- `tests/integration/test_find_prepayments.py` (7) — empty book reports zero; single customer/vendor credit; multi-credit per owner; `--customer` / `--vendor` filters; after partial consume shows residual.
+
+All 84 fixture files live in `tests/fixtures/q015_*.txt` with distinct invoice/bill IDs and amounts per scenario so a reader can tell at a glance which fixture each test uses.
+
+## Documentation
+
+- `README.md` — new sections on incremental add-payment workflow, overpayment + `prepayment:` field, `auto_apply_credit:` flag, `find-prepayments` CLI with sample output.
+- `docs/payment-manual-edit-behavior.md` — new doc characterising importer behaviour under five book/plaintext-divergence scenarios (manual UI edits to splits and txs, plaintext-side edits) with the per-scenario outcome table.
+
+## Related
+
+- **Q-007** — entry-GUID preservation contract.
+- **Q-010** — strict 'unchanged' status; mutable posted invoices/bills + `unpost` CLI. Introduced the destructive rebuild path this issue narrows.
+- **Q-014** — orphan-payment warning on `unpost-invoices` / `unpost-bills`. Q-015 extends the same warning to every importer-side unpost callsite, factors the formatter into a shared function, and adds the `find-prepayments` companion to `find-orphan-payments`.

--- a/docs/payment-manual-edit-behavior.md
+++ b/docs/payment-manual-edit-behavior.md
@@ -1,0 +1,46 @@
+# Payment / lot behavior when the book and plaintext have diverged
+
+This project models plaintext as the source of truth, with `import` and `export` as the only sanctioned ways to move data between the two. In practice the two can drift apart for several reasons:
+
+- the user opens the `.gnucash` file in the GnuCash UI and hand-edits a payment transaction or split,
+- another tool (a QFX importer, a third-party reporting utility, a script using `gnucash_core_c` directly) modifies the `.gnucash` file behind our back,
+- the user opens the `.txt` plaintext file in a text editor and deletes / changes a `payment:` or `entry:` block before re-importing.
+
+None of these are "supported" workflows in the sense that round-trip is guaranteed, but they all happen. This document records what `gnucash-plaintext import` does in each divergence scenario so the user knows what to expect.
+
+## Plaintext-side edits
+
+Direct edits to the `.txt` file before re-import are well-tested by the Q-015 integration suites — re-importing always reconciles the book to whatever the plaintext now says, either via the Q-015 add-payment fast path (entries / payments / posted block all match, only new `payment:` blocks appended) or via the destructive rebuild path with an orphan-payment warning emitted to stderr for every bank-side payment about to be detached. See `tests/integration/test_incremental_payment_reimport.py` and `tests/integration/test_importer_destructive_orphan.py` for the full matrix.
+
+## Book-side edits (GnuCash UI or external tools)
+
+All book-side scenarios below assume the canonical setup:
+
+- **INV-001** for $100, **paid $150** → bank tx `T1` for $150; AR has two lots — the invoice lot (closed, balance $0) and a pre-payment lot (open, balance −$50).
+- **INV-002** for $100, **paid $60** → bank tx `T2` for $60; AR lot still open at +$40.
+- Original plaintext expresses both invoices including their payments and the `prepayment: 50` on INV-001.
+
+| # | Manual edit in GnuCash UI | What the book looks like after the edit | What re-import does | Outcome |
+|---|---|---|---|---|
+| 1 | Delete the **bank-side split** of T2 (the $60 partial payment) | T2 becomes unbalanced; GnuCash auto-adds an `Imbalance-CAD` split as the replacement bank side | Importer's matcher compares the directive's `bank_account: "Assets:Bank"` to T2's actual non-AR split, finds `Imbalance-CAD`, returns False. The Q-015 orphan warning fires naming the Imbalance-CAD split, the destructive rebuild runs, ApplyPayment re-creates a clean $60 bank tx. | Recovered. User sees the warning and the resulting orphan-cleanup advice; the original Imbalance-CAD entry remains in the book until the user explicitly deletes it. |
+| 2 | Delete the **prepay AR split** (the −$50 on T1) | T1 becomes unbalanced (bank +$150 vs. AR −$100); the pre-payment lot empties; GnuCash may add an Imbalance-CAD split to T1. | Matcher computes actual prepayment = $0, directive declares `prepayment: 50` — mismatch. Orphan warning fires for T1 ($150), destructive rebuild runs, ApplyPayment re-creates the overpayment correctly with both lots. | Recovered. The warning correctly names T1 as the orphan. |
+| 3 | Destroy T2 entirely (delete both the bank and the AR splits) | T2 gone. INV-002 lot reverts to just the +$100 posting, balance +$100 (back to unpaid). | Q-015 **add-payment fast path** fires (existing lot has zero payments, directive has one) → applies the $60 via `ApplyPayment` on the still-posted invoice. No Unpost, no destructive rebuild. | Clean recovery. No orphan, no warning, posting/entry GUIDs preserved, single new bank tx for $60. |
+| 4 | Destroy INV-001's posting transaction directly | No-op — GnuCash silently blocks direct `Destroy()` on a transaction belonging to a posted invoice. The user *can* unpost from the UI; that produces the same state as our `unpost-invoices` CLI and a subsequent re-import follows scenario 2/3 as appropriate. | Re-import sees nothing changed. | N/A — the UI's "Unpost" is the only practical path; re-importing afterwards goes through the Q-014 orphan warning if the invoice had payments. |
+| 5 | Delete only the **AR-side split** of T2, keep the bank-side intact | INV-002 lot reverts to balance +$100 (only the posting remains in the lot); T2 still has the +$60 bank split paired with whatever auto-replacement GnuCash created on the other side. | Q-015 fast path sees lot has zero payments, directive has one → applies a new $60 payment via `ApplyPayment`. A *new* $60 bank tx is created on top of the existing T2 (which is now functionally orphaned). | **Recovers the invoice state but leaves a duplicate $60 bank tx.** This is fringe — the user explicitly mutated split structure outside the importer. The duplicate is discoverable via `find-orphan-payments` (the original T2's AR-side fragment may now be classified as an orphan depending on what auto-replacement GnuCash inserted) or by scanning the bank for unexplained txs. |
+
+## What the importer guarantees vs. doesn't
+
+**Guaranteed:**
+
+- Any time the matcher detects an inconsistency between the directive and the book (account / amount / memo / prepayment / count), the destructive rebuild path fires *with* the Q-014-style orphan warning that names every bank-side payment about to be left dangling. The user always sees what's about to be silently lost.
+- Scenarios where the user deleted whole payment transactions outside the importer are recovered cleanly by the Q-015 add-payment fast path — the missing payments are re-applied without rebuilding the invoice/bill.
+
+**Not guaranteed:**
+
+- Single-split surgery (deleting only one side of a balanced transaction, leaving the other half stranded) can leave the book with duplicates after re-import. The importer reasons about lot membership and matches against the in-lot splits; it does not actively scan for "orphaned half-transactions" that lack a counterpart on the lot side.
+- The exact account name in the warning depends on what GnuCash chose for its auto-balancing split. On Linux this is typically `Imbalance-CAD` (or whatever the book currency is); the warning surfaces that name verbatim so the user can locate it in the GnuCash UI.
+
+## Recommendation for users
+
+If you must edit a payment in the GnuCash UI, prefer deleting and re-creating the entire payment transaction (scenario 3) over per-split surgery (scenarios 1, 2, 5). The plaintext re-import will then cleanly re-apply the missing payment without leaving behind half-deleted artifacts.
+

--- a/infrastructure/gnucash/kvp.py
+++ b/infrastructure/gnucash/kvp.py
@@ -78,12 +78,14 @@ KNOWN_VENDOR_METADATA_KEYS = frozenset({
 KNOWN_INVOICE_METADATA_KEYS = frozenset({
     'guid', 'customer_id', 'customer_guid', 'currency', 'date_opened',
     'billing_id', 'notes', 'posted', 'payment',
+    'auto_apply_credit',  # Q-015: triggers gncInvoiceAutoApplyPayments after posting
 })
 
 # Bill metadata keys that have dedicated GnuCash setters.
 KNOWN_BILL_METADATA_KEYS = frozenset({
     'guid', 'vendor_id', 'vendor_guid', 'currency', 'date_opened',
     'posted', 'payment',
+    'auto_apply_credit',  # Q-015: triggers gncInvoiceAutoApplyPayments after posting
 })
 
 # Account metadata keys that have dedicated GnuCash setters.

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -629,6 +629,107 @@ def _retarget_counter_split_to_lot(lib, existing_tx, bank_acct_name: str,
     return False
 
 
+def _retarget_with_prepayment_split(lib, book, existing_tx, bank_acct_name: str,
+                                    post_account, invoice_lot,
+                                    invoice_portion: float,
+                                    prepayment_portion: float) -> bool:
+    """Q-015 overpayment-retarget mechanic.
+
+    The bank-side tx already exists (e.g. imported from QFX) and its
+    counter-split (the non-bank side) is for more money than the invoice
+    /bill's remaining balance. We split the counter-split into two:
+
+      * the invoice-portion split: re-account to AR/AP, attach to the
+        record's posted lot — closes the lot,
+      * the prepayment-portion split (new): account = same AR/AP, attach
+        to a freshly created lot on the same account — that lot stays
+        open as a customer/vendor credit.
+
+    Returns True iff the split was successful; False if no counter-split
+    was found on `existing_tx`.
+
+    Sign handling: the new prepayment split must match the counter-split's
+    sign (same direction on AR/AP). For an invoice overpayment the
+    counter-split is negative (e.g. -150 on AR); we split into -100 +
+    -50. For a bill the counter-split is positive (+150 on AP) → +100 +
+    +50.
+    """
+    from gnucash import GncNumeric, Split
+
+    from infrastructure.gnucash.engine import safe_ctypes_string
+
+    lib.xaccSplitGetAccount.argtypes = [ctypes.c_void_p]
+    lib.xaccSplitGetAccount.restype  = ctypes.c_void_p
+    lib.xaccSplitSetAccount.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    lib.xaccSplitSetAccount.restype  = None
+    lib.gnc_account_get_parent.argtypes = [ctypes.c_void_p]
+    lib.gnc_account_get_parent.restype  = ctypes.c_void_p
+    lib.gnc_lot_new.argtypes = [ctypes.c_void_p]
+    lib.gnc_lot_new.restype  = ctypes.c_void_p
+    lib.xaccAccountInsertLot.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    lib.xaccAccountInsertLot.restype  = None
+    lib.gnc_lot_add_split.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    lib.gnc_lot_add_split.restype  = None
+
+    def _acct_name(acct_ptr):
+        parts = []
+        ptr = acct_ptr
+        while ptr:
+            name = safe_ctypes_string(lib.xaccAccountGetName, ptr)
+            if name:
+                parts.append(name)
+            parent = lib.gnc_account_get_parent(ptr)
+            if not parent:
+                break
+            if not lib.gnc_account_get_parent(parent):
+                break
+            ptr = parent
+        parts.reverse()
+        return ':'.join(parts)
+
+    import gnucash.gnucash_core_c as _gc
+
+    existing_tx.BeginEdit()
+    counter_split = None
+    for raw_sp in existing_tx.GetSplitList():
+        sp_ptr = int(raw_sp.instance)
+        acct_ptr = lib.xaccSplitGetAccount(sp_ptr)
+        if not acct_ptr:
+            continue
+        if _acct_name(acct_ptr) != bank_acct_name:
+            counter_split = raw_sp
+            break
+    if counter_split is None:
+        existing_tx.CommitEdit()
+        return False
+
+    # Reduce the existing counter-split to the invoice-portion (preserving
+    # its sign), retarget it to AR/AP, link it to the invoice lot.
+    sign = 1 if counter_split.GetAmount().to_double() >= 0 else -1
+    invoice_signed = GncNumeric(sign * int(round(invoice_portion * 100)), 100)
+    prepay_signed  = GncNumeric(sign * int(round(prepayment_portion * 100)), 100)
+
+    counter_split.SetAmount(invoice_signed)
+    counter_split.SetValue(invoice_signed)
+    lib.xaccSplitSetAccount(int(counter_split.instance), int(post_account.instance))
+    _gc.xaccSplitSetLot(counter_split.instance, invoice_lot.instance)
+
+    # Create the prepayment split on the same tx, on the same AR/AP account,
+    # in a brand-new lot on that account.
+    new_split = Split(book)
+    new_split.SetParent(existing_tx)
+    new_split.SetAccount(post_account)
+    new_split.SetAmount(prepay_signed)
+    new_split.SetValue(prepay_signed)
+
+    new_lot_ptr = lib.gnc_lot_new(int(book.instance))
+    lib.xaccAccountInsertLot(int(post_account.instance), new_lot_ptr)
+    lib.gnc_lot_add_split(new_lot_ptr, int(new_split.instance))
+
+    existing_tx.CommitEdit()
+    return True
+
+
 def _is_falsy(val: str) -> bool:
     """Return True if val is a recognised falsy string (case-insensitive)."""
     return val.strip().lower() in _FALSY_STRINGS
@@ -794,34 +895,27 @@ def _posted_matches_directive(invoice, posted_dir: 'PlaintextDirective',
     return posting_txn.GetDescription() == md['memo']
 
 
-def _payments_match_directive(invoice, payment_dirs) -> bool:
-    """Compare an invoice's existing payments against PAYMENT directives.
+def _lot_payment_splits(record):
+    """Return the AR/AP-side splits in the record's posted lot, in
+    GnuCash's iteration order, excluding the posting tx's own split AND
+    any split whose parent tx is a credit-consumption tx (Q-015
+    `auto_apply_credit`).
 
-    The exporter derives payment lines from the invoice's posted lot:
-    every transaction in the lot whose split is NOT the posting tx is a
-    payment. The bank-side split holds the date/amount/memo as the user
-    typed them (memo lives on the split, NOT on the transaction
-    description — see `_format_payment` in export_business_objects).
-
-    Two payment-directive flavours:
-      - **Normal payment**: directive supplies bank_account, date, amount,
-        memo (optionally num). Compare all of them.
-      - **Retarget (txn_guid)**: directive supplies bank_account and
-        txn_guid only — date/amount/memo come from the pre-existing bank
-        transaction and are not authoritative in the directive. Compare
-        only what the directive declares.
-
-    Note: `lot.get_split_list()` returns raw SwigPyObject pointers, so we
-    wrap them in `Split(instance=...)` and read the parent transaction
-    via `GetParent()`. This mirrors the pattern in `invoice_renderer`.
+    Used by both `_payments_match_directive` (strict count + field equality)
+    and `_payments_only_added_diff` (prefix-equal-superset check). In both
+    cases, auto-applied credit-consumption splits don't represent
+    user-declared `payment:` blocks — they're tracked via the
+    `auto_apply_credit: true` flag on the invoice/bill header.
     """
+    import gnucash.gnucash_core_c as _gc
     from gnucash import Split
-    lot = invoice.GetPostedLot()
+    lot = record.GetPostedLot()
     if lot is None:
-        return len(payment_dirs) == 0
-    posting_txn = invoice.GetPostedTxn()
+        return []
+    posting_txn = record.GetPostedTxn()
     posting_txn_guid = posting_txn.GetGUID().to_string() if posting_txn else None
-    pay_splits = []
+    this_lot_id = int(lot.instance)
+    out = []
     for raw in lot.get_split_list():
         s = Split(instance=raw)
         tx = s.GetParent()
@@ -829,48 +923,318 @@ def _payments_match_directive(invoice, payment_dirs) -> bool:
             continue
         if posting_txn_guid is not None and tx.GetGUID().to_string() == posting_txn_guid:
             continue
-        pay_splits.append(s)
+        # Skip splits that came from gncInvoiceAutoApplyPayments: their
+        # parent tx has AR/AP-side splits in another invoice/bill lot
+        # (the original invoice's lot, where the credit was created).
+        is_credit_consumption = False
+        for i in range(tx.CountSplits()):
+            other = tx.GetSplit(i)
+            other_acct = other.GetAccount()
+            if other_acct is None:
+                continue
+            other_type = other_acct.GetType()
+            if other_type not in (ACCT_TYPE_RECEIVABLE, ACCT_TYPE_PAYABLE):
+                continue
+            other_lot = other.GetLot()
+            if other_lot is None:
+                continue
+            if int(other_lot) == this_lot_id:
+                continue
+            if _gc.gncInvoiceGetInvoiceFromLot(other_lot):
+                is_credit_consumption = True
+                break
+        if is_credit_consumption:
+            continue
+        out.append(s)
+    return out
+
+
+def _prepayment_amount_for(in_lot_split):
+    """Sum of absolute amounts of AR/AP-side splits on `in_lot_split`'s
+    parent transaction OTHER than `in_lot_split` itself.
+
+    Returns 0 (as a `Decimal`-castable float) when the payment tx has
+    exactly one AR/AP split — the normal full-or-partial-payment case.
+    Returns the residual amount (as `float`) when GnuCash split the
+    payment across multiple AR/AP lots (overpayment → in-invoice lot +
+    one or more prepayment lots).
+    """
+    tx = in_lot_split.GetParent()
+    in_lot_guid = in_lot_split.GetGUID().to_string()
+    total = 0.0
+    for s in tx.GetSplitList():
+        if s.GetGUID().to_string() == in_lot_guid:
+            continue
+        acct = s.GetAccount()
+        if acct is None:
+            continue
+        if acct.GetType() in (ACCT_TYPE_RECEIVABLE, ACCT_TYPE_PAYABLE):
+            total += abs(s.GetAmount().to_double())
+    return total
+
+
+def _single_payment_matches(split, pd) -> bool:
+    """Compare one AR/AP-side payment split against one PAYMENT directive.
+
+    Returns True iff the directive's fields match the underlying bank-side
+    transaction. Two directive flavours:
+      - **Normal**: bank_account, date, amount, memo, num all compared.
+      - **Retarget (txn_guid)**: only bank_account and the tx GUID itself
+        — date/amount/memo on the directive aren't authoritative.
+
+    Memo lives on the bank-side split (see `_format_payment` in the
+    exporter), not on the transaction description.
+
+    Identifying the bank-side split: an overpayment tx has THREE splits —
+    bank + AR/AP-in-lot + AR/AP-in-prepayment-lot. We must find the
+    bank-side split by account match (the directive declares
+    `bank_account` authoritatively), not by exclusion against the
+    AR/AP-side split we were passed — the latter would pick the
+    other AR/AP split when iteration order put it first.
+    """
+    md = pd.metadata
+    tx = split.GetParent()
+    bank_acct_name = md['bank_account']
+    bank_split = next(
+        (s for s in tx.GetSplitList()
+         if (a := s.GetAccount()) is not None
+         and get_account_full_name(a) == bank_acct_name),
+        None,
+    )
+    if bank_split is None:
+        return False
+    directive_txn_guid = (md.get('txn_guid') or '').strip()
+    if directive_txn_guid:
+        return tx.GetGUID().to_string() == directive_txn_guid
+    if tx.GetDate().strftime("%Y-%m-%d") != md['date']:
+        return False
+    if not _gnc_numeric_equals(bank_split.GetAmount().abs(), md['amount']):
+        return False
+    if (bank_split.GetMemo() or '') != md.get('memo', ''):
+        return False
+    if (tx.GetNum() or '') != md.get('num', ''):
+        return False
+    # Q-015: compare prepayment portion (sum of AR/AP-side splits OTHER
+    # than the in-lot one) against the directive's `prepayment:` field.
+    # Missing on the directive ⇔ 0 in the book.
+    actual_prepay = _prepayment_amount_for(split)
+    raw_prepay = md.get('prepayment')
+    if raw_prepay is None or str(raw_prepay).strip() == '':
+        expected_prepay = 0.0
+    else:
+        try:
+            expected_prepay = float(str(raw_prepay).strip())
+        except ValueError:
+            return False
+    return not abs(actual_prepay - expected_prepay) > 1e-06
+
+
+def _payments_match_directive(record, payment_dirs) -> bool:
+    """True iff the record's posted-lot payments match the directives
+    one-for-one (same count, same field values). Used by the strict
+    `_invoice_matches_directive` / `_bill_matches_directive`.
+    """
+    pay_splits = _lot_payment_splits(record)
     if len(pay_splits) != len(payment_dirs):
         return False
-    for split, pd in zip(pay_splits, payment_dirs):
-        md = pd.metadata
-        tx = split.GetParent()
-        ar_ap_split_guid = split.GetGUID().to_string()
-        bank_split = next(
-            (s for s in tx.GetSplitList()
-             if s.GetGUID().to_string() != ar_ap_split_guid),
-            None,
-        )
-        if bank_split is None:
-            return False
-        bank_acct = bank_split.GetAccount()
-        if bank_acct is None or get_account_full_name(bank_acct) != md['bank_account']:
-            return False
-
-        directive_txn_guid = (md.get('txn_guid') or '').strip()
-        if directive_txn_guid:
-            if tx.GetGUID().to_string() != directive_txn_guid:
-                return False
-            continue
-        if tx.GetDate().strftime("%Y-%m-%d") != md['date']:
-            return False
-        if not _gnc_numeric_equals(bank_split.GetAmount().abs(), md['amount']):
-            return False
-        if (bank_split.GetMemo() or '') != md.get('memo', ''):
-            return False
-        if (tx.GetNum() or '') != md.get('num', ''):
-            return False
-    return True
+    return all(_single_payment_matches(s, pd) for s, pd in zip(pay_splits, payment_dirs))
 
 
-def _invoice_matches_directive(invoice, directive: 'PlaintextDirective', book) -> bool:
-    """Return True iff an existing customer invoice equals the directive (Q-010).
+def _emit_orphan_warning_before_unpost(record, kind: str, ident: str,
+                                       on_orphan_warning):
+    """Q-015: every importer-side `Unpost(False)` on a paid record must
+    surface the resulting orphan(s) to the user. Call this *before*
+    `record.Unpost(False)` — once unposted, the lot's invoice association
+    is destroyed and the orphans can no longer be enumerated from `record`.
 
-    Compared fields: date_opened, billing_id, notes, custom KVP, entries
-    (positional, by field), the posted block (or absence thereof), and
-    payments (count + per-payment fields). Mismatch on ANY field returns
-    False so the importer falls through to the rebuild + repost path.
+    `on_orphan_warning(kind, ident, orphans)` is invoked only when the
+    record has at least one payment-class transaction attached to its
+    posted lot. If the callback is None (library callers that don't want
+    the warning surfaced) the helper is a no-op aside from the
+    `find_lot_payment_transactions` call, which is safe.
     """
+    if on_orphan_warning is None:
+        return
+    if record.GetPostedTxn() is None:
+        return
+    from use_cases.unpost_business_objects import find_lot_payment_transactions
+    orphans = find_lot_payment_transactions(record)
+    if orphans:
+        on_orphan_warning(kind, ident, orphans)
+
+
+def _apply_payment_directive(record, pay_dir, book, is_bill):
+    """Apply one PAYMENT directive to an already-posted invoice or bill.
+
+    Used by both the normal rebuild path (after entries/posted have been
+    re-applied) and the Q-015 add-payment fast path (the record is still
+    posted and is mutated in-place).
+
+    For invoices, `ApplyPayment(+amount)` closes the AR lot. For bills,
+    AP has the opposite sign convention so we pass `-amount`; see Q-014
+    notes in `CLAUDE.md` for the accounting reasoning.
+    """
+    bank_acct_name = pay_dir.metadata['bank_account']
+    bank_account = find_account(book.get_root_account(), bank_acct_name)
+    if bank_account is None:
+        kind = 'bill' if is_bill else 'invoice'
+        raise Exception(f'Bank account {bank_acct_name!r} not found when applying {kind} payment')
+
+    txn_guid = pay_dir.metadata.get('txn_guid', '').strip()
+    if txn_guid:
+        # Retarget: existing bank tx is retargeted into the AR/AP lot
+        # without `ApplyPayment` (no new tx, preserves original tx GUID
+        # and KVP). Counter-split retargeting closes the lot when the
+        # AR/AP-side split sum hits zero.
+        existing_tx = _find_transaction_by_guid(book, txn_guid)
+        if existing_tx is None:
+            raise Exception(f'txn_guid {txn_guid!r} not found in book')
+        post_acct = record.GetPostedAcc()
+        lot = record.GetPostedLot()
+        if lot is None:
+            kind = 'Bill' if is_bill else 'Invoice'
+            raise Exception(f'{kind} has no posted lot — must be posted before payment')
+        from infrastructure.gnucash.engine import load_gnc_engine
+        lib = load_gnc_engine()
+
+        # Q-015: detect overpayment via retarget. The counter-split's
+        # absolute amount = bank-side amount. If it exceeds the lot's
+        # remaining balance the user is asking us to overpay; that
+        # requires the `prepayment:` field on the directive (we will not
+        # silently leave the lot in an overpaid state).
+        counter_amount_abs = None
+        for raw_sp in existing_tx.GetSplitList():
+            acct = raw_sp.GetAccount()
+            if acct is None:
+                continue
+            if get_account_full_name(acct) != bank_acct_name:
+                counter_amount_abs = abs(raw_sp.GetAmount().to_double())
+                break
+        invoice_remaining_abs = abs(lot.get_balance().to_double())
+
+        if counter_amount_abs is not None and \
+                counter_amount_abs > invoice_remaining_abs + 1e-6:
+            expected_prepay = counter_amount_abs - invoice_remaining_abs
+            raw_declared = pay_dir.metadata.get('prepayment')
+            declared_str = '' if raw_declared is None else str(raw_declared).strip()
+            kind = 'bill' if is_bill else 'invoice'
+            if not declared_str:
+                raise Exception(
+                    f'tx {txn_guid!r} amount {counter_amount_abs:.2f} '
+                    f'exceeds {kind} remaining {invoice_remaining_abs:.2f}; '
+                    f'add `prepayment: {expected_prepay:.2f}` to the payment '
+                    f'block to accept the residual as a pre-payment credit, '
+                    f'or retarget a bank tx whose counter-split matches the '
+                    f'{kind}\'s outstanding amount exactly.'
+                )
+            try:
+                declared = float(declared_str)
+            except ValueError as exc:
+                raise Exception(
+                    f'prepayment field must be a number, got {declared_str!r}'
+                ) from exc
+            if abs(declared - expected_prepay) > 1e-6:
+                raise Exception(
+                    f'declared `prepayment: {declared}` does not match the '
+                    f'computed residual {expected_prepay:.2f} (tx counter-split '
+                    f'{counter_amount_abs:.2f} − {kind} remaining '
+                    f'{invoice_remaining_abs:.2f}).'
+                )
+            if not _retarget_with_prepayment_split(
+                    lib, book, existing_tx, bank_acct_name,
+                    post_acct, lot, invoice_remaining_abs, expected_prepay):
+                raise Exception(
+                    f'Could not find counter-split in tx {txn_guid!r} — '
+                    f'expected a non-{bank_acct_name!r} split'
+                )
+            return
+
+        # Exact or partial retarget: original whole-split move.
+        if not _retarget_counter_split_to_lot(
+                lib, existing_tx, bank_acct_name, post_acct, lot):
+            raise Exception(
+                f'Could not find counter-split in tx {txn_guid!r} — '
+                f'expected a non-{bank_acct_name!r} split'
+            )
+        return
+
+    pay_date = datetime.strptime(pay_dir.metadata['date'], "%Y-%m-%d")
+    amount_str = pay_dir.metadata['amount']
+    memo = pay_dir.metadata['memo']
+    num = pay_dir.metadata.get('num', '')
+    if is_bill:
+        amount = string_to_gnc_numeric_quantity(f'-{amount_str}')
+    else:
+        amount = string_to_gnc_numeric_quantity(amount_str)
+    # Pass txn=None: GnuCash creates the payment transaction internally.
+    # Passing a manually-allocated Transaction causes a segfault on
+    # GnuCash 3.8 (ubuntu20) because the tx is not initialised before
+    # ApplyPayment uses it.
+    record.ApplyPayment(None, bank_account, amount, GncNumeric(1, 1), pay_date, memo, num)
+
+
+def _payments_only_added_diff(record, payment_dirs):
+    """Q-015 classifier helper.
+
+    Return (True, added_directives) iff the directive's PAYMENT list is a
+    strict prefix-equal superset of the record's existing lot payments:
+    every existing payment matches the corresponding directive 1:1, and
+    the directive has additional payment directives at the tail.
+
+    Return (False, []) for any other shape — equal count, directive has
+    fewer payments, or any in-place modification of an existing payment.
+    """
+    pay_splits = _lot_payment_splits(record)
+    if len(pay_splits) >= len(payment_dirs):
+        return False, []
+    for s, pd in zip(pay_splits, payment_dirs[:len(pay_splits)]):
+        if not _single_payment_matches(s, pd):
+            return False, []
+    return True, list(payment_dirs[len(pay_splits):])
+
+
+def _record_consumed_credit(record) -> bool:
+    """Q-015: True iff the record's posted lot contains splits that came
+    from `gncInvoiceAutoApplyPayments` (i.e. a payment tx attached to
+    another invoice/bill's lot for the same owner). Mirrors the exporter's
+    `_payment_is_credit_consumption` heuristic — see use_cases/export_business_objects.py.
+    """
+    import gnucash.gnucash_core_c as _gc
+    lot = record.GetPostedLot()
+    if lot is None:
+        return False
+    this_lot_id = int(lot.instance)
+    posting_txn = record.GetPostedTxn()
+    posting_txn_guid = posting_txn.GetGUID().to_string() if posting_txn else None
+    from gnucash import Split
+    for raw in lot.get_split_list():
+        s = Split(instance=raw)
+        tx = s.GetParent()
+        if tx is None:
+            continue
+        if posting_txn_guid is not None and tx.GetGUID().to_string() == posting_txn_guid:
+            continue
+        for i in range(tx.CountSplits()):
+            other = tx.GetSplit(i)
+            other_acct = other.GetAccount()
+            if other_acct is None:
+                continue
+            if other_acct.GetType() not in (ACCT_TYPE_RECEIVABLE, ACCT_TYPE_PAYABLE):
+                continue
+            other_lot = other.GetLot()
+            if other_lot is None or int(other_lot) == this_lot_id:
+                continue
+            if _gc.gncInvoiceGetInvoiceFromLot(other_lot):
+                return True
+    return False
+
+
+def _invoice_non_payment_matches(invoice, directive: 'PlaintextDirective') -> bool:
+    """True iff every non-payment field of an existing customer invoice
+    matches the directive: date_opened, billing_id, notes, custom KVP,
+    entries (positional by field), and the posted block (or its absence).
+    Used by both the strict-equality classifier and the Q-015 add-only
+    classifier — payments are checked separately."""
     md = directive.metadata
     if invoice.GetDateOpened().strftime("%Y-%m-%d") != md['date_opened']:
         return False
@@ -882,6 +1246,11 @@ def _invoice_matches_directive(invoice, directive: 'PlaintextDirective', book) -
                       if k not in KNOWN_INVOICE_METADATA_KEYS and v is not None}
     existing_custom = get_custom_metadata(invoice) or {}
     if existing_custom != desired_custom:
+        return False
+
+    # Q-015: auto_apply_credit flag must match the book's effective state.
+    desired_auto = not _is_falsy(str(md.get('auto_apply_credit', 'false')))
+    if desired_auto != _record_consumed_credit(invoice):
         return False
 
     entry_dirs = [c for c in directive.children if c.type == DirectiveType.INVOICE_ENTRY]
@@ -899,12 +1268,45 @@ def _invoice_matches_directive(invoice, directive: 'PlaintextDirective', book) -
         return False
     if posted_dirs and not is_posted:
         return False
-    if posted_dirs and is_posted and not _posted_matches_directive(
-            invoice, posted_dirs[0], 'ar_account'):
-        return False
+    return not (posted_dirs and is_posted and not _posted_matches_directive(invoice, posted_dirs[0], 'ar_account'))
 
+
+def _invoice_matches_directive(invoice, directive: 'PlaintextDirective', book) -> bool:
+    """Return True iff an existing customer invoice equals the directive (Q-010).
+
+    Compared fields: date_opened, billing_id, notes, custom KVP, entries
+    (positional, by field), the posted block (or absence thereof), and
+    payments (count + per-payment fields). Mismatch on ANY field returns
+    False so the importer falls through to the rebuild + repost path.
+    """
+    if not _invoice_non_payment_matches(invoice, directive):
+        return False
     payment_dirs = [c for c in directive.children if c.type == DirectiveType.PAYMENT]
     return _payments_match_directive(invoice, payment_dirs)
+
+
+def _is_only_added_payment_diff_invoice(invoice, directive):
+    """Q-015 classifier for customer invoices.
+
+    Return (True, added_directives) iff the only difference between the
+    existing posted invoice and the directive is that the directive
+    appends additional `payment:` blocks at the tail (entries + posted +
+    metadata all match; the existing payments are a prefix-equal subset
+    of the directive's payments).
+
+    When True, the caller can apply just the additional payments via
+    `ApplyPayment` on the still-posted invoice — no Unpost, no rebuild,
+    posting/entry/existing-payment GUIDs preserved.
+
+    Return (False, []) for any other shape — falls through to the
+    destructive rebuild path the test suite already covers.
+    """
+    if invoice.GetPostedTxn() is None:
+        return False, []
+    if not _invoice_non_payment_matches(invoice, directive):
+        return False, []
+    payment_dirs = [c for c in directive.children if c.type == DirectiveType.PAYMENT]
+    return _payments_only_added_diff(invoice, payment_dirs)
 
 
 def _is_only_unpost_diff(invoice_or_bill, directive: 'PlaintextDirective',
@@ -965,12 +1367,9 @@ def _is_only_unpost_diff(invoice_or_bill, directive: 'PlaintextDirective',
     return all(matcher(entry, ed) for entry, ed in zip(existing_entries, entry_dirs))
 
 
-def _bill_matches_directive(bill, directive: 'PlaintextDirective', book) -> bool:
-    """Return True iff an existing vendor bill equals the directive (Q-010).
-
-    Same shape as `_invoice_matches_directive` but uses the bill-side
-    entry getters and AP account.
-    """
+def _bill_non_payment_matches(bill, directive: 'PlaintextDirective') -> bool:
+    """Bill-side counterpart of `_invoice_non_payment_matches` — same
+    shape, uses the bill entry getters and AP account."""
     md = directive.metadata
     if bill.GetDateOpened().strftime("%Y-%m-%d") != md['date_opened']:
         return False
@@ -980,6 +1379,10 @@ def _bill_matches_directive(bill, directive: 'PlaintextDirective', book) -> bool
                       if k not in KNOWN_BILL_METADATA_KEYS and v is not None}
     existing_custom = get_custom_metadata(bill) or {}
     if existing_custom != desired_custom:
+        return False
+
+    desired_auto = not _is_falsy(str(md.get('auto_apply_credit', 'false')))
+    if desired_auto != _record_consumed_credit(bill):
         return False
 
     entry_dirs = [c for c in directive.children if c.type == DirectiveType.BILL_ENTRY]
@@ -997,12 +1400,30 @@ def _bill_matches_directive(bill, directive: 'PlaintextDirective', book) -> bool
         return False
     if posted_dirs and not is_posted:
         return False
-    if posted_dirs and is_posted and not _posted_matches_directive(
-            bill, posted_dirs[0], 'ap_account'):
-        return False
+    return not (posted_dirs and is_posted and not _posted_matches_directive(bill, posted_dirs[0], 'ap_account'))
 
+
+def _bill_matches_directive(bill, directive: 'PlaintextDirective', book) -> bool:
+    """Return True iff an existing vendor bill equals the directive (Q-010).
+
+    Same shape as `_invoice_matches_directive` but uses the bill-side
+    entry getters and AP account.
+    """
+    if not _bill_non_payment_matches(bill, directive):
+        return False
     payment_dirs = [c for c in directive.children if c.type == DirectiveType.PAYMENT]
     return _payments_match_directive(bill, payment_dirs)
+
+
+def _is_only_added_payment_diff_bill(bill, directive):
+    """Q-015 classifier for vendor bills. Symmetric to
+    `_is_only_added_payment_diff_invoice`."""
+    if bill.GetPostedTxn() is None:
+        return False, []
+    if not _bill_non_payment_matches(bill, directive):
+        return False, []
+    payment_dirs = [c for c in directive.children if c.type == DirectiveType.PAYMENT]
+    return _payments_only_added_diff(bill, payment_dirs)
 
 
 class GnuCashImporter:
@@ -1604,7 +2025,8 @@ class GnuCashImporter:
         return 'created'
 
     @staticmethod
-    def import_invoice(directive: PlaintextDirective, book: Book):
+    def import_invoice(directive: PlaintextDirective, book: Book,
+                       on_orphan_warning=None):
         if directive.type != DirectiveType.INVOICE:
             raise ValueError(f"Expected INVOICE but got {directive.type}")
 
@@ -1635,11 +2057,15 @@ class GnuCashImporter:
         if has_posted_none and payment_children:
             raise ValueError(f'Invoice {inv_id}: cannot have payment: blocks on an unposted invoice (posted: none)')
 
-        # Q-010: classify the existing record before any mutation.
+        # Q-010 / Q-015: classify the existing record before any mutation.
         #   - matches directive byte-for-byte → 'unchanged' (no-op)
         #   - only difference is `posted → posted: none` → minimal Unpost,
         #     skip the destroy-and-rebuild (preserves entry GUIDs)
-        #   - existing is posted, directive differs (entries/posted/payments)
+        #   - only difference is the directive appends payment(s) at the
+        #     tail → apply just those new payments via ApplyPayment on
+        #     the still-posted invoice (preserves posting/entry GUIDs and
+        #     does NOT orphan existing payment bank txs)
+        #   - existing is posted, directive differs in other ways
         #     → full Unpost-rebuild-repost cycle (mirrors GnuCash UI)
         #   - existing is unposted → fall through to rebuild
         # Q-007's old behaviour ("posted is immutable, return skipped")
@@ -1655,11 +2081,25 @@ class GnuCashImporter:
                     f"Invoice {inv_id}: only difference is posted→posted:none; "
                     f"minimal unpost (entry GUIDs preserved)"
                 )
+                _emit_orphan_warning_before_unpost(
+                    existing, 'invoice', inv_id, on_orphan_warning)
                 existing.Unpost(False)
+                return 'updated'
+            added, added_pays = _is_only_added_payment_diff_invoice(existing, directive)
+            if added:
+                logging.debug(
+                    f"Invoice {inv_id}: only difference is +{len(added_pays)} "
+                    f"appended payment(s); applying incrementally (posting/entry/"
+                    f"existing-payment GUIDs preserved)"
+                )
+                for pay_dir in added_pays:
+                    _apply_payment_directive(existing, pay_dir, book, is_bill=False)
                 return 'updated'
             status_on_success = 'updated'
             if existing.GetPostedTxn() is not None:
                 logging.debug(f"Invoice {inv_id} is posted but differs; unposting for rebuild")
+                _emit_orphan_warning_before_unpost(
+                    existing, 'invoice', inv_id, on_orphan_warning)
                 existing.Unpost(False)
 
         if existing is None:
@@ -1741,44 +2181,19 @@ class GnuCashImporter:
                     posting_txn.SetNotes("business_generated: true")
                     posting_txn.CommitEdit()
             elif entry_directive.type == DirectiveType.PAYMENT:
-                bank_acct_name = entry_directive.metadata['bank_account']
-                bank_account = find_account(book.get_root_account(), bank_acct_name)
-                if bank_account is None:
-                    raise Exception(f'Bank account {bank_acct_name!r} not found when applying invoice payment')
+                _apply_payment_directive(invoice, entry_directive, book, is_bill=False)
 
-                txn_guid = entry_directive.metadata.get('txn_guid', '').strip()
-                if txn_guid:
-                    # Retarget approach: the bank transaction already exists.
-                    # Find the counter-split (non-bank side), retarget it to AR,
-                    # and link it to the invoice lot. No new transaction is created,
-                    # all original bank metadata (notes, memos, KVP) is preserved.
-                    # ApplyPayment() is NOT called — the lot closes automatically
-                    # when the AR split sum reaches zero.
-                    existing_tx = _find_transaction_by_guid(book, txn_guid)
-                    if existing_tx is None:
-                        raise Exception(f'txn_guid {txn_guid!r} not found in book')
-                    ar_account = invoice.GetPostedAcc()
-                    lot = invoice.GetPostedLot()
-                    if lot is None:
-                        raise Exception(f'Invoice {inv_id} has no posted lot — must be posted before payment')
-                    from infrastructure.gnucash.engine import load_gnc_engine
-                    if not _retarget_counter_split_to_lot(
-                            load_gnc_engine(), existing_tx, bank_acct_name, ar_account, lot):
-                        raise Exception(
-                            f'Could not find counter-split in tx {txn_guid!r} — '
-                            f'expected a non-{bank_acct_name!r} split'
-                        )
-                else:
-                    # Normal path: no pre-existing bank tx — ApplyPayment creates one.
-                    pay_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
-                    amount = string_to_gnc_numeric_quantity(entry_directive.metadata['amount'])
-                    memo = entry_directive.metadata['memo']
-                    num = entry_directive.metadata.get('num', '')
-                    # Pass None for txn: GnuCash creates the payment transaction
-                    # internally. Passing a manually-allocated Transaction causes
-                    # a segfault on GnuCash 3.8 (ubuntu20) because the transaction
-                    # is not properly initialised before ApplyPayment uses it.
-                    invoice.ApplyPayment(None, bank_account, amount, GncNumeric(1, 1), pay_date, memo, num)
+        # Q-015: auto_apply_credit consumes the customer's open prepayment
+        # lots toward this invoice via gncInvoiceAutoApplyPayments. Cash
+        # payments above are applied first; auto-apply then fills any
+        # remaining balance from existing credit.
+        if not _is_falsy(str(directive.metadata.get('auto_apply_credit', 'false'))):
+            if invoice.GetPostedTxn() is None:
+                raise Exception(
+                    f'Invoice {inv_id}: auto_apply_credit requires a posted: '
+                    f'block (cannot apply credit to an unposted invoice)'
+                )
+            invoice.AutoApplyPayments()
 
         invoice.CommitEdit()
         custom_meta = {k: v for k, v in directive.metadata.items()
@@ -1792,7 +2207,8 @@ class GnuCashImporter:
         return status_on_success
 
     @staticmethod
-    def import_bill(directive: PlaintextDirective, book: Book):
+    def import_bill(directive: PlaintextDirective, book: Book,
+                    on_orphan_warning=None):
         if directive.type != DirectiveType.BILL:
             raise ValueError(f"Expected BILL but got {directive.type}")
 
@@ -1826,10 +2242,11 @@ class GnuCashImporter:
         if has_posted_none and payment_children:
             raise ValueError(f'Bill {bill_id}: cannot have payment: blocks on an unposted bill (posted: none)')
 
-        # Q-010: same classification as import_invoice. Posted bills are
-        # mutable via Unpost-edit-repost; identical re-imports are unchanged;
-        # bare unpost (posted → posted: none, no other change) skips the
-        # destroy-and-rebuild and preserves entry GUIDs.
+        # Q-010 / Q-015: same classification as import_invoice. Posted
+        # bills are mutable via Unpost-edit-repost; identical re-imports
+        # are unchanged; bare unpost (posted → posted: none, no other
+        # change) skips the destroy-and-rebuild and preserves entry
+        # GUIDs; appended payments hit the Q-015 fast path.
         status_on_success = 'created'
         if existing is not None:
             if _bill_matches_directive(existing, directive, book):
@@ -1840,11 +2257,25 @@ class GnuCashImporter:
                     f"Bill {bill_id}: only difference is posted→posted:none; "
                     f"minimal unpost (entry GUIDs preserved)"
                 )
+                _emit_orphan_warning_before_unpost(
+                    existing, 'bill', bill_id, on_orphan_warning)
                 existing.Unpost(False)
+                return 'updated'
+            added, added_pays = _is_only_added_payment_diff_bill(existing, directive)
+            if added:
+                logging.debug(
+                    f"Bill {bill_id}: only difference is +{len(added_pays)} "
+                    f"appended payment(s); applying incrementally (posting/entry/"
+                    f"existing-payment GUIDs preserved)"
+                )
+                for pay_dir in added_pays:
+                    _apply_payment_directive(existing, pay_dir, book, is_bill=True)
                 return 'updated'
             status_on_success = 'updated'
             if existing.GetPostedTxn() is not None:
                 logging.debug(f"Bill {bill_id} is posted but differs; unposting for rebuild")
+                _emit_orphan_warning_before_unpost(
+                    existing, 'bill', bill_id, on_orphan_warning)
                 existing.Unpost(False)
 
         if existing is None:
@@ -1909,47 +2340,16 @@ class GnuCashImporter:
                     posting_txn.SetNotes("business_generated: true")
                     posting_txn.CommitEdit()
             elif entry_directive.type == DirectiveType.PAYMENT:
-                bank_acct_name = entry_directive.metadata['bank_account']
-                bank_account = find_account(book.get_root_account(), bank_acct_name)
-                if bank_account is None:
-                    raise Exception(f'Bank account {bank_acct_name!r} not found when applying bill payment')
+                _apply_payment_directive(bill, entry_directive, book, is_bill=True)
 
-                txn_guid = entry_directive.metadata.get('txn_guid', '').strip()
-                if txn_guid:
-                    # Retarget approach — same as invoice, but targeting AP.
-                    existing_tx = _find_transaction_by_guid(book, txn_guid)
-                    if existing_tx is None:
-                        raise Exception(f'txn_guid {txn_guid!r} not found in book')
-                    ap_account = bill.GetPostedAcc()
-                    lot = bill.GetPostedLot()
-                    if lot is None:
-                        raise Exception(f'Bill {bill_id} has no posted lot — must be posted before payment')
-                    from infrastructure.gnucash.engine import load_gnc_engine
-                    if not _retarget_counter_split_to_lot(
-                            load_gnc_engine(), existing_tx, bank_acct_name, ap_account, lot):
-                        raise Exception(
-                            f'Could not find counter-split in tx {txn_guid!r} — '
-                            f'expected a non-{bank_acct_name!r} split'
-                        )
-                else:
-                    # Normal path: ApplyPayment creates the bank+AP transaction.
-                    # AP and AR have opposite sign conventions, so bill payments
-                    # require a negated amount:
-                    #
-                    #   Bill posting:    CR AP −N  →  lot starts at −N
-                    #   Bill payment:    DR AP +N  →  ApplyPayment(+N) creates AP = −N ✗
-                    #                                 (same sign as posting → new lot)
-                    #                   ApplyPayment(−N) creates AP = +N ✓
-                    #                                 (opposite sign → closes existing lot)
-                    #
-                    # Passing a positive amount puts the payment split in a brand-new
-                    # lot instead of the bill's posted lot.
-                    pay_date = datetime.strptime(entry_directive.metadata['date'], "%Y-%m-%d")
-                    amount_str = entry_directive.metadata['amount']
-                    memo = entry_directive.metadata['memo']
-                    num = entry_directive.metadata.get('num', '')
-                    neg_amount = string_to_gnc_numeric_quantity(f'-{amount_str}')
-                    bill.ApplyPayment(None, bank_account, neg_amount, GncNumeric(1, 1), pay_date, memo, num)
+        # Q-015: symmetric to invoice side — consume vendor credit lots.
+        if not _is_falsy(str(directive.metadata.get('auto_apply_credit', 'false'))):
+            if bill.GetPostedTxn() is None:
+                raise Exception(
+                    f'Bill {bill_id}: auto_apply_credit requires a posted: '
+                    f'block (cannot apply credit to an unposted bill)'
+                )
+            bill.AutoApplyPayments()
 
         bill.CommitEdit()
         custom_meta = {k: v for k, v in directive.metadata.items()
@@ -1963,7 +2363,8 @@ class GnuCashImporter:
         return status_on_success
 
     def import_business_objects(self, directives: List[PlaintextDirective], book: Book,
-                                 on_directive_status=None):
+                                 on_directive_status=None,
+                                 on_orphan_warning=None):
         """Import every business-object directive and report per-record status.
 
         `on_directive_status(kind, id, status)` is invoked once per directive
@@ -1972,6 +2373,14 @@ class GnuCashImporter:
         Default is no-op for library callers; the CLI passes a callback
         that prints '<kind> "<id>": <status>' lines so the user sees
         activity inline.
+
+        `on_orphan_warning(kind, id, orphans)` is invoked when a re-import
+        of a *paid* invoice/bill is about to call `Unpost(False)`
+        (Q-015): the helper captures the still-attached payment-class
+        transactions before the unpost destroys the lot, and the callback
+        gets the list so the CLI can render the same orphan-payment
+        warning block that `unpost-invoices` / `unpost-bills` emit.
+        `orphans` is a `List[OrphanPayment]`.
 
         Returns a `BusinessObjectImportResult` with per-type counts so the
         caller can render an aggregate summary at the end of the import.
@@ -2014,7 +2423,8 @@ class GnuCashImporter:
             if directive.type == DirectiveType.INVOICE:
                 iid = directive.props.get('id', '?')
                 try:
-                    status = self.import_invoice(directive, book)
+                    status = self.import_invoice(directive, book,
+                                                 on_orphan_warning=on_orphan_warning)
                 except Exception as e:
                     raise ValueError(f'invoice "{iid}": {e}') from e
                 result.tally('invoice', status)
@@ -2022,7 +2432,8 @@ class GnuCashImporter:
             elif directive.type == DirectiveType.BILL:
                 bid = directive.props.get('id', '?')
                 try:
-                    status = self.import_bill(directive, book)
+                    status = self.import_bill(directive, book,
+                                              on_orphan_warning=on_orphan_warning)
                 except Exception as e:
                     raise ValueError(f'bill "{bid}": {e}') from e
                 result.tally('bill', status)

--- a/tests/fixtures/q015_aac_bill002_partial_credit.txt
+++ b/tests/fixtures/q015_aac_bill002_partial_credit.txt
@@ -1,0 +1,24 @@
+vendor "V001"
+	name: "Supplier Co"
+	currency: CAD
+
+bill "BILL-002"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-02-01
+	auto_apply_credit: true
+	entry:
+		date: 2026-02-01
+		description: "M2"
+		action: "Material"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 30
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-02-01
+		due: 2026-02-28
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "BILL-002"
+		accumulate: true

--- a/tests/fixtures/q015_aac_inv002_composed_cash.txt
+++ b/tests/fixtures/q015_aac_inv002_composed_cash.txt
@@ -1,0 +1,29 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-002"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-02-01
+	auto_apply_credit: true
+	entry:
+		date: 2026-02-01
+		description: "B"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 80
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-02-01
+		due: 2026-02-28
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-002"
+		accumulate: true
+	payment:
+		date: 2026-02-05
+		amount: 30
+		bank_account: "Assets:Bank"
+		memo: "Top-up cash for INV-002"

--- a/tests/fixtures/q015_aac_inv002_no_flag.txt
+++ b/tests/fixtures/q015_aac_inv002_no_flag.txt
@@ -1,0 +1,23 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-002"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-02-01
+	entry:
+		date: 2026-02-01
+		description: "B"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 30
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-02-01
+		due: 2026-02-28
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-002"
+		accumulate: true

--- a/tests/fixtures/q015_aac_inv002_over_consumes.txt
+++ b/tests/fixtures/q015_aac_inv002_over_consumes.txt
@@ -1,0 +1,24 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-002"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-02-01
+	auto_apply_credit: true
+	entry:
+		date: 2026-02-01
+		description: "B"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 200
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-02-01
+		due: 2026-02-28
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-002"
+		accumulate: true

--- a/tests/fixtures/q015_aac_inv002_partial_credit.txt
+++ b/tests/fixtures/q015_aac_inv002_partial_credit.txt
@@ -1,0 +1,24 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-002"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-02-01
+	auto_apply_credit: true
+	entry:
+		date: 2026-02-01
+		description: "B"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 30
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-02-01
+		due: 2026-02-28
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-002"
+		accumulate: true

--- a/tests/fixtures/q015_aac_primer_bill.txt
+++ b/tests/fixtures/q015_aac_primer_bill.txt
@@ -1,0 +1,29 @@
+vendor "V001"
+	name: "Supplier Co"
+	currency: CAD
+
+bill "BILL-001"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "M"
+		action: "Material"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "BILL-001"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		memo: "Bill overpaid"
+		prepayment: 50

--- a/tests/fixtures/q015_aac_primer_invoice.txt
+++ b/tests/fixtures/q015_aac_primer_invoice.txt
@@ -1,0 +1,29 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-001"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "A"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-001"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		memo: "Overpaid"
+		prepayment: 50

--- a/tests/fixtures/q015_dest_addpay_v1.txt
+++ b/tests/fixtures/q015_dest_addpay_v1.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-ADDPAY-160"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 160
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-ADDPAY-160"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 95
+		bank_account: "Assets:Bank"
+		memo: "Addpay P1"

--- a/tests/fixtures/q015_dest_addpay_v2.txt
+++ b/tests/fixtures/q015_dest_addpay_v2.txt
@@ -1,0 +1,33 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-ADDPAY-160"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 160
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-ADDPAY-160"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 95
+		bank_account: "Assets:Bank"
+		memo: "Addpay P1"
+	payment:
+		date: 2026-01-25
+		amount: 35
+		bank_account: "Assets:Bank"
+		memo: "Addpay P2"

--- a/tests/fixtures/q015_dest_bill_entrymod_v1.txt
+++ b/tests/fixtures/q015_dest_bill_entrymod_v1.txt
@@ -1,0 +1,26 @@
+vendor "V001"
+	name: "Supplier Co"
+	currency: CAD
+
+bill "BILL-DEST-EMOD-140"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Materials"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 140
+		taxable: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-DEST-EMOD-140"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 80
+		bank_account: "Assets:Bank"
+		memo: "Bill partial emod"

--- a/tests/fixtures/q015_dest_bill_entrymod_v2.txt
+++ b/tests/fixtures/q015_dest_bill_entrymod_v2.txt
@@ -1,0 +1,26 @@
+vendor "V001"
+	name: "Supplier Co"
+	currency: CAD
+
+bill "BILL-DEST-EMOD-140"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Materials v2"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 140
+		taxable: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-DEST-EMOD-140"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 80
+		bank_account: "Assets:Bank"
+		memo: "Bill partial emod"

--- a/tests/fixtures/q015_dest_bill_postnone_v1.txt
+++ b/tests/fixtures/q015_dest_bill_postnone_v1.txt
@@ -1,0 +1,26 @@
+vendor "V001"
+	name: "Supplier Co"
+	currency: CAD
+
+bill "BILL-DEST-POSTNONE-145"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Materials"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 145
+		taxable: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-DEST-POSTNONE-145"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 85
+		bank_account: "Assets:Bank"
+		memo: "Bill partial postnone"

--- a/tests/fixtures/q015_dest_bill_postnone_v2.txt
+++ b/tests/fixtures/q015_dest_bill_postnone_v2.txt
@@ -1,0 +1,16 @@
+vendor "V001"
+	name: "Supplier Co"
+	currency: CAD
+
+bill "BILL-DEST-POSTNONE-145"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Materials"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 145
+		taxable: false
+	posted: none

--- a/tests/fixtures/q015_dest_identical.txt
+++ b/tests/fixtures/q015_dest_identical.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-IDENT-155"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 155
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-IDENT-155"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 90
+		bank_account: "Assets:Bank"
+		memo: "Identical reimport partial"

--- a/tests/fixtures/q015_dest_inv_entryadd_v1.txt
+++ b/tests/fixtures/q015_dest_inv_entryadd_v1.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-EADD-105"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 105
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-EADD-105"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 62
+		bank_account: "Assets:Bank"
+		memo: "Partial entryadd"

--- a/tests/fixtures/q015_dest_inv_entryadd_v2.txt
+++ b/tests/fixtures/q015_dest_inv_entryadd_v2.txt
@@ -1,0 +1,37 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-EADD-105"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 105
+		taxable: false
+		tax_included: false
+	entry:
+		date: 2026-01-02
+		description: "Extra service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 50
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-EADD-105"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 62
+		bank_account: "Assets:Bank"
+		memo: "Partial entryadd"

--- a/tests/fixtures/q015_dest_inv_entrymod_v1.txt
+++ b/tests/fixtures/q015_dest_inv_entrymod_v1.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-EMOD-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-EMOD-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 60
+		bank_account: "Assets:Bank"
+		memo: "Partial entrymod"

--- a/tests/fixtures/q015_dest_inv_entrymod_v2.txt
+++ b/tests/fixtures/q015_dest_inv_entrymod_v2.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-EMOD-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service v2"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-EMOD-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 60
+		bank_account: "Assets:Bank"
+		memo: "Partial entrymod"

--- a/tests/fixtures/q015_dest_inv_entryrm_v1.txt
+++ b/tests/fixtures/q015_dest_inv_entryrm_v1.txt
@@ -1,0 +1,37 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-ERM-110"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 110
+		taxable: false
+		tax_included: false
+	entry:
+		date: 2026-01-02
+		description: "Extra service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 50
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-ERM-110"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 65
+		bank_account: "Assets:Bank"
+		memo: "Partial entryrm"

--- a/tests/fixtures/q015_dest_inv_entryrm_v2.txt
+++ b/tests/fixtures/q015_dest_inv_entryrm_v2.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-ERM-110"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 110
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-ERM-110"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 65
+		bank_account: "Assets:Bank"
+		memo: "Partial entryrm"

--- a/tests/fixtures/q015_dest_inv_paymemo_v1.txt
+++ b/tests/fixtures/q015_dest_inv_paymemo_v1.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-PMOD-125"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 125
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-PMOD-125"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 72
+		bank_account: "Assets:Bank"
+		memo: "Partial paymod-original"

--- a/tests/fixtures/q015_dest_inv_paymemo_v2.txt
+++ b/tests/fixtures/q015_dest_inv_paymemo_v2.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-PMOD-125"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 125
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-PMOD-125"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 72
+		bank_account: "Assets:Bank"
+		memo: "Partial paymod-edited"

--- a/tests/fixtures/q015_dest_inv_payrm_v1.txt
+++ b/tests/fixtures/q015_dest_inv_payrm_v1.txt
@@ -1,0 +1,33 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-PRM-130"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 130
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-PRM-130"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 75
+		bank_account: "Assets:Bank"
+		memo: "P1 stays"
+	payment:
+		date: 2026-01-25
+		amount: 45
+		bank_account: "Assets:Bank"
+		memo: "P2 will be removed"

--- a/tests/fixtures/q015_dest_inv_payrm_v2.txt
+++ b/tests/fixtures/q015_dest_inv_payrm_v2.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-PRM-130"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 130
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-PRM-130"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 75
+		bank_account: "Assets:Bank"
+		memo: "P1 stays"

--- a/tests/fixtures/q015_dest_inv_postedchg_v1.txt
+++ b/tests/fixtures/q015_dest_inv_postedchg_v1.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-POSTCHG-115"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 115
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-POSTCHG-115"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 67
+		bank_account: "Assets:Bank"
+		memo: "Partial postchg"

--- a/tests/fixtures/q015_dest_inv_postedchg_v2.txt
+++ b/tests/fixtures/q015_dest_inv_postedchg_v2.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-POSTCHG-115"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 115
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-POSTCHG-115 v2"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 67
+		bank_account: "Assets:Bank"
+		memo: "Partial postchg"

--- a/tests/fixtures/q015_dest_inv_postnone_v1.txt
+++ b/tests/fixtures/q015_dest_inv_postnone_v1.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-POSTNONE-120"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 120
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-POSTNONE-120"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 70
+		bank_account: "Assets:Bank"
+		memo: "Partial postnone"

--- a/tests/fixtures/q015_dest_inv_postnone_v2.txt
+++ b/tests/fixtures/q015_dest_inv_postnone_v2.txt
@@ -1,0 +1,18 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-POSTNONE-120"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 120
+		taxable: false
+		tax_included: false
+	posted: none

--- a/tests/fixtures/q015_dest_unpaid_v1.txt
+++ b/tests/fixtures/q015_dest_unpaid_v1.txt
@@ -1,0 +1,23 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-UNPAID-150"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 150
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-UNPAID-150"
+		accumulate: true

--- a/tests/fixtures/q015_dest_unpaid_v2.txt
+++ b/tests/fixtures/q015_dest_unpaid_v2.txt
@@ -1,0 +1,23 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-DEST-UNPAID-150"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service v2"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 150
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-DEST-UNPAID-150"
+		accumulate: true

--- a/tests/fixtures/q015_eq_basic_apply.txt
+++ b/tests/fixtures/q015_eq_basic_apply.txt
@@ -1,0 +1,29 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-001"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-10
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-001"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		memo: "Overpaid"
+		prepayment: 50

--- a/tests/fixtures/q015_eq_basic_pre_bank.txt
+++ b/tests/fixtures/q015_eq_basic_pre_bank.txt
@@ -1,0 +1,4 @@
+2026-01-10 * "Acme"
+  Assets:Bank  150.00 CAD
+    memo: "Overpaid"
+  Assets:Accounts Receivable  -150.00 CAD

--- a/tests/fixtures/q015_eq_basic_retarget.txt
+++ b/tests/fixtures/q015_eq_basic_retarget.txt
@@ -1,0 +1,30 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-001"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-10
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-001"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		txn_guid: "{txn_guid}"
+		prepayment: 50
+		memo: "Overpaid"

--- a/tests/fixtures/q015_eq_exact_apply.txt
+++ b/tests/fixtures/q015_eq_exact_apply.txt
@@ -1,0 +1,28 @@
+customer "C123"
+	name: "Beta Studio"
+	currency: CAD
+
+invoice "INV-EXACT-123"
+	customer_id: "C123"
+	currency: CAD
+	date_opened: 2026-02-03
+	entry:
+		date: 2026-02-03
+		description: "Consultation"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 123
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-02-05
+		due: 2026-03-05
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-EXACT-123"
+		accumulate: true
+	payment:
+		date: 2026-02-09
+		amount: 123
+		bank_account: "Assets:Bank"
+		memo: "Paid exactly"

--- a/tests/fixtures/q015_eq_exact_pre_bank.txt
+++ b/tests/fixtures/q015_eq_exact_pre_bank.txt
@@ -1,0 +1,4 @@
+2026-02-09 * "Beta Studio"
+  Assets:Bank  123.00 CAD
+    memo: "Paid exactly"
+  Assets:Accounts Receivable  -123.00 CAD

--- a/tests/fixtures/q015_eq_exact_retarget.txt
+++ b/tests/fixtures/q015_eq_exact_retarget.txt
@@ -1,0 +1,29 @@
+customer "C123"
+	name: "Beta Studio"
+	currency: CAD
+
+invoice "INV-EXACT-123"
+	customer_id: "C123"
+	currency: CAD
+	date_opened: 2026-02-03
+	entry:
+		date: 2026-02-03
+		description: "Consultation"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 123
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-02-05
+		due: 2026-03-05
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-EXACT-123"
+		accumulate: true
+	payment:
+		date: 2026-02-09
+		amount: 123
+		bank_account: "Assets:Bank"
+		txn_guid: "{txn_guid}"
+		memo: "Paid exactly"

--- a/tests/fixtures/q015_eq_partial_apply.txt
+++ b/tests/fixtures/q015_eq_partial_apply.txt
@@ -1,0 +1,28 @@
+customer "C200"
+	name: "Gamma Holdings"
+	currency: CAD
+
+invoice "INV-PARTIAL-200"
+	customer_id: "C200"
+	currency: CAD
+	date_opened: 2026-03-15
+	entry:
+		date: 2026-03-15
+		description: "Equipment lease (March)"
+		action: "Lease"
+		account: "Income:Sales"
+		quantity: 1
+		price: 200
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-03-16
+		due: 2026-04-15
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-PARTIAL-200"
+		accumulate: true
+	payment:
+		date: 2026-03-20
+		amount: 77
+		bank_account: "Assets:Bank"
+		memo: "Partial — 77 of 200"

--- a/tests/fixtures/q015_eq_partial_pre_bank.txt
+++ b/tests/fixtures/q015_eq_partial_pre_bank.txt
@@ -1,0 +1,4 @@
+2026-03-20 * "Gamma Holdings"
+  Assets:Bank  77.00 CAD
+    memo: "Partial — 77 of 200"
+  Assets:Accounts Receivable  -77.00 CAD

--- a/tests/fixtures/q015_eq_partial_retarget.txt
+++ b/tests/fixtures/q015_eq_partial_retarget.txt
@@ -1,0 +1,29 @@
+customer "C200"
+	name: "Gamma Holdings"
+	currency: CAD
+
+invoice "INV-PARTIAL-200"
+	customer_id: "C200"
+	currency: CAD
+	date_opened: 2026-03-15
+	entry:
+		date: 2026-03-15
+		description: "Equipment lease (March)"
+		action: "Lease"
+		account: "Income:Sales"
+		quantity: 1
+		price: 200
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-03-16
+		due: 2026-04-15
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-PARTIAL-200"
+		accumulate: true
+	payment:
+		date: 2026-03-20
+		amount: 77
+		bank_account: "Assets:Bank"
+		txn_guid: "{txn_guid}"
+		memo: "Partial — 77 of 200"

--- a/tests/fixtures/q015_eq_two_over_apply.txt
+++ b/tests/fixtures/q015_eq_two_over_apply.txt
@@ -1,0 +1,55 @@
+customer "C700"
+	name: "Delta Café"
+	currency: CAD
+
+invoice "INV-DOUBLE-A"
+	customer_id: "C700"
+	currency: CAD
+	date_opened: 2026-04-02
+	entry:
+		date: 2026-04-02
+		description: "Catering (April)"
+		action: "Service"
+		account: "Income:Sales"
+		quantity: 1
+		price: 80
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-04-03
+		due: 2026-05-03
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-DOUBLE-A"
+		accumulate: true
+	payment:
+		date: 2026-04-10
+		amount: 130
+		bank_account: "Assets:Bank"
+		memo: "Overpaid A (130 of 80)"
+		prepayment: 50
+
+invoice "INV-DOUBLE-B"
+	customer_id: "C700"
+	currency: CAD
+	date_opened: 2026-05-04
+	entry:
+		date: 2026-05-04
+		description: "Catering (May)"
+		action: "Service"
+		account: "Income:Sales"
+		quantity: 1
+		price: 250
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-05-05
+		due: 2026-06-04
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-DOUBLE-B"
+		accumulate: true
+	payment:
+		date: 2026-05-12
+		amount: 300
+		bank_account: "Assets:Bank"
+		memo: "Overpaid B (300 of 250)"
+		prepayment: 50

--- a/tests/fixtures/q015_eq_two_over_pre_bank.txt
+++ b/tests/fixtures/q015_eq_two_over_pre_bank.txt
@@ -1,0 +1,9 @@
+2026-04-10 * "Delta Café"
+  Assets:Bank  130.00 CAD
+    memo: "Overpaid A (130 of 80)"
+  Assets:Accounts Receivable  -130.00 CAD
+
+2026-05-12 * "Delta Café"
+  Assets:Bank  300.00 CAD
+    memo: "Overpaid B (300 of 250)"
+  Assets:Accounts Receivable  -300.00 CAD

--- a/tests/fixtures/q015_eq_two_over_retarget.txt
+++ b/tests/fixtures/q015_eq_two_over_retarget.txt
@@ -1,0 +1,57 @@
+customer "C700"
+	name: "Delta Café"
+	currency: CAD
+
+invoice "INV-DOUBLE-A"
+	customer_id: "C700"
+	currency: CAD
+	date_opened: 2026-04-02
+	entry:
+		date: 2026-04-02
+		description: "Catering (April)"
+		action: "Service"
+		account: "Income:Sales"
+		quantity: 1
+		price: 80
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-04-03
+		due: 2026-05-03
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-DOUBLE-A"
+		accumulate: true
+	payment:
+		date: 2026-04-10
+		amount: 130
+		bank_account: "Assets:Bank"
+		txn_guid: "{txn_guid_a}"
+		prepayment: 50
+		memo: "Overpaid A (130 of 80)"
+
+invoice "INV-DOUBLE-B"
+	customer_id: "C700"
+	currency: CAD
+	date_opened: 2026-05-04
+	entry:
+		date: 2026-05-04
+		description: "Catering (May)"
+		action: "Service"
+		account: "Income:Sales"
+		quantity: 1
+		price: 250
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-05-05
+		due: 2026-06-04
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-DOUBLE-B"
+		accumulate: true
+	payment:
+		date: 2026-05-12
+		amount: 300
+		bank_account: "Assets:Bank"
+		txn_guid: "{txn_guid_b}"
+		prepayment: 50
+		memo: "Overpaid B (300 of 250)"

--- a/tests/fixtures/q015_fp_multi_cust1.txt
+++ b/tests/fixtures/q015_fp_multi_cust1.txt
@@ -1,0 +1,29 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-FP-MULTI-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-FP-MULTI-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		memo: "Payment for INV-FP-MULTI-100"
+		prepayment: 50

--- a/tests/fixtures/q015_fp_multi_cust2.txt
+++ b/tests/fixtures/q015_fp_multi_cust2.txt
@@ -1,0 +1,29 @@
+customer "C002"
+	name: "Beta Inc"
+	currency: CAD
+
+invoice "INV-FP-MULTI-200"
+	customer_id: "C002"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 200
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-FP-MULTI-200"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 220
+		bank_account: "Assets:Bank"
+		memo: "Payment for INV-FP-MULTI-200"
+		prepayment: 20

--- a/tests/fixtures/q015_fp_residual_inv2.txt
+++ b/tests/fixtures/q015_fp_residual_inv2.txt
@@ -1,0 +1,20 @@
+invoice "INV-FP-RESIDUAL-30"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-02-01
+	auto_apply_credit: true
+	entry:
+		date: 2026-02-01
+		description: "B"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 30
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-02-01
+		due: 2026-02-28
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-FP-RESIDUAL-30"
+		accumulate: true

--- a/tests/fixtures/q015_fp_residual_primer.txt
+++ b/tests/fixtures/q015_fp_residual_primer.txt
@@ -1,0 +1,29 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-FP-RESIDUAL-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-FP-RESIDUAL-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		memo: "Payment for INV-FP-RESIDUAL-100"
+		prepayment: 50

--- a/tests/fixtures/q015_fp_single_cust_credit.txt
+++ b/tests/fixtures/q015_fp_single_cust_credit.txt
@@ -1,0 +1,29 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-FP-SINGLE-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-FP-SINGLE-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		memo: "Payment for INV-FP-SINGLE-100"
+		prepayment: 50

--- a/tests/fixtures/q015_fp_single_vendor_credit.txt
+++ b/tests/fixtures/q015_fp_single_vendor_credit.txt
@@ -1,0 +1,29 @@
+vendor "V001"
+	name: "Supplier Co"
+	currency: CAD
+
+bill "BILL-FP-SINGLE-100"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Mat"
+		action: "Material"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "BILL-FP-SINGLE-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		memo: "Bill paid"
+		prepayment: 50

--- a/tests/fixtures/q015_fp_vendor_filter_v1.txt
+++ b/tests/fixtures/q015_fp_vendor_filter_v1.txt
@@ -1,0 +1,29 @@
+vendor "V001"
+	name: "Supplier A"
+	currency: CAD
+
+bill "BILL-FP-FILTER-100"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Mat"
+		action: "Material"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "BILL-FP-FILTER-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		memo: "Bill paid"
+		prepayment: 50

--- a/tests/fixtures/q015_fp_vendor_filter_v2.txt
+++ b/tests/fixtures/q015_fp_vendor_filter_v2.txt
@@ -1,0 +1,29 @@
+vendor "V002"
+	name: "Supplier B"
+	currency: CAD
+
+bill "BILL-FP-FILTER-200"
+	vendor_id: "V002"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Mat"
+		action: "Material"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 200
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "BILL-FP-FILTER-200"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 230
+		bank_account: "Assets:Bank"
+		memo: "Bill paid"
+		prepayment: 30

--- a/tests/fixtures/q015_inc_add_bill_v1.txt
+++ b/tests/fixtures/q015_inc_add_bill_v1.txt
@@ -1,0 +1,28 @@
+vendor "V001"
+	name: "Supplier Co"
+	currency: CAD
+
+bill "BILL-INC-ADD-100"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Materials"
+		action: "Material"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-INC-ADD-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 60
+		bank_account: "Assets:Bank"
+		memo: "Bill payment 1"

--- a/tests/fixtures/q015_inc_add_bill_v2.txt
+++ b/tests/fixtures/q015_inc_add_bill_v2.txt
@@ -1,0 +1,33 @@
+vendor "V001"
+	name: "Supplier Co"
+	currency: CAD
+
+bill "BILL-INC-ADD-100"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Materials"
+		action: "Material"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-INC-ADD-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 60
+		bank_account: "Assets:Bank"
+		memo: "Bill payment 1"
+	payment:
+		date: 2026-01-25
+		amount: 40
+		bank_account: "Assets:Bank"
+		memo: "Bill payment 2"

--- a/tests/fixtures/q015_inc_add_inv_v1.txt
+++ b/tests/fixtures/q015_inc_add_inv_v1.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-INC-ADD-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-INC-ADD-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 60
+		bank_account: "Assets:Bank"
+		memo: "Partial 1"

--- a/tests/fixtures/q015_inc_add_inv_v2.txt
+++ b/tests/fixtures/q015_inc_add_inv_v2.txt
@@ -1,0 +1,33 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-INC-ADD-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-INC-ADD-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 60
+		bank_account: "Assets:Bank"
+		memo: "Partial 1"
+	payment:
+		date: 2026-01-25
+		amount: 40
+		bank_account: "Assets:Bank"
+		memo: "Partial 2"

--- a/tests/fixtures/q015_inc_identical.txt
+++ b/tests/fixtures/q015_inc_identical.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-INC-IDENT-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-INC-IDENT-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 55
+		bank_account: "Assets:Bank"
+		memo: "Single partial"

--- a/tests/fixtures/q015_inc_memo_v1.txt
+++ b/tests/fixtures/q015_inc_memo_v1.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-INC-MEMO-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-INC-MEMO-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 65
+		bank_account: "Assets:Bank"
+		memo: "Original memo"

--- a/tests/fixtures/q015_inc_memo_v2.txt
+++ b/tests/fixtures/q015_inc_memo_v2.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-INC-MEMO-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-INC-MEMO-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 65
+		bank_account: "Assets:Bank"
+		memo: "Modified memo"

--- a/tests/fixtures/q015_inc_remove_v1.txt
+++ b/tests/fixtures/q015_inc_remove_v1.txt
@@ -1,0 +1,33 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-INC-REMOVE-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-INC-REMOVE-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 70
+		bank_account: "Assets:Bank"
+		memo: "P1 (will stay)"
+	payment:
+		date: 2026-01-25
+		amount: 25
+		bank_account: "Assets:Bank"
+		memo: "P2 (will be removed)"

--- a/tests/fixtures/q015_inc_remove_v2.txt
+++ b/tests/fixtures/q015_inc_remove_v2.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-INC-REMOVE-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-INC-REMOVE-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 70
+		bank_account: "Assets:Bank"
+		memo: "P1 (will stay)"

--- a/tests/fixtures/q015_oh_bill_export_emits.txt
+++ b/tests/fixtures/q015_oh_bill_export_emits.txt
@@ -1,0 +1,28 @@
+vendor "V001"
+	name: "Supplier Co"
+	currency: CAD
+
+bill "BILL-OH-EXP-100"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Materials"
+		action: "Material"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-OH-EXP-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		memo: "Bill overpaid export-emits"

--- a/tests/fixtures/q015_oh_bill_retarget_nopre_biz.txt
+++ b/tests/fixtures/q015_oh_bill_retarget_nopre_biz.txt
@@ -1,0 +1,29 @@
+vendor "V004"
+	name: "Supplier Delta"
+	currency: CAD
+
+bill "BILL-RT-NOPRE-100"
+	vendor_id: "V004"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Materials"
+		action: "Material"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-RT-NOPRE-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		txn_guid: "{txn_guid}"
+		memo: "Bill retarget without prepayment marker"

--- a/tests/fixtures/q015_oh_bill_retarget_nopre_pre_bank.txt
+++ b/tests/fixtures/q015_oh_bill_retarget_nopre_pre_bank.txt
@@ -1,0 +1,3 @@
+2026-01-10 * "Pre-existing bill payment wire 150 no-prepayment"
+  Assets:Bank  -150.00 CAD
+  Liabilities:Accounts Payable  150.00 CAD

--- a/tests/fixtures/q015_oh_bill_retarget_over_biz.txt
+++ b/tests/fixtures/q015_oh_bill_retarget_over_biz.txt
@@ -1,0 +1,30 @@
+vendor "V003"
+	name: "Supplier Gamma"
+	currency: CAD
+
+bill "BILL-RT-OVER-100"
+	vendor_id: "V003"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Materials"
+		action: "Material"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-RT-OVER-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		txn_guid: "{txn_guid}"
+		prepayment: 50
+		memo: "Bill retarget with $50 prepayment"

--- a/tests/fixtures/q015_oh_bill_retarget_over_pre_bank.txt
+++ b/tests/fixtures/q015_oh_bill_retarget_over_pre_bank.txt
@@ -1,0 +1,3 @@
+2026-01-10 * "Pre-existing bill payment wire 150"
+  Assets:Bank  -150.00 CAD
+  Liabilities:Accounts Payable  150.00 CAD

--- a/tests/fixtures/q015_oh_bill_roundtrip_preserves.txt
+++ b/tests/fixtures/q015_oh_bill_roundtrip_preserves.txt
@@ -1,0 +1,28 @@
+vendor "V002"
+	name: "Supplier Beta"
+	currency: CAD
+
+bill "BILL-OH-RT-110"
+	vendor_id: "V002"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Materials"
+		action: "Material"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 110
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-OH-RT-110"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 160
+		bank_account: "Assets:Bank"
+		memo: "Bill overpaid roundtrip-preserves"

--- a/tests/fixtures/q015_oh_inv_double_roundtrip.txt
+++ b/tests/fixtures/q015_oh_inv_double_roundtrip.txt
@@ -1,0 +1,28 @@
+customer "C003"
+	name: "Gamma Ltd"
+	currency: CAD
+
+invoice "INV-OH-DBL-120"
+	customer_id: "C003"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 120
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-OH-DBL-120"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 170
+		bank_account: "Assets:Bank"
+		memo: "Overpaid double-roundtrip"

--- a/tests/fixtures/q015_oh_inv_export_emits.txt
+++ b/tests/fixtures/q015_oh_inv_export_emits.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-OH-EXP-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-OH-EXP-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		memo: "Overpaid export-emits"

--- a/tests/fixtures/q015_oh_inv_roundtrip_preserves.txt
+++ b/tests/fixtures/q015_oh_inv_roundtrip_preserves.txt
@@ -1,0 +1,28 @@
+customer "C002"
+	name: "Beta Inc"
+	currency: CAD
+
+invoice "INV-OH-RT-110"
+	customer_id: "C002"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 110
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-OH-RT-110"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 160
+		bank_account: "Assets:Bank"
+		memo: "Overpaid roundtrip-preserves"

--- a/tests/fixtures/q015_oh_retarget_exact_biz.txt
+++ b/tests/fixtures/q015_oh_retarget_exact_biz.txt
@@ -1,0 +1,29 @@
+customer "C006"
+	name: "Zeta Co"
+	currency: CAD
+
+invoice "INV-RT-EXACT-100"
+	customer_id: "C006"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-RT-EXACT-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 100
+		bank_account: "Assets:Bank"
+		txn_guid: "{txn_guid}"
+		memo: "Exact retarget"

--- a/tests/fixtures/q015_oh_retarget_exact_pre_bank.txt
+++ b/tests/fixtures/q015_oh_retarget_exact_pre_bank.txt
@@ -1,0 +1,3 @@
+2026-01-10 * "Pre-existing payment 100 exact"
+  Assets:Bank  100.00 CAD
+  Assets:Accounts Receivable  -100.00 CAD

--- a/tests/fixtures/q015_oh_retarget_nopre_biz.txt
+++ b/tests/fixtures/q015_oh_retarget_nopre_biz.txt
@@ -1,0 +1,29 @@
+customer "C005"
+	name: "Epsilon Inc"
+	currency: CAD
+
+invoice "INV-RT-NOPRE-100"
+	customer_id: "C005"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-RT-NOPRE-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		txn_guid: "{txn_guid}"
+		memo: "Trying to retarget oversize tx without prepayment marker"

--- a/tests/fixtures/q015_oh_retarget_nopre_pre_bank.txt
+++ b/tests/fixtures/q015_oh_retarget_nopre_pre_bank.txt
@@ -1,0 +1,4 @@
+2026-01-10 * "Pre-existing wire transfer 150 no-prepayment"
+  Assets:Bank  150.00 CAD
+    memo: "External payment"
+  Assets:Accounts Receivable  -150.00 CAD

--- a/tests/fixtures/q015_oh_retarget_over_biz.txt
+++ b/tests/fixtures/q015_oh_retarget_over_biz.txt
@@ -1,0 +1,30 @@
+customer "C004"
+	name: "Delta Co"
+	currency: CAD
+
+invoice "INV-RT-OVER-100"
+	customer_id: "C004"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-RT-OVER-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		txn_guid: "{txn_guid}"
+		prepayment: 50
+		memo: "External payment, retargeted, $50 prepayment"

--- a/tests/fixtures/q015_oh_retarget_over_pre_bank.txt
+++ b/tests/fixtures/q015_oh_retarget_over_pre_bank.txt
@@ -1,0 +1,4 @@
+2026-01-10 * "Pre-existing wire transfer 150"
+  Assets:Bank  150.00 CAD
+    memo: "External payment"
+  Assets:Accounts Receivable  -150.00 CAD

--- a/tests/fixtures/q015_oh_retarget_under_biz.txt
+++ b/tests/fixtures/q015_oh_retarget_under_biz.txt
@@ -1,0 +1,29 @@
+customer "C007"
+	name: "Eta Ltd"
+	currency: CAD
+
+invoice "INV-RT-PARTIAL-100"
+	customer_id: "C007"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-RT-PARTIAL-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 60
+		bank_account: "Assets:Bank"
+		txn_guid: "{txn_guid}"
+		memo: "Partial via retarget"

--- a/tests/fixtures/q015_oh_retarget_under_pre_bank.txt
+++ b/tests/fixtures/q015_oh_retarget_under_pre_bank.txt
@@ -1,0 +1,3 @@
+2026-01-10 * "Pre-existing partial payment 60"
+  Assets:Bank  60.00 CAD
+  Assets:Accounts Receivable  -60.00 CAD

--- a/tests/fixtures/q015_pr_add_partial_v1.txt
+++ b/tests/fixtures/q015_pr_add_partial_v1.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-PR-ADD-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-PR-ADD-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 60
+		bank_account: "Assets:Bank"
+		memo: "P1"

--- a/tests/fixtures/q015_pr_add_partial_v2.txt
+++ b/tests/fixtures/q015_pr_add_partial_v2.txt
@@ -1,0 +1,33 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-PR-ADD-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-PR-ADD-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 60
+		bank_account: "Assets:Bank"
+		memo: "P1"
+	payment:
+		date: 2026-01-25
+		amount: 40
+		bank_account: "Assets:Bank"
+		memo: "P2"

--- a/tests/fixtures/q015_pr_bill_full_paid.txt
+++ b/tests/fixtures/q015_pr_bill_full_paid.txt
@@ -1,0 +1,28 @@
+vendor "V001"
+	name: "Supplier Co"
+	currency: CAD
+
+bill "BILL-PR-FULL-100"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Materials"
+		action: "Material"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-PR-FULL-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 100
+		bank_account: "Assets:Bank"
+		memo: "Full bill payment"

--- a/tests/fixtures/q015_pr_bill_partial_paid.txt
+++ b/tests/fixtures/q015_pr_bill_partial_paid.txt
@@ -1,0 +1,28 @@
+vendor "V001"
+	name: "Supplier Co"
+	currency: CAD
+
+bill "BILL-PR-PARTIAL-100"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Materials"
+		action: "Material"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-PR-PARTIAL-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 60
+		bank_account: "Assets:Bank"
+		memo: "Bill partial"

--- a/tests/fixtures/q015_pr_inv_full_paid.txt
+++ b/tests/fixtures/q015_pr_inv_full_paid.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-PR-FULL-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-PR-FULL-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 100
+		bank_account: "Assets:Bank"
+		memo: "Full payment"

--- a/tests/fixtures/q015_pr_inv_partial_paid.txt
+++ b/tests/fixtures/q015_pr_inv_partial_paid.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-PR-PARTIAL-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-PR-PARTIAL-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 60
+		bank_account: "Assets:Bank"
+		memo: "Partial 1"

--- a/tests/fixtures/q015_pr_orphan_bill_setup.txt
+++ b/tests/fixtures/q015_pr_orphan_bill_setup.txt
@@ -1,0 +1,28 @@
+vendor "V001"
+	name: "Supplier Co"
+	currency: CAD
+
+bill "BILL-PR-ORPHAN-100"
+	vendor_id: "V001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Materials"
+		action: "Material"
+		account: "Expenses:Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-PR-ORPHAN-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 100
+		bank_account: "Assets:Bank"
+		memo: "Will be orphan"

--- a/tests/fixtures/q015_pr_orphan_inv_setup.txt
+++ b/tests/fixtures/q015_pr_orphan_inv_setup.txt
@@ -1,0 +1,28 @@
+customer "C001"
+	name: "Acme"
+	currency: CAD
+
+invoice "INV-PR-ORPHAN-100"
+	customer_id: "C001"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Service"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-PR-ORPHAN-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 100
+		bank_account: "Assets:Bank"
+		memo: "Will be orphan"

--- a/tests/integration/test_auto_apply_credit.py
+++ b/tests/integration/test_auto_apply_credit.py
@@ -1,0 +1,293 @@
+"""Q-015: invoice/bill-level `auto_apply_credit: true` consumes existing
+pre-payment credit on the same owner via `gncInvoiceAutoApplyPayments`.
+
+Setup (shared across most tests):
+  - INV-001 for $100, paid $150 → bank tx for $150; AR has invoice lot
+    (closed) and prepay lot (open, balance −$50).
+  - INV-002 / BILL-001 / etc. is then imported with `auto_apply_credit: true`.
+
+What we assert:
+  * the flag triggers `inv.AutoApplyPayments()` after PostToAccount,
+  * no new bank tx is created (no `payment:` block in the directive),
+  * the consumed amount is taken from the prepay lot (split-in-place when
+    credit > invoice; whole-split when credit ≤ invoice),
+  * roundtrip emits the flag and re-importing is idempotent,
+  * compose with a cash `payment:` block (credit covers part, bank covers
+    the rest),
+  * bill counterparts behave symmetrically (AP, opposite signs).
+"""
+
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+ACCOUNTS_PATH = 'tests/fixtures/payment_roundtrip_accounts.txt'
+FIXTURES_DIR = Path('tests/fixtures')
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES_DIR / name).read_text()
+
+
+def _setup(runner, tmp_path, kind='invoice'):
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS_PATH])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    primer = ('q015_aac_primer_invoice.txt' if kind == 'invoice'
+              else 'q015_aac_primer_bill.txt')
+    primer_path = tmp_path / 'primer.txt'
+    primer_path.write_text(_fixture(primer))
+    r = runner.invoke(cli, ['import', str(gf), str(primer_path),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    return gf
+
+
+def _import_fixture(runner, gf, fixture_name, tmp_path, alias=None):
+    """Import a fixture by name (re-writes the .txt under tmp_path so
+    `import` can read it inside CliRunner's environment)."""
+    p = tmp_path / (alias or fixture_name)
+    p.write_text(_fixture(fixture_name))
+    return runner.invoke(cli, ['import', str(gf), str(p),
+                               '--include-business-objects'])
+
+
+def _import_text(runner, gf, content, name, tmp_path):
+    p = tmp_path / name
+    p.write_text(content)
+    return runner.invoke(cli, ['import', str(gf), str(p),
+                               '--include-business-objects'])
+
+
+def _export(runner, gf, tmp_path, name):
+    out = tmp_path / name
+    r = runner.invoke(cli, ['export', str(gf), str(out), '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    return out.read_text()
+
+
+def _ar_lot_summary(gf, ar_account='Assets.Accounts Receivable'):
+    from gnucash import GncLot
+
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        def find(a, n):
+            if a.get_full_name() == n:
+                return a
+            for c in a.get_children():
+                r = find(c, n)
+                if r:
+                    return r
+            return None
+        ar = find(repo.book.get_root_account(), ar_account)
+        seen, lots = set(), []
+        for sp in ar.GetSplitList():
+            raw = sp.GetLot()
+            if raw is None or int(raw) in seen:
+                continue
+            seen.add(int(raw))
+            lot = GncLot(instance=raw)
+            lots.append({'closed': lot.is_closed(),
+                         'balance': lot.get_balance().to_double(),
+                         'members': len(list(lot.get_split_list()))})
+        return sorted(lots, key=lambda d: (d['closed'], d['balance']))
+    finally:
+        repo.close()
+
+
+def _bank_tx_count(gf, bank='Assets.Bank'):
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        def find(a, n):
+            if a.get_full_name() == n:
+                return a
+            for c in a.get_children():
+                r = find(c, n)
+                if r:
+                    return r
+            return None
+        b = find(repo.book.get_root_account(), bank)
+        if b is None:
+            return 0
+        return len({sp.GetParent().GetGUID().to_string() for sp in b.GetSplitList()})
+    finally:
+        repo.close()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Invoice — consume credit fully covers the invoice
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_invoice_auto_apply_credit_consumes_partial_credit(tmp_path):
+    """INV-002 for $30 with credit of $50 available — auto-apply
+    consumes $30, leaves $20 still open as residual prepay credit."""
+    runner = CliRunner()
+    gf = _setup(runner, tmp_path, kind='invoice')
+
+    r = _import_fixture(runner, gf, 'q015_aac_inv002_partial_credit.txt', tmp_path)
+    assert r.exit_code == 0, f'import: {r.output}'
+    time.sleep(1)
+
+    # Expect: no new bank tx, INV-002's lot closed (credit consumed),
+    # residual prepay lot open with -$20.
+    assert _bank_tx_count(gf) == 1, 'auto-apply must not create a new bank tx'
+    lots = _ar_lot_summary(gf)
+    assert len(lots) == 3, f'expected 3 AR lots (INV-001, ex-prepay-now-closed, residual). got {lots}'
+    closed = [lot for lot in lots if lot['closed']]
+    open_ = [lot for lot in lots if not lot['closed']]
+    assert len(closed) == 2, f'two closed lots (INV-001 + INV-002 ex-prepay). got: {lots}'
+    assert all(lot['balance'] == 0.0 for lot in closed)
+    assert len(open_) == 1 and open_[0]['balance'] == -20.0, (
+        f'residual prepay lot must be open at -20. got: {open_}'
+    )
+
+
+def test_invoice_auto_apply_credit_over_consumes_partial_pay(tmp_path):
+    """INV-002 for $200 with credit of $50 available — credit < invoice.
+    Auto-apply consumes the full $50, INV-002 lot still open at +$150."""
+    runner = CliRunner()
+    gf = _setup(runner, tmp_path, kind='invoice')
+
+    r = _import_fixture(runner, gf, 'q015_aac_inv002_over_consumes.txt', tmp_path)
+    assert r.exit_code == 0, f'import: {r.output}'
+    time.sleep(1)
+
+    assert _bank_tx_count(gf) == 1
+    lots = _ar_lot_summary(gf)
+    # Expect: INV-001 closed; ex-prepay lot now contains the full -50 + INV-002 partial +50? Actually:
+    #   - INV-001 closed at 0
+    #   - ex-prepay lot closed at 0 (had -50; INV-002 posting +200 added; lot now needs balance 0;
+    #     GnuCash splits invoice posting? or moves entire -50 into INV-002 lot?)
+    # The exact lot reorg is what AutoApplyPayments decides — at minimum:
+    #   * INV-002 must reflect $150 remaining,
+    #   * no prepay lot still open with -50 (the credit was fully consumed).
+    open_lots = [lot for lot in lots if not lot['closed']]
+    open_balances = sorted(lot['balance'] for lot in open_lots)
+    assert -50.0 not in open_balances, (
+        f'-50 prepay lot must have been consumed entirely. got: {lots}'
+    )
+    # The invoice (or what remains of it) must show a net +150 unpaid.
+    open_positive = [lot for lot in open_lots if lot['balance'] > 0]
+    assert open_positive, f'expected an open lot for the unpaid balance. got: {lots}'
+    assert sum(lot['balance'] for lot in open_positive) == 150.0
+
+
+def test_invoice_auto_apply_credit_roundtrip_emits_flag_and_idempotent(tmp_path):
+    """After auto-apply, export must emit `auto_apply_credit: true`; re-import
+    is unchanged (no further consumption, no drift)."""
+    runner = CliRunner()
+    gf = _setup(runner, tmp_path, kind='invoice')
+
+    r = _import_fixture(runner, gf, 'q015_aac_inv002_partial_credit.txt', tmp_path)
+    assert r.exit_code == 0
+    time.sleep(1)
+    initial_lots = _ar_lot_summary(gf)
+
+    exported = _export(runner, gf, tmp_path, 'r1.txt')
+    # Exporter must surface the flag on INV-002.
+    assert 'auto_apply_credit: true' in exported, (
+        f'exporter must emit auto_apply_credit flag. exported:\n{exported}'
+    )
+
+    r = _import_text(runner, gf, exported, 'r1_in.txt', tmp_path)
+    assert r.exit_code == 0, f're-import: {r.output}'
+    final_lots = _ar_lot_summary(gf)
+    assert final_lots == initial_lots, (
+        f'roundtrip drifted.\nbefore: {initial_lots}\nafter:  {final_lots}'
+    )
+    assert _bank_tx_count(gf) == 1, 'roundtrip must not add a bank tx'
+
+
+def test_invoice_auto_apply_credit_composes_with_cash_payment(tmp_path):
+    """INV-002 for $80 with credit of $50 + an additional cash payment of $30 →
+    invoice closes via credit ($50) + bank payment ($30)."""
+    runner = CliRunner()
+    gf = _setup(runner, tmp_path, kind='invoice')
+
+    r = _import_fixture(runner, gf, 'q015_aac_inv002_composed_cash.txt', tmp_path)
+    assert r.exit_code == 0, f'import: {r.output}'
+    time.sleep(1)
+
+    assert _bank_tx_count(gf) == 2, (
+        f'expect 2 bank txs (original $150 + new $30). got {_bank_tx_count(gf)}'
+    )
+    lots = _ar_lot_summary(gf)
+    open_lots = [lot for lot in lots if not lot['closed']]
+    assert open_lots == [], (
+        f'invoice + credit + cash must close all lots; left open: {open_lots}'
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Bill — symmetric overpayment credit consumption
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_bill_auto_apply_credit_consumes_partial_credit(tmp_path):
+    """BILL-002 for $30 against existing vendor credit of $50 → consume
+    $30, leaves $20 credit residual."""
+    runner = CliRunner()
+    gf = _setup(runner, tmp_path, kind='bill')
+
+    r = _import_fixture(runner, gf, 'q015_aac_bill002_partial_credit.txt', tmp_path)
+    assert r.exit_code == 0, f'import: {r.output}'
+    time.sleep(1)
+
+    assert _bank_tx_count(gf) == 1
+    lots = _ar_lot_summary(gf, ar_account='Liabilities.Accounts Payable')
+    closed = [lot for lot in lots if lot['closed']]
+    open_ = [lot for lot in lots if not lot['closed']]
+    assert len(closed) == 2 and all(lot['balance'] == 0.0 for lot in closed)
+    assert len(open_) == 1 and open_[0]['balance'] == 20.0, (
+        f'bill prepay residual must be open at +20 (AP sign). got: {open_}'
+    )
+
+
+def test_bill_auto_apply_credit_roundtrip_emits_flag(tmp_path):
+    runner = CliRunner()
+    gf = _setup(runner, tmp_path, kind='bill')
+
+    r = _import_fixture(runner, gf, 'q015_aac_bill002_partial_credit.txt', tmp_path)
+    assert r.exit_code == 0, f'import: {r.output}'
+    time.sleep(1)
+
+    exported = _export(runner, gf, tmp_path, 'r1.txt')
+    # The flag on BILL-002 must round-trip.
+    bill_block_starts = [i for i, ln in enumerate(exported.splitlines())
+                         if ln.startswith('bill "BILL-002"')]
+    assert bill_block_starts, 'BILL-002 missing from export'
+    start = bill_block_starts[0]
+    bill_block = '\n'.join(exported.splitlines()[start:start + 30])
+    assert 'auto_apply_credit: true' in bill_block, (
+        f'BILL-002 export must emit auto_apply_credit. block:\n{bill_block}'
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Negative control
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_invoice_no_flag_does_not_consume_credit(tmp_path):
+    """Without the flag, INV-002 stays open at its full amount; no credit consumed."""
+    runner = CliRunner()
+    gf = _setup(runner, tmp_path, kind='invoice')
+
+    r = _import_fixture(runner, gf, 'q015_aac_inv002_no_flag.txt', tmp_path)
+    assert r.exit_code == 0
+    time.sleep(1)
+
+    lots = _ar_lot_summary(gf)
+    open_lots = [lot for lot in lots if not lot['closed']]
+    open_balances = sorted(lot['balance'] for lot in open_lots)
+    assert open_balances == [-50.0, 30.0], (
+        f'without auto_apply_credit, prepay -50 and INV-002 +30 must both stay open. '
+        f'got: {open_balances}'
+    )

--- a/tests/integration/test_find_prepayments.py
+++ b/tests/integration/test_find_prepayments.py
@@ -1,0 +1,146 @@
+"""Q-015: `find-prepayments` CLI lists open customer/vendor credits
+that aren't attached to any invoice/bill (i.e. pre-payment lots produced
+by overpayment or standalone payments that haven't been applied yet).
+
+Read-only command, parallel to Q-014's `find-orphan-payments`:
+  - whole-book sweep by default
+  - `--customer C001` filters to that customer's credits
+  - `--vendor V001` filters to that vendor's credits
+  - reports per-credit: owner type + id + name, currency + amount, source
+    bank tx GUID + date, ar/ap account
+"""
+
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+ACCOUNTS_PATH = 'tests/fixtures/payment_roundtrip_accounts.txt'
+FIXTURES_DIR = Path('tests/fixtures')
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES_DIR / name).read_text()
+
+
+def _setup_empty(runner, tmp_path):
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS_PATH])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    return gf
+
+
+def _import_biz_fixture(runner, gf, fixture_name, tmp_path, alias=None):
+    p = tmp_path / (alias or fixture_name)
+    p.write_text(_fixture(fixture_name))
+    r = runner.invoke(cli, ['import', str(gf), str(p),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f'{fixture_name}: {r.output}'
+    time.sleep(1)
+
+
+def _credit_count(output):
+    """Count guid: lines in find-prepayments output (one per credit)."""
+    if 'No pre-payment' in output or 'No prepayment' in output:
+        return 0
+    return sum(1 for line in output.splitlines() if line.strip().startswith('guid:'))
+
+
+# ──────────────────────────────────────────────────────────────────────────
+
+def test_find_prepayments_empty_book_reports_zero(tmp_path):
+    runner = CliRunner()
+    gf = _setup_empty(runner, tmp_path)
+    r = runner.invoke(cli, ['find-prepayments', str(gf)])
+    assert r.exit_code == 0, f'find-prepayments: {r.output}'
+    assert _credit_count(r.output) == 0
+
+
+def test_find_prepayments_lists_single_customer_credit(tmp_path):
+    """INV-FP-SINGLE-100 $100 paid $150 → one $50 customer credit."""
+    runner = CliRunner()
+    gf = _setup_empty(runner, tmp_path)
+    _import_biz_fixture(runner, gf, 'q015_fp_single_cust_credit.txt', tmp_path)
+    r = runner.invoke(cli, ['find-prepayments', str(gf)])
+    assert r.exit_code == 0, r.output
+    assert _credit_count(r.output) == 1, (
+        f'expected 1 credit (C001 -50). output:\n{r.output}'
+    )
+    # Output must surface customer id and the credit amount
+    assert 'C001' in r.output and ('50' in r.output or '50.00' in r.output), r.output
+
+
+def test_find_prepayments_lists_single_vendor_credit(tmp_path):
+    """BILL-FP-SINGLE-100 $100 paid $150 → one $50 vendor credit."""
+    runner = CliRunner()
+    gf = _setup_empty(runner, tmp_path)
+    _import_biz_fixture(runner, gf, 'q015_fp_single_vendor_credit.txt', tmp_path)
+    r = runner.invoke(cli, ['find-prepayments', str(gf)])
+    assert r.exit_code == 0, r.output
+    assert _credit_count(r.output) == 1
+    assert 'V001' in r.output and ('50' in r.output or '50.00' in r.output), r.output
+
+
+def test_find_prepayments_multi_customer_credits(tmp_path):
+    """C001 INV-FP-MULTI-100 $100/$150 + C002 INV-FP-MULTI-200 $200/$220."""
+    runner = CliRunner()
+    gf = _setup_empty(runner, tmp_path)
+    _import_biz_fixture(runner, gf, 'q015_fp_multi_cust1.txt', tmp_path)
+    _import_biz_fixture(runner, gf, 'q015_fp_multi_cust2.txt', tmp_path)
+    r = runner.invoke(cli, ['find-prepayments', str(gf)])
+    assert r.exit_code == 0, r.output
+    assert _credit_count(r.output) == 2, (
+        f'expected 2 credits (C001 -50, C002 -20). output:\n{r.output}'
+    )
+    assert 'C001' in r.output and 'C002' in r.output
+
+
+def test_find_prepayments_customer_filter(tmp_path):
+    """Same two-customer book; --customer C001 must filter to one credit."""
+    runner = CliRunner()
+    gf = _setup_empty(runner, tmp_path)
+    _import_biz_fixture(runner, gf, 'q015_fp_multi_cust1.txt', tmp_path)
+    _import_biz_fixture(runner, gf, 'q015_fp_multi_cust2.txt', tmp_path)
+    r = runner.invoke(cli, ['find-prepayments', str(gf), '--customer', 'C001'])
+    assert r.exit_code == 0, r.output
+    assert _credit_count(r.output) == 1, (
+        f'--customer C001 must filter to one credit. output:\n{r.output}'
+    )
+    assert 'C001' in r.output
+    assert 'C002' not in r.output
+
+
+def test_find_prepayments_vendor_filter(tmp_path):
+    """V001 BILL-FP-FILTER-100 $100/$150 + V002 BILL-FP-FILTER-200 $200/$230;
+    --vendor V002 must filter to one credit."""
+    runner = CliRunner()
+    gf = _setup_empty(runner, tmp_path)
+    _import_biz_fixture(runner, gf, 'q015_fp_vendor_filter_v1.txt', tmp_path)
+    _import_biz_fixture(runner, gf, 'q015_fp_vendor_filter_v2.txt', tmp_path)
+    r = runner.invoke(cli, ['find-prepayments', str(gf), '--vendor', 'V002'])
+    assert r.exit_code == 0, r.output
+    assert _credit_count(r.output) == 1, (
+        f'--vendor V002 must filter to one credit. output:\n{r.output}'
+    )
+    assert 'V002' in r.output
+    assert 'V001' not in r.output
+
+
+def test_find_prepayments_after_partial_consume_shows_residual(tmp_path):
+    """C001 INV-FP-RESIDUAL-100 $100/$150 → $50 credit, then INV-FP-RESIDUAL-30
+    with auto_apply_credit consumes $30, leaving $20 residual."""
+    runner = CliRunner()
+    gf = _setup_empty(runner, tmp_path)
+    _import_biz_fixture(runner, gf, 'q015_fp_residual_primer.txt', tmp_path)
+    _import_biz_fixture(runner, gf, 'q015_fp_residual_inv2.txt', tmp_path)
+
+    r = runner.invoke(cli, ['find-prepayments', str(gf)])
+    assert r.exit_code == 0, r.output
+    assert _credit_count(r.output) == 1
+    # The residual is $20
+    assert '20' in r.output or '20.00' in r.output, (
+        f'residual $20 credit must be reported. output:\n{r.output}'
+    )

--- a/tests/integration/test_importer_destructive_orphan.py
+++ b/tests/integration/test_importer_destructive_orphan.py
@@ -1,0 +1,337 @@
+"""Q-015: every importer code path that internally calls `Unpost(False)`
+on a paid invoice/bill must surface the resulting orphan(s) to the user.
+
+The `unpost-invoices` / `unpost-bills` CLI ships an orphan-payment
+warning (Q-014). The same `Unpost(False)` call is made by the importer
+in four other paths:
+
+* Q-010 minimal-unpost path (`posted: none` in re-imported plaintext)
+* destructive rebuild path triggered by: entry modify/add/remove,
+  posted-block change, payment modify, payment remove
+
+In every one of those, the importer currently calls `Unpost(False)`
+silently. These tests assert:
+
+1. **Each destructive path on a paid record emits an orphan warning**
+   (mentions the original bank-tx GUID, the orphan amount, and the
+   originating invoice/bill ID) so the user can act before re-pay
+   creates a duplicate.
+2. **Re-running the same destructive import is idempotent** — the
+   orphan count after running the same modified import twice is the
+   same as after running it once. The fix must not let orphans
+   accumulate on repeat.
+3. **Negative controls**: an UNPAID invoice/bill re-imported with the
+   same destructive change does NOT emit an orphan warning (there
+   was nothing to orphan).
+4. **Negative control**: an identical re-import (`unchanged` path)
+   does NOT emit an orphan warning.
+
+When these tests pass, every importer-side unpost is visible to the
+user with the same level of detail as the CLI `unpost-invoices`
+warning.
+"""
+
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+ACCOUNTS_PATH = 'tests/fixtures/payment_roundtrip_accounts.txt'
+FIXTURES_DIR = Path('tests/fixtures')
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES_DIR / name).read_text()
+
+
+# -- helpers --------------------------------------------------------------
+
+
+def _setup_book(runner, tmp_path):
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS_PATH])
+    assert r.exit_code == 0, f'accounts: {r.output}'
+    time.sleep(1)
+    return gf
+
+
+def _import(runner, gf, fixture_name, tmp_path, alias=None):
+    p = tmp_path / (alias or fixture_name)
+    p.write_text(_fixture(fixture_name))
+    return runner.invoke(cli, ['import', str(gf), str(p),
+                               '--include-business-objects'])
+
+
+def _orphan_count(runner, gf):
+    r = runner.invoke(cli, ['find-orphan-payments', str(gf)])
+    assert r.exit_code == 0, f'find-orphan-payments: {r.output}'
+    if 'No orphan' in r.output:
+        return 0
+    return sum(1 for line in r.output.splitlines() if line.strip().startswith('guid:'))
+
+
+def _bank_tx_guids(gf, account_name='Assets.Bank'):
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        def find(acct, name):
+            if acct.get_full_name() == name:
+                return acct
+            for child in acct.get_children():
+                r = find(child, name)
+                if r:
+                    return r
+            return None
+        bank = find(repo.book.get_root_account(), account_name)
+        if bank is None:
+            return set()
+        return {sp.GetParent().GetGUID().to_string() for sp in bank.GetSplitList()}
+    finally:
+        repo.close()
+
+
+def _assert_orphan_warning(output, payment_guid):
+    """Per Q-014's per-record warning shape, the user must see the
+    payment GUID and the word 'orphan' (or equivalent) so they can
+    act. Be lenient on phrasing — match GUID literally and require
+    *some* orphan-related word nearby."""
+    msg = output.lower()
+    assert payment_guid in output, (
+        f"Importer output must mention the orphaned payment GUID "
+        f"{payment_guid!r}. Output:\n{output}"
+    )
+    assert ('orphan' in msg or 'stranded' in msg or 'no longer linked' in msg), (
+        f"Importer output must use the word 'orphan' (or equivalent) "
+        f"when warning about a payment that just got detached from a "
+        f"lot. Output:\n{output}"
+    )
+
+
+# -- invoice: each destructive path warns + does not duplicate orphans ----
+
+def test_reimport_entry_modify_on_paid_invoice_warns_and_does_not_duplicate(tmp_path):
+    """INV-DEST-EMOD-100: modify the entry description on a paid invoice
+    must trigger destructive rebuild + orphan warning; re-running it must
+    not accumulate orphans."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import(runner, gf, 'q015_dest_inv_entrymod_v1.txt', tmp_path, alias='v1.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+    original_payment_guids = _bank_tx_guids(gf)
+    assert len(original_payment_guids) == 1
+
+    r = _import(runner, gf, 'q015_dest_inv_entrymod_v2.txt', tmp_path, alias='v2.txt')
+    assert r.exit_code == 0, f'v2: {r.output}'
+    _assert_orphan_warning(r.output, next(iter(original_payment_guids)))
+    orphans_after_one = _orphan_count(runner, gf)
+    assert orphans_after_one >= 1
+    time.sleep(1)
+
+    # Idempotency: re-running the SAME v2 must not produce more orphans.
+    r = _import(runner, gf, 'q015_dest_inv_entrymod_v2.txt', tmp_path,
+                alias='v2_again.txt')
+    assert r.exit_code == 0
+    assert _orphan_count(runner, gf) == orphans_after_one, (
+        f'orphan count drifted on idempotent re-run: '
+        f'{orphans_after_one} -> {_orphan_count(runner, gf)}'
+    )
+
+
+def test_reimport_entry_added_on_paid_invoice_warns(tmp_path):
+    """INV-DEST-EADD-105: adding a second entry to a paid invoice triggers
+    destructive rebuild and an orphan warning."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import(runner, gf, 'q015_dest_inv_entryadd_v1.txt', tmp_path, alias='v1.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+    original_payment_guid = next(iter(_bank_tx_guids(gf)))
+
+    r = _import(runner, gf, 'q015_dest_inv_entryadd_v2.txt', tmp_path, alias='v2.txt')
+    assert r.exit_code == 0
+    _assert_orphan_warning(r.output, original_payment_guid)
+
+
+def test_reimport_entry_removed_on_paid_invoice_warns(tmp_path):
+    """INV-DEST-ERM-110: removing an entry from a paid invoice triggers
+    destructive rebuild and an orphan warning."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import(runner, gf, 'q015_dest_inv_entryrm_v1.txt', tmp_path, alias='v1.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+    original_payment_guid = next(iter(_bank_tx_guids(gf)))
+
+    r = _import(runner, gf, 'q015_dest_inv_entryrm_v2.txt', tmp_path, alias='v2.txt')
+    assert r.exit_code == 0
+    _assert_orphan_warning(r.output, original_payment_guid)
+
+
+def test_reimport_posted_block_change_on_paid_invoice_warns(tmp_path):
+    """INV-DEST-POSTCHG-115: changing the posted memo triggers destructive
+    rebuild and an orphan warning."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import(runner, gf, 'q015_dest_inv_postedchg_v1.txt', tmp_path, alias='v1.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+    original_payment_guid = next(iter(_bank_tx_guids(gf)))
+
+    r = _import(runner, gf, 'q015_dest_inv_postedchg_v2.txt', tmp_path, alias='v2.txt')
+    assert r.exit_code == 0
+    _assert_orphan_warning(r.output, original_payment_guid)
+
+
+def test_reimport_posted_none_on_paid_invoice_warns(tmp_path):
+    """INV-DEST-POSTNONE-120: Q-010 minimal-unpost path — explicit user
+    request to unpost via re-import. Same orphan trap as `unpost-invoices`
+    CLI."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import(runner, gf, 'q015_dest_inv_postnone_v1.txt', tmp_path, alias='v1.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+    original_payment_guid = next(iter(_bank_tx_guids(gf)))
+
+    r = _import(runner, gf, 'q015_dest_inv_postnone_v2.txt', tmp_path, alias='v2.txt')
+    assert r.exit_code == 0, f'v2: {r.output}'
+    _assert_orphan_warning(r.output, original_payment_guid)
+
+
+def test_reimport_payment_field_modified_on_paid_invoice_warns(tmp_path):
+    """INV-DEST-PMOD-125: changing a payment memo triggers destructive
+    rebuild and an orphan warning."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import(runner, gf, 'q015_dest_inv_paymemo_v1.txt', tmp_path, alias='v1.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+    original_payment_guid = next(iter(_bank_tx_guids(gf)))
+
+    r = _import(runner, gf, 'q015_dest_inv_paymemo_v2.txt', tmp_path, alias='v2.txt')
+    assert r.exit_code == 0
+    _assert_orphan_warning(r.output, original_payment_guid)
+
+
+def test_reimport_payment_removed_on_paid_invoice_warns(tmp_path):
+    """INV-DEST-PRM-130: removing one of two payments triggers destructive
+    rebuild and an orphan warning."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import(runner, gf, 'q015_dest_inv_payrm_v1.txt', tmp_path, alias='v1.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+    payment_guids = _bank_tx_guids(gf)
+    assert len(payment_guids) == 2
+
+    r = _import(runner, gf, 'q015_dest_inv_payrm_v2.txt', tmp_path, alias='v2.txt')
+    assert r.exit_code == 0
+    # The removed payment ($45) becomes orphan-eligible; ANY of the
+    # original payment GUIDs is acceptable, since at least one survived
+    # the rebuild and stranded on the bank side.
+    found_any = any(g in r.output for g in payment_guids)
+    assert found_any, (
+        f'orphan warning must mention at least one of the original payment '
+        f'GUIDs {payment_guids}. Output:\n{r.output}'
+    )
+    assert 'orphan' in r.output.lower() or 'stranded' in r.output.lower()
+
+
+# -- bill counterparts ----------------------------------------------------
+
+def test_reimport_entry_modify_on_paid_bill_warns(tmp_path):
+    """BILL-DEST-EMOD-140: bill entry modify triggers destructive rebuild
+    and orphan warning."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import(runner, gf, 'q015_dest_bill_entrymod_v1.txt', tmp_path, alias='v1.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+    original_payment_guid = next(iter(_bank_tx_guids(gf)))
+
+    r = _import(runner, gf, 'q015_dest_bill_entrymod_v2.txt', tmp_path, alias='v2.txt')
+    assert r.exit_code == 0
+    _assert_orphan_warning(r.output, original_payment_guid)
+
+
+def test_reimport_posted_none_on_paid_bill_warns(tmp_path):
+    """BILL-DEST-POSTNONE-145: bill posted:none re-import triggers orphan
+    warning."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import(runner, gf, 'q015_dest_bill_postnone_v1.txt', tmp_path, alias='v1.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+    original_payment_guid = next(iter(_bank_tx_guids(gf)))
+
+    r = _import(runner, gf, 'q015_dest_bill_postnone_v2.txt', tmp_path, alias='v2.txt')
+    assert r.exit_code == 0
+    _assert_orphan_warning(r.output, original_payment_guid)
+
+
+# -- negative controls ----------------------------------------------------
+
+def test_reimport_entry_modify_on_unpaid_invoice_does_not_warn(tmp_path):
+    """INV-DEST-UNPAID-150: if there are no payments to orphan, the
+    destructive rebuild should run quietly (no orphan warning)."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import(runner, gf, 'q015_dest_unpaid_v1.txt', tmp_path, alias='v1.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+
+    r = _import(runner, gf, 'q015_dest_unpaid_v2.txt', tmp_path, alias='v2.txt')
+    assert r.exit_code == 0
+    assert 'orphan' not in r.output.lower(), (
+        f"Unpaid invoice re-import must NOT mention 'orphan'. Output:\n{r.output}"
+    )
+
+
+def test_identical_reimport_does_not_warn(tmp_path):
+    """INV-DEST-IDENT-155: the `unchanged` path doesn't call Unpost — must
+    be silent on orphans."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import(runner, gf, 'q015_dest_identical.txt', tmp_path, alias='v1.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+
+    r = _import(runner, gf, 'q015_dest_identical.txt', tmp_path, alias='v1_again.txt')
+    assert r.exit_code == 0
+    assert 'orphan' not in r.output.lower(), (
+        f"Identical re-import (unchanged path) must NOT mention 'orphan'. "
+        f"Output:\n{r.output}"
+    )
+
+
+def test_add_payment_fast_path_does_not_warn(tmp_path):
+    """INV-DEST-ADDPAY-160: Q-015 add-payment fast path doesn't call
+    Unpost — must be silent on orphans."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import(runner, gf, 'q015_dest_addpay_v1.txt', tmp_path, alias='v1.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+
+    r = _import(runner, gf, 'q015_dest_addpay_v2.txt', tmp_path, alias='v2.txt')
+    assert r.exit_code == 0
+    assert 'orphan' not in r.output.lower(), (
+        f"Q-015 add-payment fast path must NOT mention 'orphan'. "
+        f"Output:\n{r.output}"
+    )

--- a/tests/integration/test_incremental_payment_reimport.py
+++ b/tests/integration/test_incremental_payment_reimport.py
@@ -1,0 +1,276 @@
+"""Q-015: incremental payment re-import preserves GUIDs and bank txs.
+
+When the user re-imports a posted invoice/bill whose only difference vs.
+the existing record is "K additional `payment:` blocks appended at the
+tail", the importer takes a fast path:
+
+* no Unpost, so the posting transaction is preserved (same GUID)
+* no entry rebuild, so entry GUIDs are preserved
+* existing payment bank transactions are untouched (same GUIDs, same
+  splits in the same lot — no orphans)
+* the trailing K payment directives are applied via `ApplyPayment` on the
+  still-posted invoice, adding exactly K new bank transactions
+
+Any other shape of payment-list diff (count equal but a field changed,
+existing payment removed, payment field modified) still falls through to
+the destructive rebuild path the test suite already covers.
+"""
+
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+ACCOUNTS_PATH = 'tests/fixtures/payment_roundtrip_accounts.txt'
+FIXTURES_DIR = Path('tests/fixtures')
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES_DIR / name).read_text()
+
+
+def _setup_book(runner, tmp_path):
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS_PATH])
+    assert r.exit_code == 0, f'accounts import: {r.output}'
+    time.sleep(1)
+    return gf
+
+
+def _import_biz_fixture(runner, gf, fixture_name, tmp_path, alias=None):
+    p = tmp_path / (alias or fixture_name)
+    p.write_text(_fixture(fixture_name))
+    return runner.invoke(cli, ['import', str(gf), str(p),
+                               '--include-business-objects'])
+
+
+def _snapshot(gf, business_id='INV-001', is_bill=False):
+    """Return posting/entry GUIDs and bank-tx state for an invoice or bill."""
+    from gnucash import Split
+    from gnucash.gnucash_core_c import gncInvoiceGetInvoiceFromTxn
+
+    from repositories.gnucash_repository import GnuCashRepository
+    from services.gnucash_importer import _find_bills_by_id, _find_invoices_by_id
+
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        book = repo.book
+        lookups = _find_bills_by_id(book, business_id) if is_bill else _find_invoices_by_id(book, business_id)
+        assert lookups, f"{'bill' if is_bill else 'invoice'} {business_id} not found"
+        inv = lookups[0]
+        posting_txn = inv.GetPostedTxn()
+        posting_guid = posting_txn.GetGUID().to_string() if posting_txn else None
+        entries = list(inv.GetEntries())
+        entry_guids = sorted(e.GetGUID().to_string() for e in entries)
+
+        lot = inv.GetPostedLot()
+        lot_payment_tx_guids = []
+        if lot is not None:
+            for raw in lot.get_split_list():
+                s = Split(instance=raw)
+                tx = s.GetParent()
+                if tx is None:
+                    continue
+                if gncInvoiceGetInvoiceFromTxn(tx.instance) is not None:
+                    continue  # posting tx
+                lot_payment_tx_guids.append(tx.GetGUID().to_string())
+
+        def find(acct, name):
+            if acct.get_full_name() == name:
+                return acct
+            for child in acct.get_children():
+                r = find(child, name)
+                if r:
+                    return r
+            return None
+
+        bank = find(book.get_root_account(), 'Assets.Bank')
+        bank_tx = {}
+        if bank is not None:
+            for split in bank.GetSplitList():
+                tx = split.GetParent()
+                bank_tx[tx.GetGUID().to_string()] = {
+                    'date': tx.GetDate().strftime('%Y-%m-%d'),
+                    'amount': split.GetAmount().to_double(),
+                }
+        return {
+            'posting_guid': posting_guid,
+            'entry_guids': entry_guids,
+            'lot_payment_tx_guids': sorted(lot_payment_tx_guids),
+            'bank_tx_by_guid': bank_tx,
+        }
+    finally:
+        repo.close()
+
+
+# -- tests ----------------------------------------------------------------
+
+def test_invoice_adding_partial_payment_preserves_posting_and_entry_guids(tmp_path):
+    """INV-INC-ADD-100: re-import adds a second `payment:` block. Posting tx
+    + entry GUIDs must be unchanged."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_biz_fixture(runner, gf, 'q015_inc_add_inv_v1.txt', tmp_path)
+    assert r.exit_code == 0, f'v1: {r.output}'
+    time.sleep(1)
+    snap1 = _snapshot(gf, business_id='INV-INC-ADD-100')
+
+    r = _import_biz_fixture(runner, gf, 'q015_inc_add_inv_v2.txt', tmp_path)
+    assert r.exit_code == 0, f'v2: {r.output}'
+    snap2 = _snapshot(gf, business_id='INV-INC-ADD-100')
+
+    assert snap2['posting_guid'] == snap1['posting_guid'], (
+        f"Posting GUID must NOT change on add-payment re-import. "
+        f"Before {snap1['posting_guid']}, after {snap2['posting_guid']}"
+    )
+    assert snap2['entry_guids'] == snap1['entry_guids'], (
+        f"Entry GUIDs must NOT change. Before {snap1['entry_guids']}, "
+        f"after {snap2['entry_guids']}"
+    )
+
+
+def test_invoice_adding_partial_payment_does_not_orphan_existing_bank_tx(tmp_path):
+    """INV-INC-ADD-100: the original $60 bank transaction must be in the lot
+    AFTER the re-import (same GUID), and no orphan must be left behind."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_biz_fixture(runner, gf, 'q015_inc_add_inv_v1.txt', tmp_path)
+    assert r.exit_code == 0, f'v1: {r.output}'
+    time.sleep(1)
+    snap1 = _snapshot(gf, business_id='INV-INC-ADD-100')
+    original_payment_guid = snap1['lot_payment_tx_guids'][0]
+
+    r = _import_biz_fixture(runner, gf, 'q015_inc_add_inv_v2.txt', tmp_path)
+    assert r.exit_code == 0, f'v2: {r.output}'
+    snap2 = _snapshot(gf, business_id='INV-INC-ADD-100')
+
+    assert original_payment_guid in snap2['lot_payment_tx_guids'], (
+        f"Original $60 bank tx {original_payment_guid} must remain attached "
+        f"to the lot. Lot now contains: {snap2['lot_payment_tx_guids']}"
+    )
+    assert len(snap2['lot_payment_tx_guids']) == 2, (
+        f"Lot should hold exactly two payment txs after the add. "
+        f"Got: {snap2['lot_payment_tx_guids']}"
+    )
+    assert len(snap2['bank_tx_by_guid']) == 2, (
+        f"Bank account should hold exactly 2 transactions (original $60 + "
+        f"new $40), not duplicates. Got {len(snap2['bank_tx_by_guid'])}: "
+        f"{snap2['bank_tx_by_guid']}"
+    )
+    new_guids = set(snap2['bank_tx_by_guid']) - set(snap1['bank_tx_by_guid'])
+    assert len(new_guids) == 1, (
+        f"Exactly one new bank tx (the $40) must be created. "
+        f"new_guids={new_guids}"
+    )
+
+
+def test_invoice_repeated_identical_reimport_is_unchanged(tmp_path):
+    """INV-INC-IDENT-100: re-importing the same file (no new payments)
+    must hit the existing `unchanged` fast path, not the new add-payment
+    fast path."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_biz_fixture(runner, gf, 'q015_inc_identical.txt', tmp_path,
+                            alias='v1.txt')
+    assert r.exit_code == 0, f'v1: {r.output}'
+    time.sleep(1)
+    snap1 = _snapshot(gf, business_id='INV-INC-IDENT-100')
+
+    r = _import_biz_fixture(runner, gf, 'q015_inc_identical.txt', tmp_path,
+                            alias='v1_again.txt')
+    assert r.exit_code == 0, f'v1 second import: {r.output}'
+    assert 'unchanged' in r.output, (
+        f"Second import of identical fixture must report 'unchanged'. "
+        f"Got:\n{r.output}"
+    )
+    snap2 = _snapshot(gf, business_id='INV-INC-IDENT-100')
+    assert snap1 == snap2, 'snapshots must be identical after no-op re-import'
+
+
+def test_invoice_modifying_existing_payment_memo_still_uses_destructive_rebuild(tmp_path):
+    """INV-INC-MEMO-100: changing an existing payment's memo is NOT
+    'adding payments at the tail'; the fast path must NOT fire. The
+    rebuild path runs as before (and produces an orphan — that's the
+    existing Q-014 trap, separate from Q-015). This test guards against
+    the fast-path classifier being too permissive."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_biz_fixture(runner, gf, 'q015_inc_memo_v1.txt', tmp_path)
+    assert r.exit_code == 0, f'v1: {r.output}'
+    time.sleep(1)
+    snap1 = _snapshot(gf, business_id='INV-INC-MEMO-100')
+
+    r = _import_biz_fixture(runner, gf, 'q015_inc_memo_v2.txt', tmp_path)
+    assert r.exit_code == 0, f'v2: {r.output}'
+    snap2 = _snapshot(gf, business_id='INV-INC-MEMO-100')
+
+    # The fast path MUST NOT fire — that would silently mishandle the
+    # memo change. The classifier returns False, the rebuild path runs,
+    # so the posting GUID changes.
+    assert snap2['posting_guid'] != snap1['posting_guid'], (
+        "Modifying an existing payment's memo must take the destructive "
+        "rebuild path (posting GUID changes), NOT the Q-015 fast path. "
+        "If this assertion fires, the classifier is too permissive."
+    )
+
+
+def test_invoice_removing_payment_via_reimport_still_uses_destructive_rebuild(tmp_path):
+    """INV-INC-REMOVE-100: directive has FEWER payments than existing.
+    Q-015's fast path is strictly 'add at tail'; removal is out of scope
+    and must still take the rebuild path."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_biz_fixture(runner, gf, 'q015_inc_remove_v1.txt', tmp_path)
+    assert r.exit_code == 0, f'v1: {r.output}'
+    time.sleep(1)
+    snap1 = _snapshot(gf, business_id='INV-INC-REMOVE-100')
+
+    r = _import_biz_fixture(runner, gf, 'q015_inc_remove_v2.txt', tmp_path)
+    assert r.exit_code == 0, f'v2: {r.output}'
+    snap2 = _snapshot(gf, business_id='INV-INC-REMOVE-100')
+
+    assert snap2['posting_guid'] != snap1['posting_guid'], (
+        'Removing a payment must take the rebuild path (posting GUID changes).'
+    )
+
+
+def test_bill_adding_partial_payment_preserves_posting_and_entry_guids(tmp_path):
+    """BILL-INC-ADD-100: symmetric bill test — adding a partial payment
+    preserves posting + entry GUIDs and leaves existing AP bank tx in place."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_biz_fixture(runner, gf, 'q015_inc_add_bill_v1.txt', tmp_path)
+    assert r.exit_code == 0, f'v1: {r.output}'
+    time.sleep(1)
+    snap1 = _snapshot(gf, business_id='BILL-INC-ADD-100', is_bill=True)
+
+    r = _import_biz_fixture(runner, gf, 'q015_inc_add_bill_v2.txt', tmp_path)
+    assert r.exit_code == 0, f'v2: {r.output}'
+    snap2 = _snapshot(gf, business_id='BILL-INC-ADD-100', is_bill=True)
+
+    assert snap2['posting_guid'] == snap1['posting_guid'], (
+        f"Bill posting GUID must NOT change. Before {snap1['posting_guid']}, "
+        f"after {snap2['posting_guid']}"
+    )
+    assert snap2['entry_guids'] == snap1['entry_guids'], (
+        'Bill entry GUIDs must NOT change.'
+    )
+    original_payment_guid = snap1['lot_payment_tx_guids'][0]
+    assert original_payment_guid in snap2['lot_payment_tx_guids'], (
+        f"Original bill payment {original_payment_guid} must remain attached "
+        f"to the AP lot. Got: {snap2['lot_payment_tx_guids']}"
+    )
+    assert len(snap2['bank_tx_by_guid']) == 2, (
+        f"Bank account should hold exactly 2 transactions for the bill "
+        f"(original $60 + new $40), not duplicates. "
+        f"Got {len(snap2['bank_tx_by_guid'])}"
+    )

--- a/tests/integration/test_overpayment_handling.py
+++ b/tests/integration/test_overpayment_handling.py
@@ -1,0 +1,416 @@
+"""Q-015 expanded scope: overpayment / pre-payment exports + retargeting.
+
+When a customer pays more than the invoice total (or a bill is overpaid
+to a vendor), GnuCash's `ApplyPayment` automatically splits the payment
+transaction:
+
+  * one AR/AP-side split for the invoice/bill total → into the invoice's
+    posted lot (closes it),
+  * a second AR/AP-side split for the residual → into a new pre-payment
+    lot on the AR/AP account.
+
+Our exporter currently only emits a single `payment:` line with the
+total bank-side amount. The pre-payment lot is invisible in plaintext.
+These tests pin the desired behavior of a `prepayment:` field in the
+payment block:
+
+* exporter emits `prepayment: N` when a payment tx has AR/AP-side splits
+  outside the invoice/bill lot,
+* round-trip preserves the value and the pre-payment lot,
+* the `txn_guid:` retarget path requires `prepayment:` when the bank
+  tx amount exceeds the invoice/bill remaining (otherwise an explicit
+  error — silently retargeting an oversize counter-split would leave the
+  lot in an undefined state).
+
+Symmetric bill (AP) tests included.
+"""
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+ACCOUNTS_PATH = 'tests/fixtures/payment_roundtrip_accounts.txt'
+FIXTURES_DIR = Path('tests/fixtures')
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES_DIR / name).read_text()
+
+
+def _setup_book(runner, tmp_path):
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS_PATH])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    return gf
+
+
+def _import_text(runner, gf, content, name, tmp_path, biz=True):
+    p = tmp_path / name
+    p.write_text(content)
+    args = ['import', str(gf), str(p)]
+    if biz:
+        args.append('--include-business-objects')
+    return runner.invoke(cli, args)
+
+
+def _import_fixture(runner, gf, fixture_name, tmp_path, biz=True, alias=None):
+    return _import_text(runner, gf, _fixture(fixture_name),
+                        alias or fixture_name, tmp_path, biz=biz)
+
+
+def _export(runner, gf, tmp_path, name):
+    out = tmp_path / name
+    r = runner.invoke(cli, ['export', str(gf), str(out), '--include-business-objects'])
+    return r, out.read_text() if r.exit_code == 0 else ''
+
+
+def _ar_lot_state(gf, ar_account='Assets.Accounts Receivable'):
+    """Return [{is_closed, balance, members_count}] for every lot on the
+    AR/AP account that has at least one split."""
+    from gnucash import GncLot, Split
+
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        def find(acct, name):
+            if acct.get_full_name() == name:
+                return acct
+            for child in acct.get_children():
+                r = find(child, name)
+                if r:
+                    return r
+            return None
+        ar = find(repo.book.get_root_account(), ar_account)
+        if ar is None:
+            return []
+        seen = set()
+        out = []
+        for s in ar.GetSplitList():
+            raw_lot = s.GetLot()
+            if raw_lot is None:
+                continue
+            key = int(raw_lot)
+            if key in seen:
+                continue
+            seen.add(key)
+            lot = GncLot(instance=raw_lot)
+            members = list(lot.get_split_list())
+            out.append({
+                'is_closed': lot.is_closed(),
+                'balance': lot.get_balance().to_double(),
+                'members': len(members),
+            })
+        return sorted(out, key=lambda d: (d['is_closed'], d['balance']))
+    finally:
+        repo.close()
+
+
+def _bank_tx_count(gf, bank='Assets.Bank'):
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        def find(acct, name):
+            if acct.get_full_name() == name:
+                return acct
+            for child in acct.get_children():
+                r = find(child, name)
+                if r:
+                    return r
+            return None
+        b = find(repo.book.get_root_account(), bank)
+        if b is None:
+            return 0
+        return len({sp.GetParent().GetGUID().to_string() for sp in b.GetSplitList()})
+    finally:
+        repo.close()
+
+
+def _bank_tx_guid(gf, bank='Assets.Bank', amount=None):
+    """Return the GUID of the (single, by default) bank tx, optionally
+    filtered to a specific amount."""
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        def find(acct, name):
+            if acct.get_full_name() == name:
+                return acct
+            for child in acct.get_children():
+                r = find(child, name)
+                if r:
+                    return r
+            return None
+        b = find(repo.book.get_root_account(), bank)
+        for sp in b.GetSplitList():
+            if amount is None or abs(sp.GetAmount().to_double() - amount) < 0.001:
+                return sp.GetParent().GetGUID().to_string()
+        return None
+    finally:
+        repo.close()
+
+
+# -- 1. ApplyPayment overpayment: export must emit `prepayment:` ----------
+
+def test_invoice_overpayment_export_emits_prepayment_field(tmp_path):
+    """INV-OH-EXP-100 $100 paid $150 → exporter must emit `prepayment: 50`."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_fixture(runner, gf, 'q015_oh_inv_export_emits.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+
+    _, exported = _export(runner, gf, tmp_path, 'r1.txt')
+    # The exported invoice block must include `prepayment: 50`.
+    assert 'prepayment: 50' in exported, (
+        f"Exporter must emit `prepayment: 50` for the $50 overpayment "
+        f"residual. Exported plaintext:\n{exported}"
+    )
+
+
+def test_invoice_overpayment_roundtrip_preserves_prepayment_lot(tmp_path):
+    """INV-OH-RT-110 $110 paid $160 → prepayment lot of $50 must round-trip."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_fixture(runner, gf, 'q015_oh_inv_roundtrip_preserves.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    initial_lots = _ar_lot_state(gf)
+    initial_bank = _bank_tx_count(gf)
+    assert initial_bank == 1
+    assert len(initial_lots) == 2, f'expected 2 AR lots (invoice + prepayment), got: {initial_lots}'
+    # invoice lot: closed, balance 0; prepayment lot: open, balance -50
+    assert any(lot['is_closed'] and lot['balance'] == 0.0 for lot in initial_lots)
+    assert any(not lot['is_closed'] and lot['balance'] == -50.0 for lot in initial_lots)
+
+    _, exported = _export(runner, gf, tmp_path, 'r1.txt')
+    r = _import_text(runner, gf, exported, 'r1_in.txt', tmp_path)
+    assert r.exit_code == 0, f're-import: {r.output}'
+
+    final_lots = _ar_lot_state(gf)
+    final_bank = _bank_tx_count(gf)
+    assert final_bank == 1, (
+        f'roundtrip must not duplicate the bank tx for overpayment. '
+        f'before={initial_bank} after={final_bank}'
+    )
+    assert final_lots == initial_lots, (
+        f'AR lot state changed after roundtrip.\nbefore: {initial_lots}\nafter:  {final_lots}'
+    )
+
+
+def test_invoice_overpayment_double_roundtrip_no_lot_accumulation(tmp_path):
+    """INV-OH-DBL-120 $120 paid $170 → two roundtrips must not accumulate lots."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+    r = _import_fixture(runner, gf, 'q015_oh_inv_double_roundtrip.txt', tmp_path)
+    assert r.exit_code == 0
+    time.sleep(1)
+    initial = _ar_lot_state(gf)
+
+    for i in (1, 2):
+        _, exported = _export(runner, gf, tmp_path, f'r{i}.txt')
+        r = _import_text(runner, gf, exported, f'r{i}_in.txt', tmp_path)
+        assert r.exit_code == 0, f'round {i}: {r.output}'
+        time.sleep(1)
+        current = _ar_lot_state(gf)
+        assert current == initial, (
+            f'double roundtrip drifted AR lots.\nstart: {initial}\nround{i}: {current}'
+        )
+        assert _bank_tx_count(gf) == 1
+
+
+# -- 2. Retarget path overpayment: explicit `prepayment:` required --------
+
+
+def test_retarget_overpayment_with_explicit_prepayment_succeeds(tmp_path):
+    """Bank tx for $150 retargeted to a $100 invoice — must split the
+    counter-split: $100 to invoice lot, $50 to a new pre-payment lot."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    # Pre-create the bank tx for $150
+    r = _import_fixture(runner, gf, 'q015_oh_retarget_over_pre_bank.txt',
+                        tmp_path, biz=False, alias='pre_bank.txt')
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    bank_guid = _bank_tx_guid(gf, amount=150.0)
+    assert bank_guid is not None
+
+    # Now import the invoice that retargets that bank tx, declaring a $50 prepayment.
+    biz = _fixture('q015_oh_retarget_over_biz.txt').replace('{txn_guid}', bank_guid)
+    r = _import_text(runner, gf, biz, 'inv.txt', tmp_path)
+    assert r.exit_code == 0, f'retarget+prepayment import failed: {r.output}'
+    time.sleep(1)
+
+    assert _bank_tx_count(gf) == 1, 'no new bank tx must be created on retarget'
+    assert _bank_tx_guid(gf, amount=150.0) == bank_guid, 'original bank tx GUID preserved'
+
+    lots = _ar_lot_state(gf)
+    assert len(lots) == 2, f'must create 2 AR lots (invoice + prepayment); got {lots}'
+    assert any(lot['is_closed'] and lot['balance'] == 0.0 for lot in lots), (
+        f'invoice lot must close at balance 0: {lots}'
+    )
+    assert any(not lot['is_closed'] and lot['balance'] == -50.0 for lot in lots), (
+        f'prepayment lot must be open with balance -50: {lots}'
+    )
+
+
+def test_retarget_overpayment_without_prepayment_fails_with_clear_error(tmp_path):
+    """Bank tx for $150 retargeted to a $100 invoice without specifying
+    `prepayment: 50` — silently retargeting an oversize counter-split
+    leaves the invoice lot at balance -$50, semantically broken. The
+    importer must refuse and tell the user what's wrong."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+    r = _import_fixture(runner, gf, 'q015_oh_retarget_nopre_pre_bank.txt',
+                        tmp_path, biz=False, alias='pre_bank.txt')
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    bank_guid = _bank_tx_guid(gf, amount=150.0)
+
+    biz = _fixture('q015_oh_retarget_nopre_biz.txt').replace('{txn_guid}', bank_guid)
+    r = _import_text(runner, gf, biz, 'inv.txt', tmp_path)
+    assert r.exit_code != 0, (
+        f'retargeting $150 to a $100 invoice without `prepayment:` must fail. '
+        f'Got exit={r.exit_code}, output:\n{r.output}'
+    )
+    msg = r.output.lower()
+    assert ('prepayment' in msg or 'overpay' in msg
+            or 'exceeds' in msg or 'remaining' in msg), (
+        f'error must explain the amount mismatch and point at `prepayment:`. '
+        f'Output:\n{r.output}'
+    )
+
+
+def test_retarget_exact_amount_still_works(tmp_path):
+    """Sanity: when the bank tx amount equals the invoice remaining,
+    the retarget path with no `prepayment:` field works as before."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_fixture(runner, gf, 'q015_oh_retarget_exact_pre_bank.txt',
+                        tmp_path, biz=False, alias='pre.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+    bank_guid = _bank_tx_guid(gf, amount=100.0)
+
+    biz = _fixture('q015_oh_retarget_exact_biz.txt').replace('{txn_guid}', bank_guid)
+    r = _import_text(runner, gf, biz, 'inv.txt', tmp_path)
+    assert r.exit_code == 0, f'exact retarget: {r.output}'
+    lots = _ar_lot_state(gf)
+    assert len(lots) == 1
+    assert lots[0]['is_closed']
+    assert lots[0]['balance'] == 0.0
+
+
+def test_retarget_underpayment_still_works(tmp_path):
+    """Bank tx for $60 retargeted to a $100 invoice — partial payment
+    via retarget; lot remains open with balance +$40 (invoice $100 − paid $60)."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_fixture(runner, gf, 'q015_oh_retarget_under_pre_bank.txt',
+                        tmp_path, biz=False, alias='pre.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+    bank_guid = _bank_tx_guid(gf, amount=60.0)
+
+    biz = _fixture('q015_oh_retarget_under_biz.txt').replace('{txn_guid}', bank_guid)
+    r = _import_text(runner, gf, biz, 'inv.txt', tmp_path)
+    assert r.exit_code == 0, f'partial retarget: {r.output}'
+    lots = _ar_lot_state(gf)
+    assert len(lots) == 1, f'partial payment must produce 1 lot, got {lots}'
+    assert not lots[0]['is_closed']
+    assert lots[0]['balance'] == 40.0, (
+        f'partial payment lot should have +$40 remaining (invoice $100 - paid $60), '
+        f'got balance={lots[0]["balance"]}'
+    )
+
+
+# -- 3. Bill counterparts -------------------------------------------------
+
+def test_bill_overpayment_export_emits_prepayment_field(tmp_path):
+    """BILL-OH-EXP-100 $100 paid $150 → exporter must emit `prepayment: 50`."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+    r = _import_fixture(runner, gf, 'q015_oh_bill_export_emits.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+
+    _, exported = _export(runner, gf, tmp_path, 'r1.txt')
+    assert 'prepayment: 50' in exported, (
+        f'bill overpayment must export `prepayment: 50`. exported:\n{exported}'
+    )
+
+
+def test_bill_overpayment_roundtrip_preserves_prepayment_lot(tmp_path):
+    """BILL-OH-RT-110 $110 paid $160 → prepayment lot of $50 must round-trip."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+    r = _import_fixture(runner, gf, 'q015_oh_bill_roundtrip_preserves.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    initial_lots = _ar_lot_state(gf, ar_account='Liabilities.Accounts Payable')
+    assert _bank_tx_count(gf) == 1
+    assert len(initial_lots) == 2, (
+        f'bill overpayment must produce 2 AP lots (bill + prepayment), got {initial_lots}'
+    )
+    # AP signs are opposite to AR: bill posts CR AP -100, payment DR AP +100,
+    # extra overpayment DR AP +50 in a new lot (positive balance).
+    assert any(lot['is_closed'] and lot['balance'] == 0.0 for lot in initial_lots)
+    assert any(not lot['is_closed'] and lot['balance'] == 50.0 for lot in initial_lots)
+
+    _, exported = _export(runner, gf, tmp_path, 'r1.txt')
+    r = _import_text(runner, gf, exported, 'r1_in.txt', tmp_path)
+    assert r.exit_code == 0, f'bill re-import: {r.output}'
+
+    final_lots = _ar_lot_state(gf, ar_account='Liabilities.Accounts Payable')
+    assert _bank_tx_count(gf) == 1
+    assert final_lots == initial_lots, (
+        f'bill overpayment roundtrip drifted.\nbefore: {initial_lots}\nafter: {final_lots}'
+    )
+
+
+def test_bill_retarget_overpayment_with_explicit_prepayment_succeeds(tmp_path):
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+    r = _import_fixture(runner, gf, 'q015_oh_bill_retarget_over_pre_bank.txt',
+                        tmp_path, biz=False, alias='pre_bank.txt')
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    bank_guid = _bank_tx_guid(gf, amount=-150.0)
+    assert bank_guid is not None
+
+    biz = _fixture('q015_oh_bill_retarget_over_biz.txt').replace('{txn_guid}', bank_guid)
+    r = _import_text(runner, gf, biz, 'bill.txt', tmp_path)
+    assert r.exit_code == 0, f'bill retarget+prepayment failed: {r.output}'
+    time.sleep(1)
+
+    assert _bank_tx_count(gf) == 1
+    lots = _ar_lot_state(gf, ar_account='Liabilities.Accounts Payable')
+    assert len(lots) == 2
+    assert any(lot['is_closed'] and lot['balance'] == 0.0 for lot in lots)
+    assert any(not lot['is_closed'] and lot['balance'] == 50.0 for lot in lots)
+
+
+def test_bill_retarget_overpayment_without_prepayment_fails(tmp_path):
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+    r = _import_fixture(runner, gf, 'q015_oh_bill_retarget_nopre_pre_bank.txt',
+                        tmp_path, biz=False, alias='pre_bank.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+    bank_guid = _bank_tx_guid(gf, amount=-150.0)
+
+    biz = _fixture('q015_oh_bill_retarget_nopre_biz.txt').replace('{txn_guid}', bank_guid)
+    r = _import_text(runner, gf, biz, 'bill.txt', tmp_path)
+    assert r.exit_code != 0, (
+        f'bill retarget overpayment without `prepayment:` must fail. '
+        f'Got exit={r.exit_code}'
+    )

--- a/tests/integration/test_overpayment_path_equivalence.py
+++ b/tests/integration/test_overpayment_path_equivalence.py
@@ -1,0 +1,276 @@
+"""Q-015: the two code paths for invoice payment must produce
+equivalent book state across roundtrip and double-roundtrip.
+
+Path A — ApplyPayment:
+  `payment: amount=N` (no txn_guid) → GnuCash creates the bank tx via
+  `inv.ApplyPayment(N)`. Handles exact, partial, and overpayment via
+  GnuCash's native splitting.
+
+Path B — retarget:
+  The user pre-creates the bank tx (e.g. from QFX import), then posts
+  the invoice with `payment: amount=N txn_guid=<bank>` (plus
+  `prepayment: M` for overpayment). Our `_retarget_*` mechanic
+  re-routes the existing counter-split.
+
+Four scenarios with distinct amounts so a reader can tell at a glance
+which fixture each test uses:
+
+  * basic overpayment  — INV-001 $100 paid $150 (prepayment 50)
+  * exact payment      — INV-EXACT-123 $123 paid $123
+  * partial payment    — INV-PARTIAL-200 $200 paid $77
+  * two overpayments   — INV-DOUBLE-A $80 paid $130; INV-DOUBLE-B
+                         $250 paid $300; both with prepayment 50
+
+For each scenario the user-facing outcome must be semantically
+identical between the two paths after initial import, after the 1st
+roundtrip, and after the 2nd roundtrip. Split GUIDs may legitimately
+differ; what must match is bank tx amounts, AR lot count, lot
+balances, and lot member amounts.
+"""
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+ACCOUNTS_PATH = 'tests/fixtures/payment_roundtrip_accounts.txt'
+FIXTURES_DIR = Path('tests/fixtures')
+
+
+def _write(p, t):
+    with open(p, 'w') as f:
+        f.write(t)
+    return str(p)
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES_DIR / name).read_text()
+
+
+def _import_new(runner, gf, fixture_path, tmp_path):
+    args = ['import', '--new', str(gf), fixture_path]
+    r = runner.invoke(cli, args)
+    assert r.exit_code == 0, f'import --new: {r.output}'
+    time.sleep(1)
+
+
+def _import(runner, gf, content, name, tmp_path, biz=True):
+    args = ['import', str(gf),
+            _write(tmp_path / name, content)]
+    if biz:
+        args.append('--include-business-objects')
+    return runner.invoke(cli, args)
+
+
+def _bank_tx_guids_sorted(gf, bank='Assets.Bank'):
+    """Return list of (date, amount, tx_guid) sorted by date — lets us
+    pin a known fixture amount to its actual GUID for retarget substitution."""
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        def find(a, n):
+            if a.get_full_name() == n:
+                return a
+            for c in a.get_children():
+                r = find(c, n)
+                if r:
+                    return r
+            return None
+        b = find(repo.book.get_root_account(), bank)
+        out = []
+        for sp in b.GetSplitList():
+            tx = sp.GetParent()
+            out.append((tx.GetDate(), sp.GetAmount().to_double(),
+                        tx.GetGUID().to_string()))
+        return sorted(out, key=lambda x: x[0])
+    finally:
+        repo.close()
+
+
+def _semantic_state(gf):
+    """Book state for equivalence comparison: amounts, balances, lot
+    structure. Ignores split/tx GUIDs (legitimately differ between the
+    two paths)."""
+    from gnucash import GncLot, Split
+
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        def find(a, n):
+            if a.get_full_name() == n:
+                return a
+            for c in a.get_children():
+                r = find(c, n)
+                if r:
+                    return r
+            return None
+        ar = find(repo.book.get_root_account(), 'Assets.Accounts Receivable')
+        bank = find(repo.book.get_root_account(), 'Assets.Bank')
+        bank_amounts = sorted(
+            round(sp.GetAmount().to_double(), 2)
+            for sp in bank.GetSplitList()
+        )
+        seen, lots = set(), []
+        for sp in ar.GetSplitList():
+            raw = sp.GetLot()
+            if raw is None or int(raw) in seen:
+                continue
+            seen.add(int(raw))
+            lot = GncLot(instance=raw)
+            members = sorted(
+                round(Split(instance=m).GetAmount().to_double(), 2)
+                for m in lot.get_split_list()
+            )
+            lots.append({
+                'closed': lot.is_closed(),
+                'balance': round(lot.get_balance().to_double(), 2),
+                'members': members,
+            })
+        return {
+            'bank_amounts': bank_amounts,
+            'ar_lots': sorted(lots, key=lambda d: (d['closed'], d['balance'], d['members'])),
+        }
+    finally:
+        repo.close()
+
+
+def _roundtrip(runner, gf, tmp_path, suffix):
+    out = tmp_path / f'export_{suffix}.txt'
+    r = runner.invoke(cli, ['export', str(gf), str(out),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f'export {suffix}: {r.output}'
+    content = out.read_text()
+    r = _import(runner, gf, content, f'reimport_{suffix}.txt', tmp_path)
+    assert r.exit_code == 0, f'reimport {suffix}: {r.output}'
+    time.sleep(1)
+
+
+def _make_book(runner, tmp_path):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    gf = tmp_path / 'book.gnucash'
+    _import_new(runner, gf, ACCOUNTS_PATH, tmp_path)
+    return gf
+
+
+def _build_via_apply(runner, tmp_path, apply_fixture: str):
+    """Build a book via the ApplyPayment path using a single biz fixture
+    (customer + invoice with payment block, no pre-existing bank tx)."""
+    gf = _make_book(runner, tmp_path)
+    r = _import(runner, gf, _fixture(apply_fixture), 'apply_biz.txt', tmp_path)
+    assert r.exit_code == 0, f'{apply_fixture}: {r.output}'
+    time.sleep(1)
+    return gf
+
+
+def _build_via_retarget(runner, tmp_path, pre_bank_fixture: str,
+                         retarget_fixture: str, guid_placeholders=None):
+    """Build a book via the retarget path: (1) pre-create one or more
+    bank txs from `pre_bank_fixture`, (2) import the retarget biz file
+    after substituting bank tx GUIDs into its `{txn_guid...}`
+    placeholders."""
+    gf = _make_book(runner, tmp_path)
+    r = _import(runner, gf, _fixture(pre_bank_fixture), 'pre_bank.txt', tmp_path,
+                biz=False)
+    assert r.exit_code == 0, f'{pre_bank_fixture}: {r.output}'
+    time.sleep(1)
+    bank_entries = _bank_tx_guids_sorted(gf)
+    biz = _fixture(retarget_fixture)
+    placeholders = guid_placeholders or ['txn_guid']
+    for i, key in enumerate(placeholders):
+        biz = biz.replace('{' + key + '}', bank_entries[i][2])
+    r = _import(runner, gf, biz, 'retarget_biz.txt', tmp_path)
+    assert r.exit_code == 0, f'{retarget_fixture}: {r.output}'
+    time.sleep(1)
+    return gf
+
+
+def _assert_paths_equivalent_across_roundtrips(runner, gf_a, gf_b, label):
+    a_dir = gf_a.parent
+    b_dir = gf_b.parent
+    state_a_0 = _semantic_state(gf_a)
+    state_b_0 = _semantic_state(gf_b)
+    assert state_a_0 == state_b_0, (
+        f'[{label}] initial state diverges.\n'
+        f'  apply:    {state_a_0}\n  retarget: {state_b_0}'
+    )
+
+    _roundtrip(runner, gf_a, a_dir, 'r1')
+    _roundtrip(runner, gf_b, b_dir, 'r1')
+    state_a_r1 = _semantic_state(gf_a)
+    state_b_r1 = _semantic_state(gf_b)
+    assert state_a_r1 == state_b_r1, (
+        f'[{label}] diverged after 1st roundtrip.\n'
+        f'  apply:    {state_a_r1}\n  retarget: {state_b_r1}'
+    )
+
+    _roundtrip(runner, gf_a, a_dir, 'r2')
+    _roundtrip(runner, gf_b, b_dir, 'r2')
+    state_a_r2 = _semantic_state(gf_a)
+    state_b_r2 = _semantic_state(gf_b)
+    assert state_a_r2 == state_a_r1, f'[{label}] apply path drifted on r2.'
+    assert state_b_r2 == state_b_r1, f'[{label}] retarget path drifted on r2.'
+    assert state_a_r2 == state_b_r2, (
+        f'[{label}] diverged after 2nd roundtrip.\n'
+        f'  apply:    {state_a_r2}\n  retarget: {state_b_r2}'
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Scenarios
+# ────────────────────────────────────────────────────────────────────────────
+
+def test_basic_overpayment_paths_equivalent(tmp_path):
+    """INV-001 $100 paid $150 (prepayment 50)."""
+    runner = CliRunner()
+    gf_a = _build_via_apply(runner, tmp_path / 'apply',
+                            'q015_eq_basic_apply.txt')
+    gf_b = _build_via_retarget(runner, tmp_path / 'retarget',
+                               'q015_eq_basic_pre_bank.txt',
+                               'q015_eq_basic_retarget.txt')
+    _assert_paths_equivalent_across_roundtrips(runner, gf_a, gf_b, 'basic')
+
+
+def test_exact_payment_paths_equivalent(tmp_path):
+    """INV-EXACT-123 $123 paid $123."""
+    runner = CliRunner()
+    gf_a = _build_via_apply(runner, tmp_path / 'apply',
+                            'q015_eq_exact_apply.txt')
+    gf_b = _build_via_retarget(runner, tmp_path / 'retarget',
+                               'q015_eq_exact_pre_bank.txt',
+                               'q015_eq_exact_retarget.txt')
+    _assert_paths_equivalent_across_roundtrips(runner, gf_a, gf_b, 'exact')
+
+
+def test_partial_payment_paths_equivalent(tmp_path):
+    """INV-PARTIAL-200 $200 paid $77 — partial leaves lot open at +$123."""
+    runner = CliRunner()
+    gf_a = _build_via_apply(runner, tmp_path / 'apply',
+                            'q015_eq_partial_apply.txt')
+    gf_b = _build_via_retarget(runner, tmp_path / 'retarget',
+                               'q015_eq_partial_pre_bank.txt',
+                               'q015_eq_partial_retarget.txt')
+    _assert_paths_equivalent_across_roundtrips(runner, gf_a, gf_b, 'partial')
+
+
+def test_two_overpayments_paths_equivalent(tmp_path):
+    """INV-DOUBLE-A $80 paid $130 + INV-DOUBLE-B $250 paid $300 — both
+    overpayments produce separate $50 credits; no credit merging."""
+    runner = CliRunner()
+    gf_a = _build_via_apply(runner, tmp_path / 'apply',
+                            'q015_eq_two_over_apply.txt')
+    gf_b = _build_via_retarget(runner, tmp_path / 'retarget',
+                               'q015_eq_two_over_pre_bank.txt',
+                               'q015_eq_two_over_retarget.txt',
+                               guid_placeholders=['txn_guid_a', 'txn_guid_b'])
+    _assert_paths_equivalent_across_roundtrips(runner, gf_a, gf_b, 'two_over')
+
+    # Bonus assertion on user-visible outcome — two separate $50 credits.
+    state = _semantic_state(gf_a)
+    open_balances = sorted(lot['balance'] for lot in state['ar_lots'] if not lot['closed'])
+    assert open_balances == [-50.0, -50.0], (
+        f'two overpayments must produce two $50 credits (no merging). '
+        f'got: {open_balances}'
+    )

--- a/tests/integration/test_payment_roundtrip_no_orphan.py
+++ b/tests/integration/test_payment_roundtrip_no_orphan.py
@@ -1,0 +1,405 @@
+"""Q-015: roundtrip / double-roundtrip must not duplicate or create orphan bank txs.
+
+The trap Q-015 closes is the destructive rebuild path that fires whenever
+`_invoice_matches_directive` returns False on re-import. These tests
+exercise the export → re-import cycle (and a second re-import on top of
+the first) to assert:
+
+* a paid invoice/bill exported and re-imported into the SAME book
+  produces no new bank transactions and no orphans (round-trip is a
+  no-op),
+* doing it again on top of round-trip #1 stays a no-op (round-trip #2
+  is idempotent),
+* after legitimately adding a partial payment, the new total round-trips
+  cleanly,
+* a pre-existing orphan (e.g. left over from an `unpost-invoices` run)
+  is preserved across round-trips — not duplicated, not silently
+  collected, not turned into multiple orphans.
+"""
+
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+ACCOUNTS_PATH = 'tests/fixtures/payment_roundtrip_accounts.txt'
+FIXTURES_DIR = Path('tests/fixtures')
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES_DIR / name).read_text()
+
+
+# -- helpers ---------------------------------------------------------------
+
+
+def _setup_book(runner, tmp_path):
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS_PATH])
+    assert r.exit_code == 0, f'accounts import: {r.output}'
+    time.sleep(1)
+    return gf
+
+
+def _import_biz_fixture(runner, gf, fixture_name, tmp_path, alias=None):
+    p = tmp_path / (alias or fixture_name)
+    p.write_text(_fixture(fixture_name))
+    return runner.invoke(cli, ['import', str(gf), str(p),
+                               '--include-business-objects'])
+
+
+def _import_biz_text(runner, gf, content, name, tmp_path):
+    p = tmp_path / name
+    p.write_text(content)
+    return runner.invoke(cli, ['import', str(gf), str(p),
+                               '--include-business-objects'])
+
+
+def _export(runner, gf, tmp_path, name):
+    out = tmp_path / name
+    r = runner.invoke(cli, ['export', str(gf), str(out), '--include-business-objects'])
+    assert r.exit_code == 0, f'export failed: {r.output}'
+    return out.read_text()
+
+
+def _bank_tx_state(gf, account_name='Assets.Bank'):
+    """Return [{guid, date, amount, memo}] for every transaction touching
+    the given bank account."""
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        def find(acct, name):
+            if acct.get_full_name() == name:
+                return acct
+            for child in acct.get_children():
+                r = find(child, name)
+                if r:
+                    return r
+            return None
+        bank = find(repo.book.get_root_account(), account_name)
+        if bank is None:
+            return []
+        out = []
+        for split in bank.GetSplitList():
+            tx = split.GetParent()
+            out.append({
+                'guid': tx.GetGUID().to_string(),
+                'date': tx.GetDate().strftime('%Y-%m-%d'),
+                'amount': split.GetAmount().to_double(),
+                'memo': split.GetMemo() or '',
+            })
+        return sorted(out, key=lambda d: (d['date'], d['amount']))
+    finally:
+        repo.close()
+
+
+def _orphan_count(runner, gf):
+    """Run find-orphan-payments and return the orphan count from output."""
+    r = runner.invoke(cli, ['find-orphan-payments', str(gf)])
+    assert r.exit_code == 0, f'find-orphan-payments failed: {r.output}'
+    if 'No orphan' in r.output:
+        return 0
+    # Count "guid:" lines (one per orphan)
+    return sum(1 for line in r.output.splitlines() if line.strip().startswith('guid:'))
+
+
+# -- tests -----------------------------------------------------------------
+
+def test_paid_invoice_single_roundtrip_creates_no_orphan(tmp_path):
+    """INV-PR-FULL-100 paid in full → export → re-import into same book:
+    zero orphans, bank tx unchanged (same GUIDs)."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_biz_fixture(runner, gf, 'q015_pr_inv_full_paid.txt', tmp_path,
+                            alias='v1.txt')
+    assert r.exit_code == 0, f'v1 import: {r.output}'
+    time.sleep(1)
+
+    bank_before = _bank_tx_state(gf)
+    orphans_before = _orphan_count(runner, gf)
+    assert orphans_before == 0
+    assert len(bank_before) == 1, f'precondition: 1 bank tx, got {len(bank_before)}'
+
+    exported = _export(runner, gf, tmp_path, 'round1.txt')
+    r = _import_biz_text(runner, gf, exported, 'round1_reimport.txt', tmp_path)
+    assert r.exit_code == 0, f'roundtrip 1 import: {r.output}'
+    time.sleep(1)
+
+    bank_after = _bank_tx_state(gf)
+    orphans_after = _orphan_count(runner, gf)
+    assert orphans_after == 0, f'roundtrip must NOT create orphans; got {orphans_after}'
+    assert bank_after == bank_before, (
+        f'roundtrip must NOT change bank txs.\n'
+        f'before: {bank_before}\nafter:  {bank_after}'
+    )
+
+
+def test_paid_invoice_double_roundtrip_is_idempotent(tmp_path):
+    """INV-PR-FULL-100 roundtripped twice. State after round 2 == state after
+    round 1 == initial state. No orphan accumulation."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_biz_fixture(runner, gf, 'q015_pr_inv_full_paid.txt', tmp_path,
+                            alias='v1.txt')
+    assert r.exit_code == 0, f'v1 import: {r.output}'
+    time.sleep(1)
+    initial_bank = _bank_tx_state(gf)
+
+    exported_1 = _export(runner, gf, tmp_path, 'r1.txt')
+    r = _import_biz_text(runner, gf, exported_1, 'r1_in.txt', tmp_path)
+    assert r.exit_code == 0
+    time.sleep(1)
+    bank_r1 = _bank_tx_state(gf)
+    assert bank_r1 == initial_bank, f'round 1 changed bank txs: {bank_r1} vs {initial_bank}'
+
+    exported_2 = _export(runner, gf, tmp_path, 'r2.txt')
+    r = _import_biz_text(runner, gf, exported_2, 'r2_in.txt', tmp_path)
+    assert r.exit_code == 0
+    bank_r2 = _bank_tx_state(gf)
+
+    assert bank_r2 == initial_bank, f'round 2 changed bank txs: {bank_r2} vs {initial_bank}'
+    assert _orphan_count(runner, gf) == 0
+
+
+def test_partial_paid_invoice_single_roundtrip_no_orphan(tmp_path):
+    """INV-PR-PARTIAL-100 partially paid: roundtrip must NOT create an
+    orphan even though the lot isn't closed."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_biz_fixture(runner, gf, 'q015_pr_inv_partial_paid.txt', tmp_path,
+                            alias='v1.txt')
+    assert r.exit_code == 0, f'v1 import: {r.output}'
+    time.sleep(1)
+    bank_before = _bank_tx_state(gf)
+
+    exported = _export(runner, gf, tmp_path, 'r1.txt')
+    r = _import_biz_text(runner, gf, exported, 'r1_in.txt', tmp_path)
+    assert r.exit_code == 0
+    bank_after = _bank_tx_state(gf)
+
+    assert bank_after == bank_before, (
+        f'partial-paid roundtrip changed bank state.\n'
+        f'before: {bank_before}\nafter:  {bank_after}'
+    )
+    assert _orphan_count(runner, gf) == 0
+
+
+def test_partial_paid_invoice_double_roundtrip_no_orphan_accumulation(tmp_path):
+    """INV-PR-PARTIAL-100 two rounds of export → re-import on a still-outstanding
+    invoice. Bank state must be stable; orphan count stays at 0."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_biz_fixture(runner, gf, 'q015_pr_inv_partial_paid.txt', tmp_path,
+                            alias='v1.txt')
+    assert r.exit_code == 0, f'v1 import: {r.output}'
+    time.sleep(1)
+    initial = _bank_tx_state(gf)
+
+    for i in (1, 2):
+        exported = _export(runner, gf, tmp_path, f'r{i}.txt')
+        r = _import_biz_text(runner, gf, exported, f'r{i}_in.txt', tmp_path)
+        assert r.exit_code == 0, f'round {i} import: {r.output}'
+        time.sleep(1)
+        current = _bank_tx_state(gf)
+        assert current == initial, (
+            f'round {i} drifted bank state.\nstart: {initial}\nnow:  {current}'
+        )
+        assert _orphan_count(runner, gf) == 0, (
+            f'round {i} produced orphans (count={_orphan_count(runner, gf)})'
+        )
+
+
+def test_add_partial_payment_then_roundtrip_no_orphan(tmp_path):
+    """INV-PR-ADD-100: the intended Q-015 workflow — pay partial $60, then
+    add a second partial $40, then export and re-import. Final state must
+    have exactly the two payments and zero orphans."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    # Step 1: invoice + $60 partial
+    r = _import_biz_fixture(runner, gf, 'q015_pr_add_partial_v1.txt', tmp_path)
+    assert r.exit_code == 0
+    time.sleep(1)
+
+    # Step 2: add the $40 (Q-015 fast path)
+    r = _import_biz_fixture(runner, gf, 'q015_pr_add_partial_v2.txt', tmp_path)
+    assert r.exit_code == 0
+    time.sleep(1)
+
+    bank_after_add = _bank_tx_state(gf)
+    assert len(bank_after_add) == 2, (
+        f'after add-payment must have exactly 2 bank txs, got {len(bank_after_add)}: '
+        f'{bank_after_add}'
+    )
+    assert _orphan_count(runner, gf) == 0
+
+    # Step 3: roundtrip
+    exported = _export(runner, gf, tmp_path, 'r1.txt')
+    r = _import_biz_text(runner, gf, exported, 'r1_in.txt', tmp_path)
+    assert r.exit_code == 0
+    final = _bank_tx_state(gf)
+
+    assert final == bank_after_add, (
+        f'roundtrip after add-payment drifted.\n'
+        f'before: {bank_after_add}\nafter:  {final}'
+    )
+    assert _orphan_count(runner, gf) == 0
+
+
+def test_paid_bill_single_roundtrip_creates_no_orphan(tmp_path):
+    """BILL-PR-FULL-100: paid bill roundtrip is a no-op."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_biz_fixture(runner, gf, 'q015_pr_bill_full_paid.txt', tmp_path,
+                            alias='v1.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+    bank_before = _bank_tx_state(gf)
+    assert len(bank_before) == 1
+
+    exported = _export(runner, gf, tmp_path, 'r1.txt')
+    r = _import_biz_text(runner, gf, exported, 'r1_in.txt', tmp_path)
+    assert r.exit_code == 0
+    bank_after = _bank_tx_state(gf)
+
+    assert bank_after == bank_before, (
+        f'bill roundtrip changed bank state.\nbefore: {bank_before}\nafter:  {bank_after}'
+    )
+    assert _orphan_count(runner, gf) == 0
+
+
+def test_partial_paid_bill_double_roundtrip_no_orphan(tmp_path):
+    """BILL-PR-PARTIAL-100 bill counterpart of the partial-paid double
+    roundtrip test."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_biz_fixture(runner, gf, 'q015_pr_bill_partial_paid.txt', tmp_path,
+                            alias='v1.txt')
+    assert r.exit_code == 0
+    time.sleep(1)
+    initial = _bank_tx_state(gf)
+
+    for i in (1, 2):
+        exported = _export(runner, gf, tmp_path, f'r{i}.txt')
+        r = _import_biz_text(runner, gf, exported, f'r{i}_in.txt', tmp_path)
+        assert r.exit_code == 0
+        time.sleep(1)
+        current = _bank_tx_state(gf)
+        assert current == initial, (
+            f'bill roundtrip {i} drifted.\nstart: {initial}\nnow:  {current}'
+        )
+        assert _orphan_count(runner, gf) == 0
+
+
+# -- pre-existing orphan preservation across roundtrips -------------------
+
+def _create_orphan_via_unpost(runner, gf, tmp_path, kind='invoice'):
+    """Create an orphan bank tx the legitimate way: post + pay + unpost.
+    Returns the orphan tx GUID."""
+    if kind == 'invoice':
+        fixture = 'q015_pr_orphan_inv_setup.txt'
+        unpost_cmd = ['unpost-invoices', str(gf), 'INV-PR-ORPHAN-100']
+    else:
+        fixture = 'q015_pr_orphan_bill_setup.txt'
+        unpost_cmd = ['unpost-bills', str(gf), 'BILL-PR-ORPHAN-100']
+    r = _import_biz_fixture(runner, gf, fixture, tmp_path,
+                            alias='orphan_setup.txt')
+    assert r.exit_code == 0, f'setup import: {r.output}'
+    time.sleep(1)
+    bank_before_unpost = _bank_tx_state(gf)
+    assert len(bank_before_unpost) == 1
+    orphan_guid = bank_before_unpost[0]['guid']
+    r = runner.invoke(cli, unpost_cmd)
+    assert r.exit_code == 0, f'unpost: {r.output}'
+    time.sleep(1)
+    assert _orphan_count(runner, gf) == 1, 'precondition: exactly 1 orphan after unpost'
+    return orphan_guid
+
+
+def test_pre_existing_invoice_orphan_survives_single_roundtrip_without_duplication(tmp_path):
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+    orphan_guid = _create_orphan_via_unpost(runner, gf, tmp_path, 'invoice')
+    bank_before = _bank_tx_state(gf)
+
+    exported = _export(runner, gf, tmp_path, 'r1.txt')
+    r = _import_biz_text(runner, gf, exported, 'r1_in.txt', tmp_path)
+    assert r.exit_code == 0, f'roundtrip: {r.output}'
+    bank_after = _bank_tx_state(gf)
+
+    assert _orphan_count(runner, gf) == 1, (
+        'roundtrip must preserve the single existing orphan, not duplicate '
+        'it. Current count: ' + str(_orphan_count(runner, gf))
+    )
+    assert any(t['guid'] == orphan_guid for t in bank_after), (
+        f'orphan GUID {orphan_guid} must still be present in bank after roundtrip; '
+        f'got {[t["guid"] for t in bank_after]}'
+    )
+    assert bank_after == bank_before, (
+        f'roundtrip must not change bank state.\nbefore: {bank_before}\nafter:  {bank_after}'
+    )
+
+
+def test_pre_existing_invoice_orphan_survives_double_roundtrip_without_duplication(tmp_path):
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+    _create_orphan_via_unpost(runner, gf, tmp_path, 'invoice')
+    initial_bank = _bank_tx_state(gf)
+    initial_orphans = _orphan_count(runner, gf)
+
+    for i in (1, 2):
+        exported = _export(runner, gf, tmp_path, f'r{i}.txt')
+        r = _import_biz_text(runner, gf, exported, f'r{i}_in.txt', tmp_path)
+        assert r.exit_code == 0, f'round {i}: {r.output}'
+        time.sleep(1)
+        current_bank = _bank_tx_state(gf)
+        current_orphans = _orphan_count(runner, gf)
+        assert current_orphans == initial_orphans, (
+            f'round {i} changed orphan count: {initial_orphans} -> {current_orphans}'
+        )
+        assert current_bank == initial_bank, (
+            f'round {i} changed bank state.\nstart: {initial_bank}\nnow:  {current_bank}'
+        )
+
+
+def test_pre_existing_bill_orphan_survives_single_roundtrip_without_duplication(tmp_path):
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+    orphan_guid = _create_orphan_via_unpost(runner, gf, tmp_path, 'bill')
+    bank_before = _bank_tx_state(gf)
+
+    exported = _export(runner, gf, tmp_path, 'r1.txt')
+    r = _import_biz_text(runner, gf, exported, 'r1_in.txt', tmp_path)
+    assert r.exit_code == 0, f'bill roundtrip: {r.output}'
+    bank_after = _bank_tx_state(gf)
+
+    assert _orphan_count(runner, gf) == 1, (
+        'bill roundtrip must not duplicate the existing orphan'
+    )
+    assert any(t['guid'] == orphan_guid for t in bank_after)
+    assert bank_after == bank_before
+
+
+def test_pre_existing_bill_orphan_survives_double_roundtrip_without_duplication(tmp_path):
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+    _create_orphan_via_unpost(runner, gf, tmp_path, 'bill')
+    initial_bank = _bank_tx_state(gf)
+    initial_orphans = _orphan_count(runner, gf)
+
+    for i in (1, 2):
+        exported = _export(runner, gf, tmp_path, f'r{i}.txt')
+        r = _import_biz_text(runner, gf, exported, f'r{i}_in.txt', tmp_path)
+        assert r.exit_code == 0, f'bill round {i}: {r.output}'
+        time.sleep(1)
+        assert _orphan_count(runner, gf) == initial_orphans
+        assert _bank_tx_state(gf) == initial_bank

--- a/use_cases/export_business_objects.py
+++ b/use_cases/export_business_objects.py
@@ -30,6 +30,34 @@ def _fmt_quantity(val: float) -> str:
     return f'{val:g}'
 
 
+def _payment_is_credit_consumption(txn, this_lot_id: int) -> bool:
+    """Q-015: True if any AR/AP-side split on `txn` is in a lot OTHER than
+    `this_lot_id` that has an invoice/bill attached. That's the signature
+    of `gncInvoiceAutoApplyPayments`: the same payment tx is now linked to
+    two (or more) invoice/bill lots, with its splits redistributed across
+    them. The exporter must mark the consuming invoice with
+    `auto_apply_credit: true` rather than emit a misleading `payment:` block
+    for what is actually a credit re-routing.
+    """
+    for i in range(txn.CountSplits()):
+        sp = txn.GetSplit(i)
+        acct = sp.GetAccount()
+        if acct is None:
+            continue
+        atype = gc.xaccAccountGetType(acct.instance)
+        if atype not in (gc.ACCT_TYPE_RECEIVABLE, gc.ACCT_TYPE_PAYABLE):
+            continue
+        raw_lot = sp.GetLot()
+        if raw_lot is None:
+            continue
+        if int(raw_lot) == this_lot_id:
+            continue
+        other_inv_ptr = gc.gncInvoiceGetInvoiceFromLot(raw_lot)
+        if other_inv_ptr:
+            return True
+    return False
+
+
 class ExportBusinessObjectsUseCase:
     def __init__(self, book: Book):
         self.book = book
@@ -264,10 +292,16 @@ class ExportBusinessObjectsUseCase:
             else:
                 lines.append('	posted: none')
 
-            # payment blocks — always emitted; "none" sentinel when no payments exist
+            # payment blocks — always emitted; "none" sentinel when no payments exist.
+            # Q-015: payment-txs that are also attached to a different invoice's
+            # lot were applied via gncInvoiceAutoApplyPayments (credit consumption).
+            # They are NOT this invoice's payment; instead we set the
+            # `auto_apply_credit: true` flag on the invoice header.
             lot = inv.GetPostedLot()
             has_payments = False
+            uses_auto_apply = False
             if lot:
+                this_lot_id = int(lot.instance)
                 for raw_split in lot.get_split_list():
                     s   = Split(instance=raw_split)
                     txn = s.GetParent()
@@ -276,10 +310,17 @@ class ExportBusinessObjectsUseCase:
                     # Skip the posting transaction itself
                     if gc.gncInvoiceGetInvoiceFromTxn(txn.instance) is not None:
                         continue
-                    lines += self._format_payment(txn)
+                    if _payment_is_credit_consumption(txn, this_lot_id):
+                        uses_auto_apply = True
+                        continue
+                    lines += self._format_payment(txn, s)
                     has_payments = True
             if not has_payments:
                 lines.append('	payment: none')
+            if uses_auto_apply:
+                # Insert the flag after date_opened (slot 5 in `lines`),
+                # before any billing_id / notes / custom_meta / entries.
+                lines.insert(6, '	auto_apply_credit: true')
 
             invoice_strings.append('\n'.join(lines))
         return '\n\n'.join(invoice_strings)
@@ -364,15 +405,21 @@ class ExportBusinessObjectsUseCase:
 
         return lines
 
-    def _format_payment(self, txn) -> list:
-        """Format one payment transaction as payment: lines."""
+    def _format_payment(self, txn, in_lot_ar_ap_split) -> list:
+        """Format one payment transaction as `payment:` lines.
+
+        `in_lot_ar_ap_split` is the AR/AP-side split that lives in the
+        invoice/bill's posted lot (the loop driving the export is already
+        walking that lot's splits). Used to compute the `prepayment:`
+        residual when GnuCash split the payment across multiple lots
+        (overpayment).
+        """
         pay_date = txn.GetDate().strftime("%Y-%m-%d")
         pay_num  = txn.GetNum() or ''
 
-        # Find the bank/asset side (non-AR) split for amount, account, and memo.
-        # GnuCash's ApplyPayment stores the memo on the splits (not on the
-        # transaction description, which is set to the owner/customer name).
-        # Reading split.GetMemo() is consistent across all GnuCash versions.
+        # Find the bank/asset side (non-AR/AP) split for amount, account,
+        # and memo. ApplyPayment stores the memo on the splits (not on
+        # the transaction description, which is set to the owner name).
         bank_name = ''
         pay_amt   = 0.0
         pay_memo  = ''
@@ -386,6 +433,22 @@ class ExportBusinessObjectsUseCase:
                 pay_memo  = split.GetMemo() or ''
                 break
 
+        # Q-015: prepayment residual — AR/AP splits OUTSIDE the
+        # invoice/bill's posted lot. Customers overpaying an invoice and
+        # vendors being overpaid both produce these via ApplyPayment.
+        in_lot_guid = in_lot_ar_ap_split.GetGUID().to_string()
+        prepay = 0.0
+        for i in range(txn.CountSplits()):
+            s = txn.GetSplit(i)
+            if s.GetGUID().to_string() == in_lot_guid:
+                continue
+            acct = s.GetAccount()
+            if acct is None:
+                continue
+            atype = gc.xaccAccountGetType(acct.instance)
+            if atype in (gc.ACCT_TYPE_RECEIVABLE, gc.ACCT_TYPE_PAYABLE):
+                prepay += abs(s.GetAmount().to_double())
+
         lines = [
             '	payment:',
             f'		date: {pay_date}',
@@ -395,6 +458,8 @@ class ExportBusinessObjectsUseCase:
         ]
         if pay_num:
             lines.append(f'		num: "{pay_num}"')
+        if prepay > 0:
+            lines.append(f'		prepayment: {_fmt_quantity(prepay)}')
         return lines
 
     # ── Bills (vendor invoices) ───────────────────────────────────────────────
@@ -454,10 +519,12 @@ class ExportBusinessObjectsUseCase:
             else:
                 lines.append('	posted: none')
 
-            # payment blocks — always emitted; "none" sentinel when no payments exist
+            # payment blocks — same Q-015 auto-apply logic as the invoice side.
             lot = inv.GetPostedLot()
             has_payments = False
+            uses_auto_apply = False
             if lot:
+                this_lot_id = int(lot.instance)
                 for raw_split in lot.get_split_list():
                     s   = Split(instance=raw_split)
                     txn = s.GetParent()
@@ -465,10 +532,16 @@ class ExportBusinessObjectsUseCase:
                         continue
                     if gc.gncInvoiceGetInvoiceFromTxn(txn.instance) is not None:
                         continue
-                    lines += self._format_payment(txn)
+                    if _payment_is_credit_consumption(txn, this_lot_id):
+                        uses_auto_apply = True
+                        continue
+                    lines += self._format_payment(txn, s)
                     has_payments = True
             if not has_payments:
                 lines.append('	payment: none')
+            if uses_auto_apply:
+                # Insert after date_opened (slot 5 — bills have no billing_id).
+                lines.insert(6, '	auto_apply_credit: true')
 
             bill_strings.append('\n'.join(lines))
         return '\n\n'.join(bill_strings)

--- a/use_cases/unpost_business_objects.py
+++ b/use_cases/unpost_business_objects.py
@@ -116,6 +116,108 @@ class UnpostResult:
         return self.id
 
 
+def format_orphan_warning_block(kind: str, orphans: List['OrphanPayment'],
+                                 ident: str = '') -> str:
+    """Render the per-record orphan-payment warning block.
+
+    Used both by the `unpost-invoices` / `unpost-bills` CLI commands and
+    by the Q-015 importer plumbing — every importer-side `Unpost(False)`
+    on a paid record runs this through `cli/import_cmd.py`'s callback so
+    the user sees the same warning shape as the dedicated CLI commands.
+
+    Returns the empty string if `orphans` is empty (record posted but
+    never paid — silent success). For invoices: "AR", "received". For
+    bills: "AP", "sent".
+
+    `ident` (e.g. "INV-001") is prepended to the lead-in when given so a
+    multi-record import distinguishes which record each warning belongs
+    to. The unpost CLI sets it to '' because its per-record output line
+    immediately precedes the warning.
+    """
+    if not orphans:
+        return ''
+
+    n = len(orphans)
+    noun = 'transaction' if n == 1 else 'transactions'
+    is_invoice = (kind == 'invoice')
+    side = 'AR' if is_invoice else 'AP'
+    flow = 'received in' if is_invoice else 'sent from'
+    record_word = kind
+    label = f' for {kind} "{ident}"' if ident else ''
+
+    lines = []
+    lines.append('')
+    lines.append(
+        f'⚠  {n} bank-side payment {noun} {"is" if n == 1 else "are"} '
+        f'now orphaned in the book{label}.'
+    )
+    lines.append(
+        f'   GnuCash unpost destroys the {side} posting transaction but '
+        f'leaves payment'
+    )
+    lines.append(
+        f'   transactions intact — the money still shows as {flow} '
+        f'your bank account.'
+    )
+    lines.append('')
+
+    def _hyphenate(guid32: str) -> str:
+        g = guid32
+        return f'{g[0:8]}-{g[8:12]}-{g[12:16]}-{g[16:20]}-{g[20:32]}'
+
+    for o in orphans:
+        lines.append(
+            f'   • {o.date}  {o.bank_account}  {o.currency} {o.amount}  '
+            f'"{o.description}"'
+        )
+        if o.memo:
+            lines.append(f'     memo: "{o.memo}"')
+        lines.append(f'     guid: {_hyphenate(o.tx_guid)}')
+
+    if n > 1:
+        by_acct: dict = {}
+        for o in orphans:
+            by_acct.setdefault((o.bank_account, o.currency), 0.0)
+            by_acct[(o.bank_account, o.currency)] += float(o.amount)
+        if len(by_acct) == 1:
+            (acct, ccy), total = next(iter(by_acct.items()))
+            lines.append('')
+            lines.append(f'   Total orphaned: {ccy} {total:.2f} in {acct}.')
+        else:
+            lines.append('')
+            lines.append('   Total orphaned per bank account:')
+            for (acct, ccy), total in sorted(by_acct.items()):
+                lines.append(f'     {ccy} {total:.2f} in {acct}')
+
+    lines.append('')
+    lines.append(f'   If you intend to re-pay this {record_word}, either:')
+    lines.append('     a) delete the orphan(s) first:')
+    for o in orphans:
+        lines.append(
+            f'          gnucash-plaintext delete-transactions <book> '
+            f'--by-guid {o.tx_guid}'
+        )
+    lines.append(
+        f'        then re-import the {record_word} with a fresh '
+        f'`payment:` block, or'
+    )
+    lines.append(
+        f'     b) re-import the {record_word} with a `payment:` block '
+        f'that includes'
+    )
+    if n == 1:
+        lines.append(f'          txn_guid: "{orphans[0].tx_guid}"')
+    else:
+        lines.append('          txn_guid: "<orphan-guid>"  (one block per orphan)')
+    lines.append(
+        '        to retarget the existing bank transaction(s) into the '
+        'new posted lot'
+    )
+    lines.append('        (see docs/issues/Q-004 for the retarget mechanism).')
+
+    return '\n'.join(lines)
+
+
 def find_lot_payment_transactions(rec) -> List[OrphanPayment]:
     """Return every payment-class transaction attached to `rec`'s posted lot.
 
@@ -261,6 +363,202 @@ def find_lot_payment_transactions(rec) -> List[OrphanPayment]:
             description=description,
             memo=bank_memo,
         ))
+    return results
+
+
+def find_prepayments_in_book(book: Book,
+                              customer_id: str = None,
+                              vendor_id: str = None) -> List['OrphanPayment']:
+    """Walk the book and return every open AR/AP lot that holds an
+    unconsumed customer/vendor credit (a "pre-payment").
+
+    A prepayment lot is the residual GnuCash creates when a customer
+    overpays an invoice (or a vendor is overpaid on a bill), or when a
+    standalone payment is recorded without an invoice to attach to. The
+    lot stays open on the AR/AP account until consumed by a future
+    invoice via `gncInvoiceAutoApplyPayments` (or by the GnuCash UI's
+    Process Payment).
+
+    Criteria — every lot must satisfy all of them:
+
+      1. Lives on an A/Receivable or A/Payable account.
+      2. `gncInvoiceGetInvoiceFromLot` returns NULL (no invoice/bill is
+         the source of the lot's existence — distinguishes prepay lots
+         from invoice/bill lots that happen to still be open from
+         partial payment).
+      3. Lot balance != 0 (excludes empty lots that haven't been
+         garbage-collected yet).
+      4. We can identify the owner (customer/vendor) from the parent
+         payment tx of one of the lot's splits, via
+         `gncOwnerGetOwnerFromTxn` (or the custom-KVP fallback that
+         Q-014 introduced for roundtripped payments).
+
+    Returns `List[OrphanPayment]` — the dataclass is reused because the
+    surface fields (owner, source tx, amount, currency, bank account)
+    are the same as for orphan payments. The `amount` field is the
+    *lot's balance* (the unconsumed credit), not the original payment
+    amount.
+
+    Filters:
+      - `customer_id` restricts to that customer's credits.
+      - `vendor_id` restricts to that vendor's credits.
+      - Pass neither for the whole-book sweep.
+    """
+    import gnucash.gnucash_core_c as _gc
+    from gnucash import GncLot, Split
+
+    lib = load_gnc_engine()
+    for name, restype, argtypes in [
+        ('xaccAccountGetType',         ctypes.c_int,    [ctypes.c_void_p]),
+        ('xaccSplitGetAccount',        ctypes.c_void_p, [ctypes.c_void_p]),
+        ('xaccSplitGetAmount',         GncNumericC,     [ctypes.c_void_p]),
+        ('xaccTransGetDate',           ctypes.c_int64,  [ctypes.c_void_p]),
+        ('xaccTransGetDescription',    ctypes.c_char_p, [ctypes.c_void_p]),
+        ('xaccTransGetCurrency',       ctypes.c_void_p, [ctypes.c_void_p]),
+        ('gnc_commodity_get_mnemonic', ctypes.c_char_p, [ctypes.c_void_p]),
+        ('qof_instance_get_guid',      ctypes.c_void_p, [ctypes.c_void_p]),
+        ('guid_to_string_buff',        ctypes.c_char_p, [ctypes.c_void_p, ctypes.c_char_p]),
+        ('xaccAccountGetName',         ctypes.c_char_p, [ctypes.c_void_p]),
+        ('gnc_account_get_parent',     ctypes.c_void_p, [ctypes.c_void_p]),
+        ('gncOwnerGetOwnerFromTxn',    ctypes.c_int,    [ctypes.c_void_p, ctypes.c_void_p]),
+        ('gncOwnerGetID',              ctypes.c_char_p, [ctypes.c_void_p]),
+        ('gncOwnerGetName',            ctypes.c_char_p, [ctypes.c_void_p]),
+        ('gncOwnerGetType',            ctypes.c_int,    [ctypes.c_void_p]),
+    ]:
+        try:
+            f = getattr(lib, name)
+            f.restype = restype
+            f.argtypes = argtypes
+        except AttributeError:
+            pass
+
+    def _acct_full_name(acct_ptr) -> str:
+        parts = []
+        ptr = acct_ptr
+        while ptr:
+            name = safe_ctypes_string(lib.xaccAccountGetName, ptr)
+            if name:
+                parts.append(name)
+            parent = lib.gnc_account_get_parent(ptr)
+            if not parent or not lib.gnc_account_get_parent(parent):
+                break
+            ptr = parent
+        parts.reverse()
+        return ':'.join(parts)
+
+    owner_buf = ctypes.create_string_buffer(256)
+    owner_ptr = ctypes.cast(owner_buf, ctypes.c_void_p).value
+
+    from gnucash import (
+        ACCT_TYPE_PAYABLE,
+        ACCT_TYPE_RECEIVABLE,
+    )
+
+    from infrastructure.gnucash.kvp import get_custom_metadata
+    from infrastructure.gnucash.utils import get_account_full_name
+
+    results: List[OrphanPayment] = []
+
+    def walk(acct):
+        atype = lib.xaccAccountGetType(int(acct.instance))
+        if atype in (11, 12):  # AR, AP
+            for raw_lot in acct.GetLotList():
+                lot = GncLot(instance=raw_lot)
+                # Criterion 2: no invoice attached.
+                if _gc.gncInvoiceGetInvoiceFromLot(raw_lot):
+                    continue
+                # Criterion 3: nonzero balance (unconsumed credit).
+                balance = lot.get_balance().to_double()
+                if abs(balance) < 1e-6:
+                    continue
+
+                # Identify owner via the parent tx of the first split.
+                members = list(lot.get_split_list())
+                if not members:
+                    continue
+                first = Split(instance=members[0])
+                tx = first.GetParent()
+                tx_ptr = int(tx.instance)
+
+                got = lib.gncOwnerGetOwnerFromTxn(tx_ptr, owner_ptr)
+                owner_id = ''
+                owner_type = 0
+                owner_name = ''
+                if got == 1:
+                    oid_raw = lib.gncOwnerGetID(owner_ptr)
+                    owner_id = oid_raw.decode('utf-8', errors='replace') if oid_raw else ''
+                    owner_type = lib.gncOwnerGetType(owner_ptr)
+                    name_raw = lib.gncOwnerGetName(owner_ptr)
+                    owner_name = name_raw.decode('utf-8', errors='replace') if name_raw else ''
+                else:
+                    # Custom-KVP fallback (Q-014 plaintext roundtrip).
+                    kvp = get_custom_metadata(tx) or {}
+                    kvp_owner = kvp.get('owner', '')
+                    if kvp_owner and ':' in kvp_owner:
+                        kind, _, oid = kvp_owner.partition(':')
+                        kind, oid = kind.strip(), oid.strip()
+                        if kind == 'customer' and oid:
+                            cust = book.CustomerLookupByID(oid)
+                            if cust is not None and cust.GetID():
+                                owner_type, owner_id, owner_name = 2, oid, cust.GetName() or ''
+                        elif kind == 'vendor' and oid:
+                            vend = book.VendorLookupByID(oid)
+                            if vend is not None and vend.GetID():
+                                owner_type, owner_id, owner_name = 4, oid, vend.GetName() or ''
+                if not owner_id:
+                    continue
+                if customer_id and not (owner_type == 2 and owner_id == customer_id):
+                    continue
+                if vendor_id and not (owner_type == 4 and owner_id == vendor_id):
+                    continue
+
+                # Source tx fields. Find the bank-side split of the original
+                # payment tx (for the user's reference back to where the
+                # credit came from).
+                bank_acct_name = ''
+                bank_memo = ''
+                for i in range(tx.CountSplits()):
+                    sp = tx.GetSplit(i)
+                    sp_acct = sp.GetAccount()
+                    if sp_acct is None:
+                        continue
+                    sp_atype = sp_acct.GetType()
+                    if sp_atype in (ACCT_TYPE_RECEIVABLE, ACCT_TYPE_PAYABLE):
+                        continue
+                    bank_acct_name = get_account_full_name(sp_acct)
+                    bank_memo = sp.GetMemo() or ''
+                    break
+
+                date_str = tx.GetDate().strftime('%Y-%m-%d')
+                description = tx.GetDescription() or ''
+                commodity_ptr = lib.xaccTransGetCurrency(tx_ptr)
+                mnemonic_raw = (lib.gnc_commodity_get_mnemonic(commodity_ptr)
+                                if commodity_ptr else None)
+                currency = (mnemonic_raw.decode('ascii', errors='replace')
+                            if mnemonic_raw else '')
+                guid_ptr = lib.qof_instance_get_guid(tx_ptr)
+                buf = ctypes.create_string_buffer(40)
+                lib.guid_to_string_buff(guid_ptr, buf)
+                tx_guid = buf.value.decode('ascii').replace('-', '')
+
+                results.append(OrphanPayment(
+                    tx_guid=tx_guid,
+                    date=date_str,
+                    bank_account=bank_acct_name,
+                    amount=f'{abs(balance):.2f}',
+                    currency=currency,
+                    description=description,
+                    memo=bank_memo,
+                    owner_type=owner_type,
+                    owner_id=owner_id,
+                    owner_name=owner_name,
+                    ar_ap_account=get_account_full_name(acct),
+                ))
+
+        for child in acct.get_children():
+            walk(child)
+
+    walk(book.get_root_account())
     return results
 
 


### PR DESCRIPTION
Closes seven related gaps on the import / export path that together broke every real-world payment shape beyond "one cash payment exactly matching invoice total". Three were silent data-corruption defects; four were missing-feature gaps where overpayment credits and credit consumption couldn't be expressed in plaintext at all.

* **Add-payment fast path.** Re-importing a posted invoice/bill where the only diff is "directive appends payment(s) at the tail" now applies just the new payments via ApplyPayment on the still-posted record. No Unpost, no rebuild, no orphan, no GUID churn. Mirrors Q-010's `_is_only_unpost_diff` classifier. Symmetric for bills.

* **Importer-side orphan warning.** All four importer callsites of `Unpost(False)` (Q-010 minimal-unpost for invoice + bill, destructive rebuild for invoice + bill) now emit the same per-record orphan-payment warning block Q-014's `unpost-invoices` / `unpost-bills` CLI commands ship. Formatter factored out of `cli/unpost_cmd.py` into `use_cases/unpost_business_objects.py` as `format_orphan_warning_block(kind, orphans, ident)` so the unpost CLI and the import CLI emit identical warning text.

* **`prepayment:` field on `payment:` blocks.** Exporter emits it when a payment tx has AR/AP-side splits outside the invoice/bill's posted lot (the GnuCash-native overpayment shape). Matcher compares the declared value to the actual residual. Round-trips cleanly.

* **`txn_guid:` retarget path with overpayment.** When the pre-existing bank tx's counter-split exceeds the invoice/bill remaining, `prepayment: N` is now required: the new `_retarget_with_prepayment_split` mechanic splits the counter-split into invoice-portion (closes the lot) + residual (new pre-payment lot on AR/AP). Missing `prepayment:` on an over-sized retarget is rejected with an explicit error naming the bank tx, the counter-split amount, the invoice remaining, and the expected `prepayment` value. Equivalence test asserts the retarget path produces the same semantic end-state as ApplyPayment overpayment across initial import + double roundtrip.

* **`auto_apply_credit:` flag on invoice/bill headers.** When set, after `PostToAccount`, the importer calls `inv.AutoApplyPayments()` — GnuCash's canonical mechanism for consuming customer / vendor pre-payment lots toward this invoice/bill. Composes with cash `payment:` blocks (cash first, then auto-apply for any remainder). Exporter detects the post-auto-apply state and emits the flag for round-trip stability.

* **`find-prepayments` CLI.** New read-only command, parallel to Q-014's `find-orphan-payments`. Walks the book for open AR/AP lots that aren't attached to any invoice/bill (i.e. unconsumed customer / vendor credits); reports owner, amount, currency, source bank tx, ar/ap account. Supports `--customer` / `--vendor` filters.

* **Critical matcher fix.** `_single_payment_matches` now finds the bank-side split by `bank_account` name match rather than "first split that isn't the in-lot AR/AP split". Fixes a silent iteration-order-dependent bill-overpayment duplication on roundtrip (3-split payment txs were mis-identifying the +50 AP split as bank, returning False from the matcher, triggering destructive rebuild, and silently duplicating the bank tx).

58 integration tests across seven files, all passing on every supported distro (debian11/12/13, ubuntu20/22/24/26, fedora41, opensuse, arch). 84 plaintext fixtures under tests/fixtures/q015_*.txt with distinct invoice/bill IDs and amounts per scenario so a reader can tell at a glance which fixture each test uses.

README documents the new `prepayment:`, `auto_apply_credit:`, and `find-prepayments` surface with sample output. `docs/payment-manual-edit-behavior.md` characterises importer behaviour under five book / plaintext-divergence scenarios.