### PR TITLE
chore: bump to 0.3.3, roll up release notes, reconcile issue tracker, prune CLAUDE.md migration scaffolding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ Project-specific rules and conventions for Claude Code and Gemini CLI assistance
    - Blank line after subject
    - **Detailed body** explaining *what* was changed and *why* (the context/rationale)
    - Use bullet points for multiple specific changes
+   - Describe the end-state of the project, not the path that got there: don't reference old filenames being "renamed" or behaviour being "replaced" — the diff already shows that and the description ages badly
    - This provides critical context for future developers (and future AI sessions)
 
 3. **Verify before commit**
@@ -68,24 +69,12 @@ This is an open-source project. **Never commit directly to `main`.**
 ### ❌ NEVER Do These:
 - Commit directly to `main`
 - Do feature work inside `worktree/main` — it is reserved for the main branch only
+- Delete the remote branch (`git push origin --delete <branch>`); the GitHub PR-merge UI handles remote cleanup
+
+### After creating a worktree
+- Run `git config --worktree core.bare false` inside the new worktree before any other git ops; otherwise commits fail with a bare-repo error.
 
 ---
-
-## Branch Strategy
-
-### Working Branch: `architecture-migration`
-- All Phase 0-6 work happens here
-- Old code (`editor/`, `parser/`) stays in place until Phase 6
-- New code (`cli/`, `services/`, `infrastructure/`, `use_cases/`) built alongside
-
-### Merge to `main` ONLY After Phase 6
-Merge criteria:
-- ✅ All new tests pass in Docker
-- ✅ Regression tests confirm same output as old code
-- ✅ CLI commands work end-to-end
-- ✅ Documentation updated
-- ✅ Old code deleted
-- ✅ Migration guide in README
 
 ## Docker Rules
 
@@ -109,19 +98,15 @@ Merge criteria:
 - `reference_file*.txt` - sample data for understanding format
 - `.claude/` - Claude CLI directory
 
-### Migration Work (IN git, on architecture-migration branch)
-- `Dockerfile` - unified Docker environment
-- `migration_plan.md` - architecture and phase plan
-- `migration_log.md` - progress tracking
-- `scripts/` - helper scripts for all platforms
-- `CLAUDE.md` - this file with project rules
-
-### Future Work (will be added during Phases 1-6)
-- `cli/` - CLI commands (Phase 4)
-- `services/` - business logic (Phase 1)
-- `infrastructure/` - I/O layers (Phase 2)
-- `use_cases/` - orchestration (Phase 3)
-- `tests/` - test suites (all phases)
+### Repository Layout
+- `cli/` - Click-based CLI commands; `cli/main.py` is the entry point
+- `services/` - business logic (importer, exporter, matcher, validator, renderer, statement-reconciler, ...)
+- `use_cases/` - orchestration that composes services for a single CLI command
+- `infrastructure/` - I/O adapters: `gnucash/` (engine bindings + ctypes wrappers), `plaintext/`, `pdf/`, `qfx/`
+- `repositories/` - thin GnuCash session and query layer
+- `tests/` - `unit/` (services / use cases / infrastructure / repositories) and `integration/` (CLI end-to-end); `research/` holds long-running scenario probes
+- `docs/` - design notes, issue tracker (`docs/issues/`), research probes, post-mortems
+- `templates/` - Jinja/XSLT templates for invoice and report rendering
 
 ## Testing Philosophy
 
@@ -160,12 +145,11 @@ Merge criteria:
 
 ## Common Mistakes to Avoid
 
-1. **Committing too early** - Phase 0 has 3 days, only Day 1 is complete
-2. **Adding reference files** - They're external, don't commit
-3. **Using git add -A** - Stage files explicitly
-4. **Skipping planning** - Follow the phase plan in migration_plan.md
-5. **Working on main** - Use architecture-migration branch
-6. **Merging too early** - Only after Phase 6 completion
+1. **Adding reference files** - `convert_qfx.py`, `ledger.py`, `reference_file*.txt` are external; don't commit them
+2. **Using `git add -A`** - Stage files explicitly so you don't sweep in untracked probes or secrets
+3. **Working on main** - Always create a feature worktree + branch (see Feature Branch Workflow)
+4. **Running pytest / python directly** - All tests must run via `./scripts/test.sh` in Docker so they hit a real GnuCash install
+5. **Skipping lint before commit** - Run `./scripts/fix-lint.sh --unsafe` before staging, not after the pre-commit hook rejects you
 
 ## Useful Commands
 
@@ -177,7 +161,7 @@ git diff --cached --name-only
 
 ### Verify branch
 ```bash
-git branch --show-current  # Should be: architecture-migration
+git branch --show-current  # main only when on worktree/main; a feature branch elsewhere
 ```
 
 ### Build and test
@@ -355,5 +339,4 @@ for all bill entries. Do NOT compare against `taxable: false` in bill export.
 
 ---
 
-**Last Updated**: 2026-04-02
-**Current Phase**: Phase 8 (Business Objects)
+**Last Updated**: 2026-05-20

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,109 @@
 # Release Notes
 
+## v0.3.3 - Payment workflows, statement import, business-object round-trip hardening (2026-05-20)
+
+This release closes the round-trip story for invoices, bills, and payments, and adds an end-to-end pipeline for reconciling raw bank statements into import-ready plaintext. Two months of bug fixes, format extensions, and new CLI subcommands.
+
+### Payment workflows
+
+Posted invoices and bills now accept incremental edits via re-import: append a `payment:` block to a posted record, re-import, and only the new payment is applied — the posting transaction, every entry, and the original bank-side payment transactions on the lot keep their GUIDs. Overpayments create an AR/AP credit lot for the owner; subsequent invoices/bills can consume the credit by setting `auto_apply_credit: true`. ([Q-015](docs/issues/Q-015-incremental-payment-reimport-rebuilds-destructively.md))
+
+Single-invoice payment retarget and multi-invoice shared bank transactions now round-trip cleanly: both the bank-side transaction and the invoice's payment block emit the full transaction GUID plus per-split GUIDs, and the importer processes standalone transactions before business objects so `payment: txn_guid:` resolves on the first pass. ([Q-016](docs/issues/Q-016-full-guid-emission-and-import-order-for-payment-roundtrip.md))
+
+```bash
+# Append a payment to a posted invoice
+$EDITOR ledger.txt   # add another payment: { ... } block
+gnucash-plaintext import mybook.gnucash ledger.txt --include-business-objects
+```
+
+### New CLI subcommands
+
+- `unpost-invoices` / `unpost-bills`: unpost without re-import. Warns about bank-side payment transactions that would become orphan if their lot is unposted. ([Q-014](docs/issues/Q-014-orphan-payment-warning-on-unpost.md))
+- `delete-invoices` / `delete-bills`: remove unposted invoices and bills from the book (refuses posted records — unpost first). ([Q-013](docs/issues/Q-013-delete-unposted-invoice-bill.md))
+- `find-orphan-payments`: list bank-side payment transactions whose AR/AP lot is no longer attached to any invoice or bill. Read-only.
+- `find-prepayments`: list open AR/AP credit lots not yet consumed by an invoice or bill. Read-only.
+- `find-transactions`: search transactions by account, date, or description.
+- `delete-customers` / `archive-customers` / `archive-vendors`: retire owners by ID or `--by-guid`. Archive flips the `active` flag; delete refuses owners with open invoices, bills, or payments. ([F-011](docs/issues/F-011-customer-active-delete.md), [Q-007](docs/issues/Q-007-delete-archive-by-guid.md))
+
+### Statement import pipeline
+
+A four-stage pipeline takes a raw bank statement (CSV / OFX / QFX provider) through reconciliation against the book and produces an import-ready plaintext file with categorized splits.
+
+1. `StatementProvider` — adapter protocol for statement sources.
+2. `StatementReconciler` — matches statement rows against existing transactions in the book (by date + amount + memo signature).
+3. `ReconcilePreviewWriter` / `ReconcilePreviewReader` — human-editable preview file lists matches, ambiguous rows, and unmatched rows.
+4. `GnuCashFuzzyMatcher` + `ReadyToImportWriter` — suggests counter-accounts from history and emits import-ready plaintext.
+
+See [docs/statement-import-pipeline.md](docs/statement-import-pipeline.md) and [docs/bank-import-workflow.md](docs/bank-import-workflow.md). ([F-005](docs/issues/F-005-data-models-and-provider-protocol.md)..[F-009](docs/issues/F-009-ready-to-import-writer.md))
+
+### print-invoice: plaintext output and multi-invoice selection
+
+`print-invoice` gained a plaintext renderer with audit-friendly tax totals (subtotal, per-tax-table breakdown, total) suitable for `git diff` review of quarterly invoices, and a `--template` flag for custom XSLT/Jinja templates. Multi-invoice selection by date range, customer, or glob produces either a combined PDF or one file per invoice. The `UNIT` column is hidden by default and the `action:` field is now optional. ([Q-011](docs/issues/Q-011-invoice-action-optional-and-custom-template.md), [Q-017](docs/issues/Q-017-print-invoice-plaintext-format-and-multi-invoice.md))
+
+```bash
+# Plaintext, all Q1 2026 invoices for one customer
+gnucash-plaintext print-invoice mybook.gnucash \
+  --customer C001 --date-from 2026-01-01 --date-to 2026-03-31 \
+  --format plaintext -o q1-acme.txt
+
+# One PDF per invoice, into a directory
+gnucash-plaintext print-invoice mybook.gnucash \
+  --customer C001 --date-from 2026-01-01 --date-to 2026-03-31 \
+  --format pdf -o q1-acme/
+```
+
+Also: `print-invoice` no longer crashes on unposted invoices — they render as a draft watermark. ([Q-012](docs/issues/Q-012-print-invoice-on-unposted-invoice-crashes.md))
+
+### Cash-basis invoice marker
+
+Invoices can be tagged `cash_basis: true` to identify revenue that should be reported on the payment date rather than the invoice date — for cash-basis tax filers (Canadian small business below the CRA threshold, US Schedule C, single-entity service consultancies). The flag is descriptive metadata stored as a KVP slot; it round-trips and does not change accounting behaviour. ([Q-018](docs/issues/Q-018-cash-basis-invoice-marker.md))
+
+### Business-object round-trip correctness
+
+- Exported account-type short-forms (`A/Receivable`, `A/Payable`) no longer crash re-import. ([Q-003](docs/issues/Q-003-account-type-export-not-reimportable.md))
+- Invoice payment blocks no longer create duplicate bank transactions when the same posted invoice is re-imported. ([Q-004](docs/issues/Q-004-payment-transaction-duplicates.md))
+- Business-object IDs are enforced unique on re-import, and full GUIDs are exported so conflict detection works across export/import cycles. ([Q-006](docs/issues/Q-006-business-object-id-uniqueness-and-guid-export.md))
+- Tax-table identity is enforced on import — re-importing a tax table with the same name no longer creates duplicates. ([Q-008](docs/issues/Q-008-taxtable-identity.md))
+- Posted invoices and bills are now mutable via the unpost-rebuild-repost cycle the importer runs internally; `unchanged` status is reported strictly when no field differs. ([Q-010](docs/issues/Q-010-strict-updated-status-on-no-change-reimport.md))
+- Import emits explicit create / update / unchanged / skip signals for every business object so re-imports are no longer silent. ([Q-009](docs/issues/Q-009-import-summary-business-objects.md))
+- The `active` flag round-trips for customers and vendors. ([F-011](docs/issues/F-011-customer-active-delete.md))
+- KVP custom-metadata round-trip is extended to every business-object type (was Transaction and Split only). ([F-010](docs/issues/F-010-kvp-metadata-all-object-types.md))
+- Business objects imported into an existing file are now persisted correctly (a save-path regression that bypassed the repository layer).
+
+### Error reporting
+
+Import errors include the source directive's line number, the directive type, and a snippet of the offending block. Inconsistent CLI exception types were normalized to a single hierarchy. ([Q-005](docs/issues/Q-005-import-errors-no-context.md), [Q-001](docs/issues/Q-001-inconsistent-cli-exception-types.md))
+
+### Platform support
+
+- Ubuntu 26.04 LTS (GnuCash 5.14) added to the test matrix.
+- Stale Windows scripts removed (Linux/macOS via Docker remains the supported development path).
+
+### Security
+
+- The `run` shim, which previously executed arbitrary scripts, is removed. ([S-001](docs/issues/S-001-run-command-executes-arbitrary-scripts.md))
+- The broad `except Exception` in the gzip fallback path is narrowed to the specific exceptions GnuCash raises so real errors are no longer masked. ([S-002](docs/issues/S-002-broad-exception-in-gzip-fallback.md))
+
+### Tests
+
+Coverage expanded across services and use cases:
+
+- Beancount round-trip data-fidelity tests.
+- `update_transaction` covers duplicate-account splits (the "meal + tip" bug) and is no longer dropped by deduplication.
+- Cross-currency split exports emit `@ price` annotations; multi-currency beancount export and close-books paths are now tested.
+- Plaintext parser edge cases, KVP colon validation, FX-rates YAML error paths, invoice renderer, and `print-invoice` have dedicated test files.
+- Disk-persistence tests for account-balance pricedb and close-books.
+- Five-state scenario tests for bills (unposted, posted/unpaid, single full payment, two partials, two payments totalling full amount) plus contradiction-error tests.
+
+### Documentation
+
+- [docs/bank-import-workflow.md](docs/bank-import-workflow.md) — end-to-end walk-through of the statement reconciliation pipeline.
+- [docs/invoice-payment-reconciliation.md](docs/invoice-payment-reconciliation.md) — payment lifecycle, incremental edits, orphan recovery, prepayment consumption.
+- [docs/payment-manual-edit-behavior.md](docs/payment-manual-edit-behavior.md) — reference for what the importer does to a payment block under each kind of diff (entry change vs. payment-only change).
+- [docs/research/2026-05-14-invoice-post-pay-unpost-cycle.md](docs/research/2026-05-14-invoice-post-pay-unpost-cycle.md) and [docs/post-mortems/2026-05-08-bill-postto-account-segfault.md](docs/post-mortems/2026-05-08-bill-postto-account-segfault.md) — research and post-mortem notes from this cycle.
+
+---
+
 ## v0.3.2 - export-accounts command (2026-04-08)
 
 ### What's new

--- a/cli/main.py
+++ b/cli/main.py
@@ -33,7 +33,7 @@ from cli.validate_cmd import validate_ledger
 
 
 @click.group()
-@click.version_option(version='0.2.0', prog_name='gnucash-plaintext')
+@click.version_option(version='0.3.3', prog_name='gnucash-plaintext')
 def cli():
     """
     GnuCash Plaintext - Work with GnuCash files in plaintext format.

--- a/docs/issues/F-003-export-date-range-filter-missing.md
+++ b/docs/issues/F-003-export-date-range-filter-missing.md
@@ -3,7 +3,7 @@ id: F-003
 title: export command has no date-range filter
 category: feature
 severity: enhancement
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/F-004-no-search-find-transaction-command.md
+++ b/docs/issues/F-004-no-search-find-transaction-command.md
@@ -3,7 +3,7 @@ id: F-004
 title: No search / find-transaction command
 category: feature
 severity: enhancement
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/F-005-data-models-and-provider-protocol.md
+++ b/docs/issues/F-005-data-models-and-provider-protocol.md
@@ -3,7 +3,7 @@ id: F-005
 title: "Statement import: data models and StatementProvider protocol"
 category: feature
 severity: high
-status: open
+status: closed
 branch: feature/statement-import-pipeline
 ---
 

--- a/docs/issues/F-006-statement-reconciler.md
+++ b/docs/issues/F-006-statement-reconciler.md
@@ -3,7 +3,7 @@ id: F-006
 title: "Statement import: StatementReconciler"
 category: feature
 severity: high
-status: open
+status: closed
 branch: feature/statement-import-pipeline
 depends_on: F-005
 ---

--- a/docs/issues/F-007-writer-and-preview-reader.md
+++ b/docs/issues/F-007-writer-and-preview-reader.md
@@ -3,7 +3,7 @@ id: F-007
 title: "Statement import: ReconcilePreviewWriter and ReconcilePreviewReader"
 category: feature
 severity: high
-status: open
+status: closed
 branch: feature/statement-import-pipeline
 depends_on: F-006
 ---

--- a/docs/issues/F-008-gnucash-fuzzy-matcher.md
+++ b/docs/issues/F-008-gnucash-fuzzy-matcher.md
@@ -3,7 +3,7 @@ id: F-008
 title: "Statement import: GnuCashFuzzyMatcher"
 category: feature
 severity: high
-status: open
+status: closed
 branch: feature/statement-import-pipeline
 depends_on: F-007
 ---

--- a/docs/issues/F-009-ready-to-import-writer.md
+++ b/docs/issues/F-009-ready-to-import-writer.md
@@ -3,7 +3,7 @@ id: F-009
 title: "Statement import: ReadyToImportWriter and end-to-end pipeline test"
 category: feature
 severity: high
-status: open
+status: closed
 branch: feature/statement-import-pipeline
 depends_on: F-008
 ---

--- a/docs/issues/F-010-kvp-metadata-all-object-types.md
+++ b/docs/issues/F-010-kvp-metadata-all-object-types.md
@@ -1,8 +1,10 @@
-# F-010: KVP Custom Metadata for All GnuCash Object Types
-
-## Status
-
-Open
+---
+id: F-010
+title: "KVP custom metadata for all GnuCash object types"
+category: feature
+severity: high
+status: closed
+---
 
 ## Summary
 

--- a/docs/issues/F-011-customer-active-delete.md
+++ b/docs/issues/F-011-customer-active-delete.md
@@ -1,7 +1,10 @@
-# F-011 — Customer/Vendor Active Flag Round-Trip and Safe Deletion
-
-## Status
-Open
+---
+id: F-011
+title: "Customer/vendor active flag round-trip and safe deletion"
+category: feature
+severity: high
+status: closed
+---
 
 ## Problem
 

--- a/docs/issues/Q-003-account-type-export-not-reimportable.md
+++ b/docs/issues/Q-003-account-type-export-not-reimportable.md
@@ -3,7 +3,7 @@ id: Q-003
 title: Exported file is not re-importable (mixed indentation + account type short-forms)
 category: quality
 severity: high
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/Q-004-payment-transaction-duplicates.md
+++ b/docs/issues/Q-004-payment-transaction-duplicates.md
@@ -3,7 +3,7 @@ id: Q-004
 title: Invoice payment blocks create duplicate bank transactions
 category: quality
 severity: high
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/Q-005-import-errors-no-context.md
+++ b/docs/issues/Q-005-import-errors-no-context.md
@@ -3,7 +3,7 @@ id: Q-005
 title: Import errors show raw exception message with no context
 category: quality
 severity: high
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/Q-006-business-object-id-uniqueness-and-guid-export.md
+++ b/docs/issues/Q-006-business-object-id-uniqueness-and-guid-export.md
@@ -3,7 +3,7 @@ id: Q-006
 title: Business object IDs are not unique on re-import; GUIDs are not exported
 category: quality
 severity: high
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/Q-007-delete-archive-by-guid.md
+++ b/docs/issues/Q-007-delete-archive-by-guid.md
@@ -3,7 +3,7 @@ id: Q-007
 title: delete/archive accept GUIDs; invoice/bill identity enforced on import
 category: quality
 severity: medium
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/Q-008-taxtable-identity.md
+++ b/docs/issues/Q-008-taxtable-identity.md
@@ -3,7 +3,7 @@ id: Q-008
 title: Tax-table identity not enforced on import; re-import duplicates
 category: quality
 severity: medium
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/Q-009-import-summary-business-objects.md
+++ b/docs/issues/Q-009-import-summary-business-objects.md
@@ -3,7 +3,7 @@ id: Q-009
 title: Business-object import is silent — re-import gives no signal of skip vs. create vs. update
 category: quality
 severity: medium
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/Q-010-strict-updated-status-on-no-change-reimport.md
+++ b/docs/issues/Q-010-strict-updated-status-on-no-change-reimport.md
@@ -3,7 +3,7 @@ id: Q-010
 title: Q-009 'updated' status is liberal — reports 'updated' for no-change re-imports
 category: quality
 severity: low
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/Q-011-invoice-action-optional-and-custom-template.md
+++ b/docs/issues/Q-011-invoice-action-optional-and-custom-template.md
@@ -3,7 +3,7 @@ id: Q-011
 title: Invoice `action` field forces a hardcode; UNIT column shows nonsense; no template override
 category: quality
 severity: low
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/Q-012-print-invoice-on-unposted-invoice-crashes.md
+++ b/docs/issues/Q-012-print-invoice-on-unposted-invoice-crashes.md
@@ -3,7 +3,7 @@ id: Q-012
 title: `print-invoice` on an unposted invoice crashes with NoneType error
 category: quality
 severity: medium
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/Q-013-delete-unposted-invoice-bill.md
+++ b/docs/issues/Q-013-delete-unposted-invoice-bill.md
@@ -3,7 +3,7 @@ id: Q-013
 title: No way to delete an unposted invoice or bill from the CLI
 category: feature
 severity: medium
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/Q-016-full-guid-emission-and-import-order-for-payment-roundtrip.md
+++ b/docs/issues/Q-016-full-guid-emission-and-import-order-for-payment-roundtrip.md
@@ -3,7 +3,7 @@ id: Q-016
 title: Full GUID emission (txn + per-split) + standalone-tx-first import order — enables clean roundtrip for single-invoice retarget AND multi-invoice shared bank tx
 category: quality
 severity: high
-status: open
+status: closed
 ---
 
 ## Problem

--- a/docs/issues/Q-017-print-invoice-plaintext-format-and-multi-invoice.md
+++ b/docs/issues/Q-017-print-invoice-plaintext-format-and-multi-invoice.md
@@ -1,4 +1,10 @@
-# Q-017 — `print-invoice` plaintext format + multi-invoice selection
+---
+id: Q-017
+title: "`print-invoice` plaintext format with tax totals; multi-invoice selection"
+category: quality
+severity: low
+status: closed
+---
 
 ## Pain point
 

--- a/docs/issues/Q-018-cash-basis-invoice-marker.md
+++ b/docs/issues/Q-018-cash-basis-invoice-marker.md
@@ -1,4 +1,10 @@
-# Q-018 — `cash_basis: true` invoice marker for cash-basis tax filing
+---
+id: Q-018
+title: "`cash_basis: true` invoice marker for cash-basis tax filing"
+category: quality
+severity: low
+status: closed
+---
 
 ## Pain point
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -3,56 +3,63 @@
 Known issues, gaps, and planned enhancements identified by code review.
 Each file follows the naming convention `<category>-<NNN>-<slug>.md`.
 
-When a fix is merged, update `status: open` → `closed` in the file's frontmatter.
+When a fix is merged, update `status: open` → `closed` in the file's frontmatter
+and in the **Status** column below.
 
 ## Tests
 
-| ID | Title | Severity |
-|----|-------|----------|
-| [T-001](T-001-print-invoice-no-dedicated-tests.md) | print-invoice command has no dedicated test file | high |
-| [T-002](T-002-invoice-renderer-no-unit-tests.md) | invoice_renderer.py has no unit tests | medium |
-| [T-003](T-003-kvp-colon-validation-untested.md) | KVP metadata colon validation is untested | medium |
-| [T-004](T-004-multi-currency-beancount-export-untested.md) | Multi-currency beancount export has no integration test | medium |
-| [T-005](T-005-multi-currency-close-books-untested.md) | Multi-currency close-books path has no test | medium |
-| [T-006](T-006-fx-rates-yaml-error-paths-untested.md) | FX rates YAML error paths are untested | low |
-| [T-007](T-007-plaintext-parser-edge-cases-untested.md) | Plaintext parser edge cases are not tested | medium |
+| ID | Title | Severity | Status |
+|----|-------|----------|--------|
+| [T-001](T-001-print-invoice-no-dedicated-tests.md) | print-invoice command has no dedicated test file | high | closed |
+| [T-002](T-002-invoice-renderer-no-unit-tests.md) | invoice_renderer.py has no unit tests | medium | closed |
+| [T-003](T-003-kvp-colon-validation-untested.md) | KVP metadata colon validation is untested | medium | closed |
+| [T-004](T-004-multi-currency-beancount-export-untested.md) | Multi-currency beancount export has no integration test | medium | closed |
+| [T-005](T-005-multi-currency-close-books-untested.md) | Multi-currency close-books path has no test | medium | closed |
+| [T-006](T-006-fx-rates-yaml-error-paths-untested.md) | FX rates YAML error paths are untested | low | closed |
+| [T-007](T-007-plaintext-parser-edge-cases-untested.md) | Plaintext parser edge cases are not tested | medium | closed |
 
 ## Security
 
-| ID | Title | Severity |
-|----|-------|----------|
-| [S-001](S-001-run-command-executes-arbitrary-scripts.md) | run command executes arbitrary scripts without documented risk | low |
-| [S-002](S-002-broad-exception-in-gzip-fallback.md) | Broad except-Exception in gzip fallback masks real errors | low |
+| ID | Title | Severity | Status |
+|----|-------|----------|--------|
+| [S-001](S-001-run-command-executes-arbitrary-scripts.md) | run command executes arbitrary scripts without documented risk | low | closed |
+| [S-002](S-002-broad-exception-in-gzip-fallback.md) | Broad except-Exception in gzip fallback masks real errors | low | closed |
 
 ## Features
 
-| ID | Title | Severity |
-|----|-------|----------|
-| [F-001](F-001-qfx-dependency-declared-but-not-implemented.md) | QFX/OFX dependency declared but feature not implemented | medium |
-| [F-002](F-002-balance-sheet-command-missing.md) | No balance-sheet command | enhancement |
-| [F-003](F-003-export-date-range-filter-missing.md) | export command has no date-range filter | enhancement |
-| [F-004](F-004-no-search-find-transaction-command.md) | No search / find-transaction command | enhancement |
-| [F-005](F-005-data-models-and-provider-protocol.md) | Statement import: data models and StatementProvider protocol | feature |
-| [F-006](F-006-statement-reconciler.md) | Statement import: StatementReconciler (depends on F-005) | feature |
-| [F-007](F-007-writer-and-preview-reader.md) | Statement import: ReconcilePreviewWriter and ReconcilePreviewReader (depends on F-006) | feature |
-| [F-008](F-008-gnucash-fuzzy-matcher.md) | Statement import: GnuCashFuzzyMatcher (depends on F-007) | feature |
-| [F-009](F-009-ready-to-import-writer.md) | Statement import: ReadyToImportWriter and end-to-end test (depends on F-008) | feature |
+| ID | Title | Severity | Status |
+|----|-------|----------|--------|
+| [F-001](F-001-qfx-dependency-declared-but-not-implemented.md) | QFX/OFX dependency declared but feature not implemented | medium | open |
+| [F-002](F-002-balance-sheet-command-missing.md) | No balance-sheet command | enhancement | open |
+| [F-003](F-003-export-date-range-filter-missing.md) | export command has no date-range filter | enhancement | closed |
+| [F-004](F-004-no-search-find-transaction-command.md) | No search / find-transaction command | enhancement | closed |
+| [F-005](F-005-data-models-and-provider-protocol.md) | Statement import: data models and StatementProvider protocol | feature | closed |
+| [F-006](F-006-statement-reconciler.md) | Statement import: StatementReconciler (depends on F-005) | feature | closed |
+| [F-007](F-007-writer-and-preview-reader.md) | Statement import: ReconcilePreviewWriter and ReconcilePreviewReader (depends on F-006) | feature | closed |
+| [F-008](F-008-gnucash-fuzzy-matcher.md) | Statement import: GnuCashFuzzyMatcher (depends on F-007) | feature | closed |
+| [F-009](F-009-ready-to-import-writer.md) | Statement import: ReadyToImportWriter and end-to-end test (depends on F-008) | feature | closed |
+| [F-010](F-010-kvp-metadata-all-object-types.md) | KVP custom metadata for all GnuCash object types | high | closed |
+| [F-011](F-011-customer-active-delete.md) | Customer/vendor active flag round-trip and safe deletion | high | closed |
 
 ## Quality
 
-| ID | Title | Severity |
-|----|-------|----------|
-| [Q-001](Q-001-inconsistent-cli-exception-types.md) | Inconsistent exception types across CLI commands | low |
-| [Q-002](Q-002-read-book-company-info-bypasses-repo-layer.md) | read_book_company_info bypasses the repository layer | low |
-| [Q-003](Q-003-account-type-export-not-reimportable.md) | Exported account types (A/Receivable, A/Payable) crash re-import | high |
-| [Q-004](Q-004-payment-transaction-duplicates.md) | Invoice payment blocks create duplicate bank transactions (Cases B and C) | high |
-| [Q-005](Q-005-import-errors-no-context.md) | Import errors show raw exception with no directive context | high |
-| [Q-006](Q-006-business-object-id-uniqueness-and-guid-export.md) | Business-object IDs are not unique on re-import; GUIDs are not exported | high |
-| [Q-007](Q-007-delete-archive-by-guid.md) | delete/archive accept GUIDs; invoice/bill identity enforced on import | medium |
-| [Q-008](Q-008-taxtable-identity.md) | Tax-table identity not enforced on import; re-import duplicates | medium |
-| [Q-009](Q-009-import-summary-business-objects.md) | Business-object import is silent — re-import gives no signal of skip vs. create vs. update | medium |
-| [Q-010](Q-010-strict-updated-status-on-no-change-reimport.md) | `'updated'` is liberal — reports updated for no-change re-imports; posted invoices/bills can't be edited via re-import | low |
-| [Q-011](Q-011-invoice-action-optional-and-custom-template.md) | Invoice `action` field forces a hardcode; UNIT column shows nonsense; no template override | low |
-| [Q-012](Q-012-print-invoice-on-unposted-invoice-crashes.md) | `print-invoice` on an unposted invoice crashes with NoneType error | medium |
-| [Q-013](Q-013-delete-unposted-invoice-bill.md) | No way to delete an unposted invoice or bill from the CLI | medium |
-| [Q-014](Q-014-orphan-payment-warning-on-unpost.md) | `unpost-invoices` / `unpost-bills` don't warn about soon-to-be-orphan bank payments | medium |
+| ID | Title | Severity | Status |
+|----|-------|----------|--------|
+| [Q-001](Q-001-inconsistent-cli-exception-types.md) | Inconsistent exception types across CLI commands | low | closed |
+| [Q-002](Q-002-read-book-company-info-bypasses-repo-layer.md) | read_book_company_info bypasses the repository layer | low | closed |
+| [Q-003](Q-003-account-type-export-not-reimportable.md) | Exported account types (A/Receivable, A/Payable) crash re-import | high | closed |
+| [Q-004](Q-004-payment-transaction-duplicates.md) | Invoice payment blocks create duplicate bank transactions (Cases B and C) | high | closed |
+| [Q-005](Q-005-import-errors-no-context.md) | Import errors show raw exception with no directive context | high | closed |
+| [Q-006](Q-006-business-object-id-uniqueness-and-guid-export.md) | Business-object IDs are not unique on re-import; GUIDs are not exported | high | closed |
+| [Q-007](Q-007-delete-archive-by-guid.md) | delete/archive accept GUIDs; invoice/bill identity enforced on import | medium | closed |
+| [Q-008](Q-008-taxtable-identity.md) | Tax-table identity not enforced on import; re-import duplicates | medium | closed |
+| [Q-009](Q-009-import-summary-business-objects.md) | Business-object import is silent — re-import gives no signal of skip vs. create vs. update | medium | closed |
+| [Q-010](Q-010-strict-updated-status-on-no-change-reimport.md) | `'updated'` is liberal — reports updated for no-change re-imports; posted invoices/bills can't be edited via re-import | low | closed |
+| [Q-011](Q-011-invoice-action-optional-and-custom-template.md) | Invoice `action` field forces a hardcode; UNIT column shows nonsense; no template override | low | closed |
+| [Q-012](Q-012-print-invoice-on-unposted-invoice-crashes.md) | `print-invoice` on an unposted invoice crashes with NoneType error | medium | closed |
+| [Q-013](Q-013-delete-unposted-invoice-bill.md) | No way to delete an unposted invoice or bill from the CLI | medium | closed |
+| [Q-014](Q-014-orphan-payment-warning-on-unpost.md) | `unpost-invoices` / `unpost-bills` don't warn about soon-to-be-orphan bank payments | medium | closed |
+| [Q-015](Q-015-incremental-payment-reimport-rebuilds-destructively.md) | Incremental + overpayment + credit-consumption payment workflows on re-import | high | closed |
+| [Q-016](Q-016-full-guid-emission-and-import-order-for-payment-roundtrip.md) | Full GUID emission and import-order swap for clean payment roundtrip | high | closed |
+| [Q-017](Q-017-print-invoice-plaintext-format-and-multi-invoice.md) | `print-invoice` plaintext format with tax totals; multi-invoice selection | low | closed |
+| [Q-018](Q-018-cash-basis-invoice-marker.md) | `cash_basis: true` invoice marker for cash-basis tax filing | low | closed |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gnucash-plaintext"
-version = "0.2.0"
+version = "0.3.3"
 description = "GnuCash Plaintext - Convert between GnuCash and human-readable plaintext format"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
Two months of feature/fix work has shipped without the housekeeping that keeps the repo's published metadata trustworthy. This commit reconciles it in one pass so the version, release notes, issue tracker, and AI-agent rules all reflect current state.

Version metadata

- pyproject.toml and cli/main.py both reported 0.2.0 (the architecture migration release from 2026-03-01); RELEASE_NOTES had already gone through 0.3.0 / 0.3.1 / 0.3.2 without the source-of-truth strings being updated. So `--version` was reporting 0.2.0 while the released-and-documented version was already 0.3.2. The 0.2.0 → 0.3.3 jump here is the metadata catching up — not a real two-minor-version release; the intermediate 0.3.0 / 0.3.1 / 0.3.2 entries already exist below the new top entry in RELEASE_NOTES.

Release notes

- New v0.3.3 entry covers everything merged since v0.3.2 (2026-04-08): the payment workflow trilogy (Q-014 orphan-payment warning at unpost, Q-015 incremental + overpayment + credit-consumption, Q-016 full GUID emission and import-order swap), the statement import pipeline (F-005..F-009), business-object round-trip hardening (Q-003..Q-013, plus F-010 KVP-all-object-types and F-011 active-flag + archive/delete), the print-invoice plaintext format and multi-invoice selection (Q-017), the cash-basis invoice marker (Q-018), Ubuntu 26.04 support and the removal of stale Windows scripts, and the S-001/S-002 security cleanups.

Issue tracker

- docs/issues/ frontmatter is the source of truth for issue status. 19 issues were marked status: open in YAML frontmatter despite having shipped: Q-003, Q-004, Q-005, Q-006, Q-007, Q-008, Q-009, Q-010, Q-011, Q-012, Q-013, Q-016, F-003, F-004, F-005, F-006, F-007, F-008, F-009. All flipped to closed.
- Four issue files (F-010, F-011, Q-017, Q-018) had no YAML frontmatter at all — they used either a free-form "## Status / Open" heading or just a top-level H1 title. All four converted to the YAML-frontmatter schema every other issue file uses (id, title, category, severity, status: closed). With this, every issue file now follows the same schema, so a future tool can grep status across the directory uniformly.
- docs/issues/README.md was missing rows for Q-015, Q-017, Q-018, F-010, F-011 even though they had shipped. Added.
- docs/issues/README.md gains a Status column. Previously the index was a flat list with no signal of what was open vs. closed — a reader had to open every file to find out. The README opening paragraph now instructs maintainers to keep both the frontmatter and the new column in sync when closing an issue.

CLAUDE.md

- Removed the "Branch Strategy" section that described the architecture-migration branch and the "Merge to main ONLY After Phase 6" criteria. That migration completed before v0.2.0 was tagged.
- Replaced "Migration Work" + "Future Work (will be added during Phases 1-6)" file-organization stubs with a current Repository Layout section that actually describes the cli/services/use_cases/infrastructure/repositories/tests/docs/templates trees as they exist today.
- "Common Mistakes to Avoid" no longer references phase numbers or the architecture-migration branch. The list is shorter and the remaining items are still correct today (don't commit reference files, don't git add -A, don't work on main, don't run pytest outside Docker, don't skip lint before commit).
- "Verify branch" comment dropped the "Should be: architecture-migration" expectation that hasn't been true for two months.
- New worktree post-create step (git config --worktree core.bare false) documented under Feature Branch Workflow — without it commits from a fresh worktree fail with a bare-repo error.
- Remote branch deletion explicitly forbidden under the Feature Branch Workflow — remote cleanup happens via the GitHub PR-merge UI.
- Commit message guidance gained an "end-state, not refactor path" reminder.
- Footer dropped the "Current Phase: Phase 8" marker (phase tracking ended when the architecture migration did) and bumped Last Updated.

The ctypes / GnuCash bindings findings and the business-object quirks sections are untouched — they are still load-bearing reference material.