### PR TITLE
Q-019: draft tax breakdown, print-bill, two-sided rendering

### DIFF
--- a/cli/bill_print_cmd.py
+++ b/cli/bill_print_cmd.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python
+"""
+CLI command for printing GnuCash vendor bills.
+
+Q-019: parallel to cli/invoice_print_cmd.py. A bill is an inbound
+document (vendor → us), so the rendered output puts the vendor on the
+"Bill From" side and our company on the "Bill To" side (driven from
+the GnuCash book's Business → Company options).
+
+Output formats: pdf, html, plaintext. The plaintext format reuses the
+canonical bill block syntax (already understood by `import`) with
+Q-017 bill_* informational totals.
+"""
+
+import fnmatch
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import click
+import gnucash.gnucash_business as gb
+from gnucash import Query
+
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from services.bill_renderer import (
+    render_to_html,
+    render_to_plaintext,
+)
+from services.invoice_renderer import read_book_company_info
+
+_XSLT_PATH = Path(__file__).parent.parent / "services" / "bill.xslt"
+
+
+def _all_bills(book):
+    q = Query()
+    q.search_for('gncInvoice')
+    q.set_book(book)
+    results = []
+    for r in q.run():
+        bill = gb.Invoice(instance=r)
+        # Vendor bills only (skip customer invoices).
+        try:
+            vendor = bill.GetOwner().GetVendor()
+        except Exception:
+            vendor = None
+        if vendor is not None:
+            results.append(bill)
+    q.destroy()
+    return results
+
+
+def _filter_bills(bills, selectors, from_date, to_date, vendor):
+    """Apply selectors (AND-composed). `selectors` accepts exact bill
+    IDs or glob patterns when they contain `*?[` characters."""
+    out = bills
+
+    if selectors:
+        def _matches(bill):
+            bid = bill.GetID()
+            for sel in selectors:
+                if any(c in sel for c in '*?['):
+                    if fnmatch.fnmatch(bid, sel):
+                        return True
+                elif bid == sel:
+                    return True
+            return False
+        out = [b for b in out if _matches(b)]
+
+    if from_date:
+        from_dt = datetime.strptime(from_date, '%Y-%m-%d').date()
+        out = [b for b in out if b.GetDateOpened().date() >= from_dt]
+    if to_date:
+        to_dt = datetime.strptime(to_date, '%Y-%m-%d').date()
+        out = [b for b in out if b.GetDateOpened().date() <= to_dt]
+
+    if vendor:
+        out = [b for b in out
+               if b.GetOwner().GetVendor() is not None
+               and b.GetOwner().GetVendor().GetID() == vendor]
+
+    out.sort(key=lambda b: (b.GetDateOpened(), b.GetID()))
+    return out
+
+
+def _write_combined(bills, book, fmt, xslt_path, company_info, output):
+    if output == '-':
+        if fmt != 'plaintext':
+            raise click.UsageError(
+                '--output - (stdout) is only supported for --format plaintext '
+                '(pdf is binary; html is interactive)'
+            )
+        parts = [
+            render_to_plaintext(b, book, company_info=company_info)
+            for b in bills
+        ]
+        sys.stdout.write('\n'.join(parts))
+        return
+
+    output_path = Path(output)
+    if fmt == 'plaintext':
+        parts = [
+            render_to_plaintext(b, book, company_info=company_info)
+            for b in bills
+        ]
+        output_path.write_text('\n'.join(parts))
+        return
+
+    if fmt == 'html':
+        fragments = [
+            render_to_html(b, book, xslt_path, company_info=company_info)
+            for b in bills
+        ]
+        shell_parts = []
+        for frag in fragments:
+            inner = frag
+            for tag in ('</body>', '</html>'):
+                inner = inner.replace(tag, '')
+            # The XSLT emits `<!DOCTYPE html PUBLIC …>` + `<html lang="en">`
+            # per-fragment; literal `<html>` and absent DOCTYPE stripping
+            # leaves nested DOCTYPEs and nested `<html>` in the combined
+            # output (invalid both as HTML and XML). Strip all three so
+            # the combined doc has exactly one outer shell.
+            inner = re.sub(r'<!DOCTYPE[^>]*>', '', inner)
+            inner = re.sub(r'<html\b[^>]*>', '', inner)
+            inner = re.sub(r'<body\b[^>]*>', '', inner)
+            shell_parts.append(
+                f'<section style="page-break-after: always;">{inner}</section>'
+            )
+        combined = '<html><body>' + ''.join(shell_parts) + '</body></html>'
+        output_path.write_text(combined)
+        return
+
+    if fmt == 'pdf':
+        import weasyprint
+        fragments = [
+            render_to_html(b, book, xslt_path, company_info=company_info)
+            for b in bills
+        ]
+        shell_parts = []
+        for frag in fragments:
+            inner = frag
+            for tag in ('</body>', '</html>'):
+                inner = inner.replace(tag, '')
+            # The XSLT emits `<!DOCTYPE html PUBLIC …>` + `<html lang="en">`
+            # per-fragment; literal `<html>` and absent DOCTYPE stripping
+            # leaves nested DOCTYPEs and nested `<html>` in the combined
+            # output (invalid both as HTML and XML). Strip all three so
+            # the combined doc has exactly one outer shell.
+            inner = re.sub(r'<!DOCTYPE[^>]*>', '', inner)
+            inner = re.sub(r'<html\b[^>]*>', '', inner)
+            inner = re.sub(r'<body\b[^>]*>', '', inner)
+            shell_parts.append(
+                f'<section style="page-break-after: always;">{inner}</section>'
+            )
+        combined_html = (
+            '<html><body>' + ''.join(shell_parts) + '</body></html>'
+        )
+        weasyprint.HTML(string=combined_html).write_pdf(str(output_path))
+        return
+
+    raise click.UsageError(f'Unknown format: {fmt!r}')
+
+
+def _write_per_bill(bills, book, fmt, xslt_path, company_info, outdir):
+    outdir = Path(outdir.rstrip('/'))
+    outdir.mkdir(parents=True, exist_ok=True)
+    ext = {'plaintext': 'txt', 'html': 'html', 'pdf': 'pdf'}[fmt]
+    for b in bills:
+        target = outdir / f'{b.GetID()}.{ext}'
+        if fmt == 'plaintext':
+            target.write_text(
+                render_to_plaintext(b, book, company_info=company_info)
+            )
+        elif fmt == 'html':
+            target.write_text(
+                render_to_html(b, book, xslt_path,
+                               company_info=company_info)
+            )
+        elif fmt == 'pdf':
+            import weasyprint
+            html = render_to_html(b, book, xslt_path,
+                                  company_info=company_info)
+            weasyprint.HTML(string=html).write_pdf(str(target))
+
+
+@click.command()
+@click.argument('gnucash_file', type=click.Path(exists=True))
+@click.argument('bill_selectors', nargs=-1)
+@click.option("--bill-id", default=None,
+              help="Single bill ID (back-compat alias for a positional ID).")
+@click.option("--from", "from_date", default=None,
+              help="Include bills opened on or after this date (YYYY-MM-DD).")
+@click.option("--to", "to_date", default=None,
+              help="Include bills opened on or before this date (YYYY-MM-DD).")
+@click.option("--vendor", default=None, help="Filter by vendor ID.")
+@click.option("--format", "fmt", default='pdf',
+              type=click.Choice(['pdf', 'html', 'plaintext']),
+              help="Output format. plaintext uses the canonical bill block "
+                   "syntax with Q-017 informational totals.")
+@click.option("-o", "--output", required=True,
+              help="Output file path, directory (trailing /), or '-' for "
+                   "stdout (plaintext only).")
+@click.option("--template", "template_path", default=None,
+              type=click.Path(exists=True, dir_okay=False),
+              help=("Path to a custom XSLT template. Defaults to the "
+                    "embedded services/bill.xslt."))
+def print_bill(gnucash_file, bill_selectors, bill_id,
+               from_date, to_date, vendor, fmt, output, template_path):
+    """Prints one or more GnuCash vendor bills.
+
+    Examples:
+
+        # single bill → PDF
+        print-bill book.gnucash --bill-id BILL-001 -o out.pdf
+
+        # multiple bills, combined PDF
+        print-bill book.gnucash BILL-001 BILL-002 -o combined.pdf
+
+        # Q1 bills, one PDF per file
+        print-bill book.gnucash --from 2026-01-01 --to 2026-03-31 \\
+            --format pdf -o q1/
+
+        # plaintext stream of one vendor's bills, stdout
+        print-bill book.gnucash --vendor V-001 --format plaintext -o -
+    """
+    company_info = read_book_company_info(gnucash_file)
+
+    selectors = list(bill_selectors)
+    if bill_id:
+        selectors.append(bill_id)
+
+    if not selectors and not from_date and not to_date and not vendor:
+        raise click.UsageError(
+            'specify at least one bill: positional ID (e.g. BILL-001), '
+            'glob (e.g. \'BILL-2026-*\'), --from/--to date range, '
+            '--vendor, or --bill-id'
+        )
+
+    repo = GnuCashRepository(gnucash_file)
+    repo.open(SessionMode.READ_ONLY)
+    book = repo.book
+
+    try:
+        all_bills = _all_bills(book)
+        selected = _filter_bills(all_bills, selectors, from_date, to_date,
+                                 vendor)
+        if not selected:
+            criteria = []
+            if selectors:
+                criteria.append(f'selectors={selectors!r}')
+            if from_date:
+                criteria.append(f'from={from_date!r}')
+            if to_date:
+                criteria.append(f'to={to_date!r}')
+            if vendor:
+                criteria.append(f'vendor={vendor!r}')
+            raise click.UsageError(
+                'no bills matched the selection ('
+                + (', '.join(criteria) if criteria else 'no selectors given')
+                + ')'
+            )
+
+        xslt = template_path if template_path else str(_XSLT_PATH)
+        if output.endswith('/'):
+            _write_per_bill(selected, book, fmt, xslt, company_info, output)
+            click.echo(f'✓ Wrote {len(selected)} bill(s) to {output}')
+        else:
+            _write_combined(selected, book, fmt, xslt, company_info, output)
+            if output != '-':
+                click.echo(f'✓ Wrote {len(selected)} bill(s) to {output}')
+
+    finally:
+        repo.close()

--- a/cli/invoice_print_cmd.py
+++ b/cli/invoice_print_cmd.py
@@ -11,6 +11,7 @@ importer recomputes these on re-import and errors on mismatch.
 """
 
 import fnmatch
+import re
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -135,7 +136,14 @@ def _write_combined(invoices, book, fmt, xslt_path, company_info, output):
             inner = frag
             for tag in ('</body>', '</html>'):
                 inner = inner.replace(tag, '')
-            inner = inner.replace('<html>', '').replace('<body>', '')
+            # The XSLT emits `<!DOCTYPE html PUBLIC …>` + `<html lang="en">`
+            # per-fragment; literal `<html>` and absent DOCTYPE stripping
+            # leaves nested DOCTYPEs and nested `<html>` in the combined
+            # output (invalid both as HTML and XML). Strip all three so
+            # the combined doc has exactly one outer shell.
+            inner = re.sub(r'<!DOCTYPE[^>]*>', '', inner)
+            inner = re.sub(r'<html\b[^>]*>', '', inner)
+            inner = re.sub(r'<body\b[^>]*>', '', inner)
             shell_parts.append(
                 f'<section style="page-break-after: always;">{inner}</section>'
             )
@@ -156,7 +164,14 @@ def _write_combined(invoices, book, fmt, xslt_path, company_info, output):
             inner = frag
             for tag in ('</body>', '</html>'):
                 inner = inner.replace(tag, '')
-            inner = inner.replace('<html>', '').replace('<body>', '')
+            # The XSLT emits `<!DOCTYPE html PUBLIC …>` + `<html lang="en">`
+            # per-fragment; literal `<html>` and absent DOCTYPE stripping
+            # leaves nested DOCTYPEs and nested `<html>` in the combined
+            # output (invalid both as HTML and XML). Strip all three so
+            # the combined doc has exactly one outer shell.
+            inner = re.sub(r'<!DOCTYPE[^>]*>', '', inner)
+            inner = re.sub(r'<html\b[^>]*>', '', inner)
+            inner = re.sub(r'<body\b[^>]*>', '', inner)
             shell_parts.append(
                 f'<section style="page-break-after: always;">{inner}</section>'
             )
@@ -272,7 +287,7 @@ def print_invoice(gnucash_file, invoice_selectors, invoice_id,
                 criteria.append(f'customer={customer!r}')
             raise click.UsageError(
                 'no invoices matched the selection ('
-                + ', '.join(criteria) if criteria else 'no selectors given'
+                + (', '.join(criteria) if criteria else 'no selectors given')
                 + ')'
             )
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -8,6 +8,7 @@ plaintext format.
 import click
 
 from cli.account_balance_cmd import account_balance
+from cli.bill_print_cmd import print_bill
 from cli.close_books_cmd import close_books
 from cli.delete_cmd import (
     archive_customers,
@@ -65,6 +66,7 @@ cli.add_command(close_books, name='close-books')
 cli.add_command(export_transaction, name='export-transaction')
 cli.add_command(income_statement, name='income-statement')
 cli.add_command(print_invoice, name='print-invoice')
+cli.add_command(print_bill, name='print-bill')
 cli.add_command(account_balance, name='account-balance')
 cli.add_command(delete_transactions, name='delete-transactions')
 cli.add_command(find_transactions, name='find-transactions')

--- a/docs/issues/Q-012-print-invoice-on-unposted-invoice-crashes.md
+++ b/docs/issues/Q-012-print-invoice-on-unposted-invoice-crashes.md
@@ -64,18 +64,17 @@ class `badge-draft` for grey/neutral colouring. The payment-history
 section is already conditional (`<xsl:if test="payments/payment">`) so
 it naturally vanishes when no payments exist.
 
-## Known limitation (Q-012 v1)
+## Resolved in Q-019: draft per-tax breakdown
 
-A draft invoice's PDF will show subtotal but **no per-tax breakdown**
-(no GST line, PST line, etc.) and no grand total inclusive of tax. To
-compute taxes pre-posting we'd need to walk each entry's `tax_table`
-and apply the rate (PERCENT/VALUE) per entry, then aggregate by tax
-account — non-trivial because GnuCash's `gnc_entry_get_value` /
-`gnc_entry_get_tax_value` SWIG bindings are unreliable across versions
-(per CLAUDE.md hard-won findings). A future issue can extend this.
-
-For the draft preview use case, showing line items + subtotal is
-already a meaningful improvement over "500 Internal Server Error".
+(Originally Q-012 documented a known limitation here: draft invoices
+showed subtotal only, no per-tax breakdown, because GnuCash only
+materialises tax splits on the posting transaction.) Q-019 resolves
+this by walking each entry's tax_table directly via
+`compute_entry_informational`, aggregating per-tax-account totals, and
+emitting full `<tax-lines>` + grand-total-with-tax on every unposted
+invoice. A `<draft-tax-notice/>` element on the XML carries through to
+the XSLT as a "figures are provisional" caption so the viewer knows
+the numbers will be recomputed at post time.
 
 ## Files to change
 
@@ -85,13 +84,13 @@ already a meaningful improvement over "500 Internal Server Error".
 | `services/invoice.xslt` | Add `'draft'` case to the status badge `<xsl:choose>`. Add `.badge-draft` CSS rule. |
 | `tests/integration/test_q012_print_unposted_invoice.py` | New test file: print-invoice on unposted → exit 0 + PDF created; rendered HTML contains DRAFT badge; rendered HTML contains entry rows; rendered HTML does NOT contain payment-history table. |
 
-## Out of scope
+## Out of scope (originally — both shipped later)
 
-- Computing tax breakdown for drafts (see Known limitation above).
+- ~~Computing tax breakdown for drafts.~~ → Shipped in Q-019.
 - A "watermark" / overlay on draft PDFs — `badge-draft` in the header
   is enough signal.
-- Bill rendering — there's no `print-bill` command; bills are received,
-  not sent.
+- ~~Bill rendering — there's no `print-bill` command; bills are received,
+  not sent.~~ → `print-bill` shipped in Q-019 (audit-print use case).
 
 ---
 

--- a/docs/issues/Q-018-cash-basis-invoice-marker.md
+++ b/docs/issues/Q-018-cash-basis-invoice-marker.md
@@ -30,7 +30,7 @@ The flag does NOT expose the issuer's tax-method classification to the customer.
 
 For **posted** invoices (the same-day post+pay path), customer-facing rendering is fully unchanged regardless of the flag — the existing PAID badge already says everything that matters.
 
-The `--format plaintext` output (Q-017) doesn't change either — the existing informational fields (`entry_amount`, `entry_tax`, `breakdown:`, invoice totals) cover all the audit numbers; the flag rides along as a header KVP slot for the issuer's own tooling.
+The `--format plaintext` output (Q-017) doesn't change either — the existing informational fields (`entry_amount`, `entry_tax`, `breakdown:`, invoice totals) cover all the audit numbers; the flag rides along as a header KVP slot for the issuer's own tooling. Q-019 generalises the informational-field emission so they're present on every unposted invoice (cash-basis or accrual draft), not only on posted ones.
 
 The GnuCash UI continues to show the invoice in its normal posted/paid state — the flag lives in the KVP slot, not in GnuCash's invoice schema.
 

--- a/docs/issues/Q-019-draft-tax-render-and-two-sided-bill-rendering.md
+++ b/docs/issues/Q-019-draft-tax-render-and-two-sided-bill-rendering.md
@@ -1,0 +1,88 @@
+---
+id: Q-019
+title: "Draft tax breakdown + `print-bill` + two-sided rendering with company info"
+category: quality
+severity: medium
+status: closed
+---
+
+## Three related gaps in the rendering surface
+
+**1. Draft invoices lost their tax breakdown.** A cash-basis invoice (Q-018) doesn't post until cash arrives — and an accrual draft hasn't been posted yet either. Both render through the "is_draft" path, which historically (Q-012) emitted subtotal-only with no `<tax-lines>` and no grand total. For a Canadian small-business filer issuing a cash-basis invoice with GST/HST, this means the rendered PDF shows the wrong amount — line items only, no tax — exactly the case where tax detail matters most.
+
+**2. The plaintext renderer silently dropped seller info.** `render_to_plaintext(invoice, book, company_info=None)` accepted a `company_info=` parameter but never referenced it in its body — every rendered plaintext invoice came out with only the customer block, no "issued by" header. Customers receiving a plaintext invoice had no way to tell who sent it. The HTML/PDF path was correct (the XSLT renders a "From" block when book options carry Company Name), but the plaintext leg quietly bypassed it.
+
+**3. Vendor bills had no renderer at all.** `cli/invoice_print_cmd.py:39` explicitly filters out vendor bills ("Customer invoices only — skip vendor bills"). There was no `print-bill` CLI command, no `bill.xslt`, no `bill_renderer.py`. Cash-basis bill audit-print — useful for reviewing what you've recorded against what the vendor sent — was simply not supported.
+
+The three gaps share a single underlying assumption: *the renderer treats GnuCash's post-time data shape as the source of truth*. GnuCash only materialises tax splits at posting; it only stores company info under Business book options that nothing in the plaintext path ever wires up; and bills are GnuCash's `GncInvoice` objects too but routed through different SWIG getters (the `gncEntryGetBill*` family). Q-019 closes all three by computing what we need from primary sources (entries' tax_table, book options, vendor-side getters) rather than waiting for GnuCash to give it to us.
+
+## Resolution
+
+### Draft tax breakdown — computed from entries
+
+`compute_entry_informational` (added in Q-017) already returns `(net_amount, entry_tax, breakdown)` for any invoice entry — it walks the entry's `tax_table` and applies the rate, identical math to what GnuCash does at post time. Q-019 calls this from `invoice_to_xml` on the `is_draft` branch, aggregates per-tax-account totals into `<tax-lines>`, emits a real `<subtotal>`/`<total>`, and adds an empty `<draft-tax-notice/>` element. The XSLT renders the notice as a muted italic row under the tax-lines: *"Tax is computed from line-item tax tables; invoice not yet posted — figures are provisional."*
+
+For the plaintext path, the `if not is_draft:` gates around `entry_amount` / `entry_tax` / `breakdown:` / `invoice_tax_total` / `invoice_total` are dropped — these are emitted for every invoice. Drafts get a leading `# Tax figures are provisional — invoice not yet posted; recomputed at post time.` comment so the recipient knows the numbers will change. The parser was extended to skip lines whose lstrip() starts with `#`, so rendered output re-imports cleanly without the caveats polluting the recipient's book.
+
+The badge logic from Q-018 is preserved: plain accrual draft → DRAFT badge, cash-basis unposted → UNPAID badge. Only the tax-rendering rule changes; both flavors of unposted invoice now show full tax detail.
+
+### Plaintext seller header
+
+`render_to_plaintext` now emits a `# Issued by: <name> | Company ID: <id> | <addr> | <phone> | <email> | <url>` comment line at the top of each invoice block when `company_info` is populated. Comment-line form means the seller info doesn't survive re-import as KVPs — we don't want the recipient's book polluted with the sender's company info. The `Company ID:` label is jurisdiction-neutral (matches the GnuCash slot name verbatim) — the slot value is whatever tax-registration the issuer uses (CRA GST/HST, US EIN, UK VAT, HK BR, JP corporate number); validity of ITC claims depends on the value, not the label.
+
+### `print-bill` CLI + `bill_renderer.py` + `bill.xslt`
+
+`cli/bill_print_cmd.py` mirrors `invoice_print_cmd.py` exactly: same flags (`--format {pdf,html,plaintext}`, `--vendor`, `--from`, `--to`, `--bill-id`, `--template`, `-o`), same multi-bill selection (positional IDs, globs, date ranges), same combined/per-bill output modes.
+
+`services/bill_renderer.py` uses the Bill-side SWIG getters (`gncEntryGetBillTaxable`, `gncEntryGetBillTaxTable`, `gncEntryGetBillPrice`, etc.) per CLAUDE.md's "Bill Entry API vs Invoice Entry API" rule, and exposes `compute_bill_entry_informational` as the bill analogue of the invoice helper. The posted-bill tax extraction filters by "everything that's not the AP-posting account and not an Expense account is a tax accrual" — this covers both LIABILITY tax-accrual accounts and ASSET ITC-recoverable accounts (Canadian input-tax-credit books).
+
+`services/bill.xslt` mirrors `invoice.xslt` with the address sides swapped:
+- **Bill From** = the vendor (the supplier sending us the bill)
+- **Bill To** = our company (read from book options via `read_book_company_info`)
+
+The plaintext bill path emits a `# Bill received by: <us>` header plus a `# Bill from vendor: <vendor>` line so the audit reader sees both sides at a glance.
+
+## Two-sided rendering — both sides verified by tests
+
+The bug behind gap #2 ("plaintext silently dropped company info") existed because no test ever populated real Business → Company book options and verified the renderer emitted the From block. The new test suite (`tests/integration/test_q019_two_sided_render.py`) populates real options via the SWIG KvpFrame API (`book.GetSlots().set_slot_path(['options','Business','Company Name'], KvpValue('Acme'))`), then runs `print-invoice` / `print-bill` through the full CLI pipeline — which calls `read_book_company_info` itself. Mocking `company_info` would have left the reader-to-renderer wiring untested, exactly where the original bug hid.
+
+Coverage breakdown:
+- **Cash-basis unposted invoice with GST 5% + PST 7%** → HTML shows both tax-line rows (per-account aggregation), correct grand total (200 + 24 = 224), provisional notice. Plaintext shows the `#` caveat, `entry_tax: 24.00`, two `breakdown:` blocks, `invoice_total: 224.00`.
+- **Plain accrual draft with single 10% Sales Tax** → DRAFT badge preserved, single tax-line row, `tax-single` CSS class, correct total (300 + 30 = 330).
+- **Rendered draft plaintext re-imports without error** → verifies the parser's new `#`-comment handling.
+- **Invoice two-sided HTML** → asserts BOTH "Bill To" customer block AND "From" company block present with all populated fields (name, Company ID, address, phone, email, URL).
+- **Invoice plaintext seller header** → asserts the first line of the rendered text is `# Issued by: ` followed by every company field.
+- **Bill two-sided HTML** → asserts "Bill From" = vendor and "Bill To" = us; verifies the same tax-line + provisional-notice behaviour on the bill side.
+- **Bill plaintext** → asserts both `# Bill received by: <us>` and `# Bill from vendor: <vendor>` headers + `bill_subtotal` / `bill_tax_total` / `bill_total` fields.
+
+The generic GST 5% + PST 7% and single 10% Sales Tax tables (rather than Ontario HST 13%) keep the fixtures meaningful across the user's multi-jurisdiction book set.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `services/invoice_renderer.py` | `invoice_to_xml`: compute draft tax from entries via `compute_entry_informational`, emit `<tax-lines>` + `<draft-tax-notice/>`. `render_to_plaintext`: drop `if not is_draft:` gates, prepend `# Issued by:` seller header from `company_info`, prepend `# Tax figures are provisional` caveat on drafts. New helper `_render_seller_header`. |
+| `services/invoice.xslt` | New XSLT template renders `<draft-tax-notice/>` as a muted italic row under tax-lines. |
+| `services/plaintext_parser.py` | `parse_iterable` skips lines whose `lstrip()` starts with `#` so rendered caveat lines round-trip through re-import. |
+| `services/bill_renderer.py` | New module: `bill_to_xml`, `render_to_html`, `render_to_pdf`, `render_to_plaintext`, `compute_bill_entry_informational`, `_read_bill_tax_label`. Uses Bill-side SWIG getters per CLAUDE.md. |
+| `services/bill.xslt` | New XSLT, mirrors `invoice.xslt` with Bill From/Bill To roles swapped. |
+| `cli/bill_print_cmd.py` | New `print-bill` Click command — same flag surface as `print-invoice`. |
+| `cli/main.py` | Register `print-bill`. |
+| `tests/fixtures/q019_accounts.txt` | Q-019 accounts tree (AR, AP, Expenses, generic tax accounts). |
+| `tests/fixtures/q019_unposted_cash_with_tax.txt` | Cash-basis unposted invoice, GST+PST combined tax. |
+| `tests/fixtures/q019_unposted_draft_with_tax.txt` | Plain accrual draft invoice, single Sales Tax. |
+| `tests/fixtures/q019_unposted_cash_bill.txt` | Cash-basis unposted bill, GST+PST combined tax. |
+| `tests/integration/test_q019_draft_tax_render.py` | Draft tax breakdown + re-import smoke. |
+| `tests/integration/test_q019_two_sided_render.py` | Two-sided HTML + plaintext seller header for invoice and bill, end-to-end through the CLI with real book options. |
+| `docs/issues/Q-018-cash-basis-invoice-marker.md` | Note that informational fields now ride along on every unposted invoice (cash-basis OR accrual draft). |
+| `docs/issues/Q-012-print-invoice-on-unposted-invoice-crashes.md` | Strike the "no per-tax breakdown" known limitation; note `print-bill` shipped. |
+
+## Out of scope
+
+- **Watermarks / "DRAFT" overlay on PDFs.** The XSLT badge plus the new provisional-tax caveat row carry the same information without weasyprint background hacks.
+- **Customer-supplied seller info override.** The seller header always comes from book options; we don't accept `--from "Other Co"` overrides. Users who need different seller info per invoice use multiple GnuCash books, one per legal entity.
+- **A `print-receipt` command.** A paid cash-basis invoice already renders with a PAID badge and the payment history block; that's a receipt.
+
+---
+
+**Created**: 2026-05-21

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -63,3 +63,4 @@ and in the **Status** column below.
 | [Q-016](Q-016-full-guid-emission-and-import-order-for-payment-roundtrip.md) | Full GUID emission and import-order swap for clean payment roundtrip | high | closed |
 | [Q-017](Q-017-print-invoice-plaintext-format-and-multi-invoice.md) | `print-invoice` plaintext format with tax totals; multi-invoice selection | low | closed |
 | [Q-018](Q-018-cash-basis-invoice-marker.md) | `cash_basis: true` invoice marker for cash-basis tax filing | low | closed |
+| [Q-019](Q-019-draft-tax-render-and-two-sided-bill-rendering.md) | Draft tax breakdown + `print-bill` + two-sided rendering with company info | medium | closed |

--- a/infrastructure/gnucash/kvp.py
+++ b/infrastructure/gnucash/kvp.py
@@ -395,6 +395,59 @@ def set_custom_metadata(obj, metadata: dict) -> None:
         logging.error(f"Failed to store custom metadata: {e}")
 
 
+def set_book_string_option(book, section: str, name: str, value: str) -> bool:
+    """Set a string-valued book option at the canonical nested slot path
+    `options → <section> → <name>`. This is the same KVP layout the
+    GnuCash File→Properties dialog writes to, and the same one
+    `read_book_company_info` reads from. Used to populate book-level
+    options like Business→Company Name without going through the
+    GnuCash GUI.
+
+    Calls `qof_book_set_string_option(book, opt_name, opt_val)` via
+    ctypes: opt_name is slash-separated (e.g. `options/Business/Company
+    Name`) and the C side does the GSList path construction +
+    `g_strdup`-ing internally — no lifetime / variadic-ABI hazards to
+    manage in Python. Marks the book instance dirty so the next
+    session save serialises the new slots to XML.
+
+    There is no SWIG fallback: GnuCash's Python bindings don't expose
+    `KvpValue` at the top level on any platform we ship (verified on
+    Debian 11/12/13, Ubuntu 20/22/24/26), and the `KvpFrame.set_slot_path`
+    method on `book.GetSlots()` requires a `KvpValue` to wrap the string.
+    All paths funnel through ctypes.
+
+    Why this exists separately from `set_custom_metadata`: that helper
+    targets per-business-object KVPs (transactions, invoices) at a
+    single flat slot key (`plaintext_metadata`). Book options live at a
+    nested 3-deep path in a different namespace, so they need their
+    own API.
+    """
+    try:
+        obj_ptr = int(book.instance)
+        lib = _load_gnc_engine()
+        lib.qof_book_set_string_option.argtypes = [
+            ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p,
+        ]
+        lib.qof_book_set_string_option.restype = None
+
+        opt_path = f'options/{section}/{name}'.encode()
+        lib.qof_book_set_string_option(
+            ctypes.c_void_p(obj_ptr),
+            opt_path,
+            value.encode('utf-8'),
+        )
+        # qof_book_set_string_option marks the book dirty internally,
+        # but call our helper too so the session save reliably re-emits
+        # the slots (matches the pattern of every other write here).
+        _mark_instance_dirty(obj_ptr)
+        return True
+    except Exception as e:
+        logging.error(
+            f"Failed to set book option options/{section}/{name}: {e}"
+        )
+        return False
+
+
 def get_custom_metadata(obj) -> dict:
     """
     Read custom metadata from a GnuCash Transaction or Split KVP slot.

--- a/services/bill.xslt
+++ b/services/bill.xslt
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  invoice.xslt — Transform invoice XML → HTML
-  ============================================
-  Input XML structure (see invoice_to_xml() in test_business_roundtrip.py):
+  bill.xslt — Transform vendor-bill XML → HTML (Q-019)
+  ====================================================
+  Mirrors invoice.xslt but with the address sides swapped:
+    "Bill From" = vendor (the supplier sending us the bill)
+    "Bill To"   = our company (the recipient — set from book options)
 
-    <invoice status="paid|unpaid|draft" currency="CAD">
+  Input XML structure (see bill_to_xml() in services/bill_renderer.py):
+
+    <bill status="paid|unpaid|draft" currency="CAD">
       <id>, <date>, <due-date>, <billing-id>, <notes>
-      <customer>  <name>, <addr1..4>, <email>, <phone>
+      <vendor>    <name>, <addr1..4>, <email>
       <company>   <name>, <id>, <addr1..4>, <phone>, <email>, <url>
       <entries>
         <entry>
@@ -18,31 +22,24 @@
       <tax-lines>
         <tax-line>  <name>, <amount>
       </tax-lines>
-      <draft-tax-notice/>           (present only on unposted invoices)
-    </invoice>
+      <draft-tax-notice/>           (present only on unposted bills)
+      <payments>
+        <payment>  <date>, <num>, <memo>, <amount>
+      </payments>
+      <amount-remaining>            (present only on posted bills)
+    </bill>
 
   Styling rules for the Tax Applied column:
-    type="exempt"   → grey italic    (zero-rated / no tax)
-    type="single"   → dark blue      (one tax, e.g. GST only or HST)
-    type="combined" → dark orange    (two or more taxes, e.g. GST + PST)
-
-  To change styles, edit the <style> block below — no Python changes needed.
+    type="exempt"   → grey italic
+    type="single"   → dark blue
+    type="combined" → dark orange
 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <xsl:output method="html" encoding="UTF-8" indent="yes" doctype-public="-//W3C//DTD HTML 4.01//EN"/>
 
-<!-- Q-011: hide the Unit column when no entry has a non-empty <action>.
-     The action field in GnuCash is free-form metadata ("Hours", "Project",
-     "Material", or just empty). When every entry has an empty action the
-     column would just be a row of blanks; suppress it. Used as a guard on
-     both the header <th> and the per-row <td>. -->
 <xsl:variable name="show-unit-column"
-              select="count(/invoice/entries/entry[normalize-space(action) != '']) &gt; 0"/>
+              select="count(/bill/entries/entry[normalize-space(action) != '']) &gt; 0"/>
 
-<!-- Q-011: shared colspan for label cells (Subtotal, Total, tax-line) that
-     span Description + (Unit?) + Qty + Unit Price. Drops 4 → 3 when the
-     Unit column is hidden. Caller emits this as the colspan attribute
-     of the surrounding <td>. -->
 <xsl:template name="label-colspan">
   <xsl:attribute name="colspan">
     <xsl:choose>
@@ -52,22 +49,17 @@
   </xsl:attribute>
 </xsl:template>
 
-<!-- ═══════════════════════════════════════════════════════════════════════
-     Root template
-     ═══════════════════════════════════════════════════════════════════════ -->
-<xsl:template match="/invoice">
+<xsl:template match="/bill">
 <html lang="en">
 <head>
   <meta charset="UTF-8"/>
-  <title>Invoice <xsl:value-of select="id"/></title>
+  <title>Bill <xsl:value-of select="id"/></title>
   <style>
-    /* ── Page layout ──────────────────────────────────────────────── */
     body        { font-family: Arial, sans-serif; font-size: 13px;
                   margin: 40px; color: #222; }
     h1          { font-size: 24px; margin: 0 0 2px; letter-spacing: 1px; }
     .inv-meta   { color: #666; font-size: 12px; margin-bottom: 24px; }
 
-    /* ── Status badge ─────────────────────────────────────────────── */
     .badge        { display: inline-block; padding: 2px 8px; border-radius: 4px;
                     font-size: 11px; font-weight: bold; text-transform: uppercase;
                     letter-spacing: 1px; margin-left: 10px; vertical-align: middle; }
@@ -75,7 +67,6 @@
     .badge-unpaid { background: #fff3cd; color: #856404; }
     .badge-draft  { background: #e2e3e5; color: #383d41; }
 
-    /* ── Payment history section ───────────────────────────────────── */
     .payment-section { margin-top: 28px; }
     .payment-section h3 { font-size: 11px; text-transform: uppercase;
                           letter-spacing: 1px; color: #999; margin: 0 0 6px; }
@@ -88,15 +79,13 @@
     .remaining-paid   { color: #155724; }
     .remaining-due    { color: #856404; }
 
-    /* ── Addresses ────────────────────────────────────────────────── */
     .addresses  { display: flex; gap: 60px; margin-bottom: 28px; }
     .addr h3    { margin: 0 0 6px; font-size: 11px; text-transform: uppercase;
                   color: #999; letter-spacing: 1px; }
     .addr p     { margin: 1px 0; }
-    .addr-from  { margin-left: auto; text-align: right; }
+    .addr-to    { margin-left: auto; text-align: right; }
     .co-reg     { color: #888; font-size: 11px; }
 
-    /* ── Line-items table ─────────────────────────────────────────── */
     table       { width: 100%; border-collapse: collapse; }
     thead th    { background: #f5f5f5; padding: 7px 8px; text-align: left;
                   border-top: 2px solid #ccc; border-bottom: 2px solid #ccc;
@@ -104,31 +93,23 @@
     tbody td    { padding: 6px 8px; border-bottom: 1px solid #eee; }
     tfoot td    { padding: 6px 8px; }
 
-    /* ── Subtotal / tax rows ──────────────────────────────────────── */
     .subtotal-row td { color: #555; font-style: italic; }
     .tax-row td      { color: #555; }
     .total-row td    { font-weight: bold; font-size: 14px;
                        border-top: 2px solid #333; }
 
-    /* ── Tax-applied column colours ──────────────────────────────── */
-    /* Change these three rules to restyle the Tax Applied column     */
-    .tax-exempt   { color: #aaa; font-style: italic; }          /* zero-rated   */
-    .tax-single   { color: #1a5276; }                            /* one tax      */
-    .tax-combined { color: #b85c00; font-weight: bold; }         /* GST + PST/QST */
+    .tax-exempt   { color: #aaa; font-style: italic; }
+    .tax-single   { color: #1a5276; }
+    .tax-combined { color: #b85c00; font-weight: bold; }
 
-    /* ── Notes ───────────────────────────────────────────────────── */
     .notes { margin-top: 28px; padding: 10px 14px; background: #fafafa;
              border-left: 3px solid #ccc; color: #555; font-size: 12px; }
   </style>
 </head>
 <body>
 
-  <!-- Invoice title + status badge -->
-  <!-- Q-012: 'draft' status is set by the renderer when the invoice is
-       not yet posted. A draft has line items but no per-tax breakdown
-       (taxes only exist post-posting) and no payment history. -->
   <h1>
-    Invoice
+    Bill
     <xsl:choose>
       <xsl:when test="@status = 'paid'">
         <span class="badge badge-paid">Paid</span>
@@ -143,11 +124,9 @@
   </h1>
 
   <div class="inv-meta">
-    <strong>Invoice #:</strong> <xsl:value-of select="id"/>
+    <strong>Bill #:</strong> <xsl:value-of select="id"/>
     &#160;|&#160;
     <strong>Date:</strong> <xsl:value-of select="date"/>
-    <!-- Q-018: due-date row hidden when empty (unposted cash-basis
-         invoice with no `due_date` KVP). -->
     <xsl:if test="string-length(due-date) > 0">
       &#160;|&#160;
       <strong>Due:</strong> <xsl:value-of select="due-date"/>
@@ -158,33 +137,31 @@
     </xsl:if>
   </div>
 
-  <!-- Bill-to / From addresses -->
+  <!-- Address blocks. Bill From = vendor (left), Bill To = us (right). -->
   <div class="addresses">
-    <!-- Bill To (customer) -->
     <div class="addr">
-      <h3>Bill To</h3>
-      <p><strong><xsl:value-of select="customer/name"/></strong></p>
-      <xsl:if test="string-length(customer/addr1) > 0">
-        <p><xsl:value-of select="customer/addr1"/></p>
+      <h3>Bill From</h3>
+      <p><strong><xsl:value-of select="vendor/name"/></strong></p>
+      <xsl:if test="string-length(vendor/addr1) > 0">
+        <p><xsl:value-of select="vendor/addr1"/></p>
       </xsl:if>
-      <xsl:if test="string-length(customer/addr2) > 0">
-        <p><xsl:value-of select="customer/addr2"/></p>
+      <xsl:if test="string-length(vendor/addr2) > 0">
+        <p><xsl:value-of select="vendor/addr2"/></p>
       </xsl:if>
-      <xsl:if test="string-length(customer/addr3) > 0">
-        <p><xsl:value-of select="customer/addr3"/></p>
+      <xsl:if test="string-length(vendor/addr3) > 0">
+        <p><xsl:value-of select="vendor/addr3"/></p>
       </xsl:if>
-      <xsl:if test="string-length(customer/addr4) > 0">
-        <p><xsl:value-of select="customer/addr4"/></p>
+      <xsl:if test="string-length(vendor/addr4) > 0">
+        <p><xsl:value-of select="vendor/addr4"/></p>
       </xsl:if>
-      <xsl:if test="string-length(customer/email) > 0">
-        <p><xsl:value-of select="customer/email"/></p>
+      <xsl:if test="string-length(vendor/email) > 0">
+        <p><xsl:value-of select="vendor/email"/></p>
       </xsl:if>
     </div>
 
-    <!-- From (seller / company) — shown only when company name is present -->
     <xsl:if test="string-length(company/name) > 0">
-      <div class="addr addr-from">
-        <h3>From</h3>
+      <div class="addr addr-to">
+        <h3>Bill To</h3>
         <p><strong><xsl:value-of select="company/name"/></strong></p>
         <xsl:if test="string-length(company/id) > 0">
           <p class="co-reg">Company ID: <xsl:value-of select="company/id"/></p>
@@ -214,7 +191,6 @@
     </xsl:if>
   </div>
 
-  <!-- Line-items table -->
   <table>
     <thead>
       <tr>
@@ -231,7 +207,6 @@
     <tbody>
       <xsl:apply-templates select="entries/entry"/>
 
-      <!-- Subtotal row -->
       <tr class="subtotal-row">
         <td style="text-align:right">
           <xsl:call-template name="label-colspan"/>
@@ -244,19 +219,15 @@
         <td/>
       </tr>
 
-      <!-- Tax lines -->
       <xsl:apply-templates select="tax-lines/tax-line"/>
 
-      <!-- Q-019: provisional-tax notice for unposted invoices
-           (cash-basis or accrual draft). The renderer emits an empty
-           <draft-tax-notice/> element only when posting_txn is None. -->
       <xsl:if test="draft-tax-notice">
         <tr class="provisional-row">
           <td>
             <xsl:call-template name="label-colspan"/>
           </td>
           <td colspan="2" style="text-align:right; font-style:italic; color:#856404; font-size:11px">
-            Tax is computed from line-item tax tables; invoice not yet posted &#8212; figures are provisional.
+            Tax is computed from line-item tax tables; bill not yet posted &#8212; figures are provisional.
           </td>
         </tr>
       </xsl:if>
@@ -265,7 +236,7 @@
       <tr class="total-row">
         <td style="text-align:right">
           <xsl:call-template name="label-colspan"/>
-          Total Due (<xsl:value-of select="@currency"/>)
+          Total Payable (<xsl:value-of select="@currency"/>)
         </td>
         <td style="text-align:right">
           <xsl:value-of select="concat(@currency, '&#160;')"/>
@@ -276,7 +247,6 @@
     </tfoot>
   </table>
 
-  <!-- Payment history -->
   <xsl:if test="payments/payment">
     <div class="payment-section">
       <h3>Payment History</h3>
@@ -313,7 +283,6 @@
     </div>
   </xsl:if>
 
-  <!-- Notes -->
   <xsl:if test="string-length(notes) > 0">
     <div class="notes">
       <strong>Notes:</strong> <xsl:value-of select="notes"/>
@@ -324,9 +293,6 @@
 </html>
 </xsl:template>
 
-<!-- ═══════════════════════════════════════════════════════════════════════
-     Line-item entry row
-     ═══════════════════════════════════════════════════════════════════════ -->
 <xsl:template match="entry">
   <tr>
     <td><xsl:value-of select="description"/></td>
@@ -343,7 +309,6 @@
       $<xsl:value-of select="format-number(amount, '#,##0.00')"/>
     </td>
     <td style="text-align:center; font-size:11px">
-      <!-- Colour class is driven by the type attribute on <tax-label> -->
       <xsl:variable name="ttype" select="tax-label/@type"/>
       <xsl:choose>
         <xsl:when test="$ttype = 'exempt'">
@@ -353,7 +318,6 @@
           <span class="tax-combined"><xsl:value-of select="tax-label"/></span>
         </xsl:when>
         <xsl:otherwise>
-          <!-- single or anything else -->
           <span class="tax-single"><xsl:value-of select="tax-label"/></span>
         </xsl:otherwise>
       </xsl:choose>
@@ -361,9 +325,6 @@
   </tr>
 </xsl:template>
 
-<!-- ═══════════════════════════════════════════════════════════════════════
-     Payment history row
-     ═══════════════════════════════════════════════════════════════════════ -->
 <xsl:template match="payment">
   <tr class="pay-row">
     <td><xsl:value-of select="date"/></td>
@@ -375,9 +336,6 @@
   </tr>
 </xsl:template>
 
-<!-- ═══════════════════════════════════════════════════════════════════════
-     Tax summary row
-     ═══════════════════════════════════════════════════════════════════════ -->
 <xsl:template match="tax-line">
   <tr class="tax-row">
     <td style="text-align:right">

--- a/services/bill_renderer.py
+++ b/services/bill_renderer.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python
+"""
+Service for rendering GnuCash vendor bills to HTML/PDF/plaintext.
+
+Q-019: parallel to services/invoice_renderer.py. A bill is the inverse
+of an invoice — money flows FROM us (Bill To) TO a vendor (Bill From),
+so the two-sided rendering swaps the role of the company-info block
+and the owner block compared to invoices.
+
+Tax handling mirrors the invoice renderer: posted bills read tax from
+the posting transaction's AP splits; unposted bills compute tax from
+each entry's bill-side tax_table via compute_bill_entry_informational
+and the rendered output carries a `draft-tax-notice` marker so the
+viewer knows the figures are provisional.
+"""
+import xml.etree.ElementTree as ET
+
+import gnucash.gnucash_core_c as gc
+from gnucash import Split
+
+from infrastructure.gnucash.engine import (
+    iterate_glist,
+    load_gnc_engine,
+    safe_ctypes_string,
+)
+from infrastructure.gnucash.kvp import get_custom_metadata
+from services.invoice_renderer import (
+    _ctypes_account_full_name,
+    _fmt_money,
+    _fmt_rate,
+    _render_seller_header,
+    _render_taxtable_block,
+)
+
+
+def _read_bill_tax_label(lib, ptr):
+    """Per-entry tax label for the rendered bill line. Uses Bill-side
+    getters per CLAUDE.md ("Bill Entry API vs Invoice Entry API")."""
+    taxable = bool(lib.gncEntryGetBillTaxable(ptr))
+    if not taxable:
+        return 'Exempt', 'exempt'
+
+    tt_ptr = lib.gncEntryGetBillTaxTable(ptr)
+    if not tt_ptr:
+        return 'Taxable', 'single'
+
+    tt_name = safe_ctypes_string(lib.gncTaxTableGetName, tt_ptr, default='Taxable')
+
+    glist_ptr = lib.gncTaxTableGetEntries(tt_ptr)
+
+    def process_tax_table_entry(_lib, tte_ptr):
+        acct_ptr = _lib.gncTaxTableEntryGetAccount(tte_ptr)
+        amt_c = _lib.gncTaxTableEntryGetAmount(tte_ptr)
+        rate = amt_c.num / amt_c.denom if amt_c.denom else 0.0
+        name = safe_ctypes_string(_lib.xaccAccountGetName, acct_ptr, default='?')
+        rate_str = f"{rate:g}%"
+        return name if rate_str in name else f"{name} {rate_str}"
+
+    rate_parts = iterate_glist(lib, glist_ptr, process_tax_table_entry)
+    rate_parts.reverse()
+
+    if not rate_parts:
+        return tt_name, 'single'
+
+    label = ' + '.join(rate_parts)
+    ttype = 'combined' if len(rate_parts) > 1 else 'single'
+    return label, ttype
+
+
+def _bill_tax_table_entries(lib, tt_ptr):
+    """Return [(account_full_name, rate_decimal)] for one tax-table
+    pointer in declaration order. Same shape as the invoice helper;
+    used by compute_bill_entry_informational."""
+
+    def _one(_lib, tte_ptr):
+        acct_ptr = _lib.gncTaxTableEntryGetAccount(tte_ptr)
+        amt_c = _lib.gncTaxTableEntryGetAmount(tte_ptr)
+        rate_pct = amt_c.num / amt_c.denom if amt_c.denom else 0.0
+        rate = rate_pct / 100.0
+        acct_name = _ctypes_account_full_name(_lib, acct_ptr) if acct_ptr else '?'
+        return (acct_name, rate)
+
+    entries_ptr = lib.gncTaxTableGetEntries(tt_ptr)
+    entries = iterate_glist(lib, entries_ptr, _one)
+    entries.reverse()
+    return entries
+
+
+def compute_bill_entry_informational(lib, entry_ptr):
+    """Bill-side analogue of compute_entry_informational. Returns
+    (entry_amount, entry_tax, breakdown) where the per-entry net amount,
+    tax dollars, and per-account breakdown are computed from the entry's
+    bill-side tax_table and tax_included flag."""
+    qty_c = lib.gncEntryGetQuantity(entry_ptr)
+    pri_c = lib.gncEntryGetBillPrice(entry_ptr)
+    qty = qty_c.num / qty_c.denom if qty_c.denom else 0.0
+    price = pri_c.num / pri_c.denom if pri_c.denom else 0.0
+    gross_or_net = qty * price
+
+    taxable = bool(lib.gncEntryGetBillTaxable(entry_ptr))
+    tax_included = bool(lib.gncEntryGetBillTaxIncluded(entry_ptr))
+    tt_ptr = lib.gncEntryGetBillTaxTable(entry_ptr) if taxable else None
+
+    if not taxable or not tt_ptr:
+        return (gross_or_net, 0.0, [])
+
+    tt_entries = _bill_tax_table_entries(lib, tt_ptr)
+    total_rate = sum(rate for _, rate in tt_entries)
+    net = gross_or_net / (1.0 + total_rate) if tax_included else gross_or_net
+    breakdown = [(acct, rate, net * rate) for acct, rate in tt_entries]
+    entry_tax = sum(amount for _, _, amount in breakdown)
+    return (net, entry_tax, breakdown)
+
+
+def bill_to_xml(bill, book, company_info=None):
+    """Render a vendor bill as XML for bill.xslt.
+
+    The output XML shape mirrors invoice_to_xml so the same XSLT
+    machinery (label-colspan template, per-entry rows, tax-line rows,
+    payment-history block) can be reused. The semantic role swap
+    ("Bill From" = vendor, "Bill To" = us) happens in bill.xslt's
+    address section, not here — the XML uses neutral element names
+    (`<vendor>`, `<company>`) so both renderers stay consistent.
+    """
+    lib = load_gnc_engine()
+
+    bill_id = bill.GetID()
+    posting_txn = bill.GetPostedTxn()
+    is_draft = posting_txn is None
+    is_paid = False if is_draft else gc.gncInvoiceIsPaid(bill.instance)
+
+    bill_kvp = get_custom_metadata(bill) or {}
+    cash_basis_marker = (
+        str(bill_kvp.get('cash_basis', '')).strip().lower() == 'true'
+    )
+    currency = bill.GetCurrency().get_mnemonic()
+    date_opened = bill.GetDateOpened().strftime("%Y-%m-%d")
+    date_due = bill.GetDateDue()
+    date_due_s = date_due.strftime("%Y-%m-%d") if date_due else ''
+    if not date_due_s and is_draft and bill_kvp.get('due_date'):
+        date_due_s = str(bill_kvp['due_date']).strip()
+    notes = bill.GetNotes() or ''
+    billing_id = bill.GetBillingID() or ''
+
+    vendor = None
+    try:
+        owner = bill.GetOwner()
+        vendor = owner.GetVendor()
+    except Exception:
+        pass
+    if vendor is None:
+        raise ValueError("Could not determine vendor for bill")
+
+    addr = vendor.GetAddr()
+    vend_name = vendor.GetName()
+    addr1, addr2 = addr.GetAddr1(), addr.GetAddr2()
+    addr3, addr4 = addr.GetAddr3(), addr.GetAddr4()
+    email = addr.GetEmail()
+
+    if is_draft and not cash_basis_marker:
+        status = 'draft'
+    elif is_paid:
+        status = 'paid'
+    else:
+        status = 'unpaid'
+    root = ET.Element('bill', status=status, currency=currency)
+    ET.SubElement(root, 'id').text = bill_id
+    ET.SubElement(root, 'date').text = date_opened
+    ET.SubElement(root, 'due-date').text = date_due_s
+    ET.SubElement(root, 'billing-id').text = billing_id
+    ET.SubElement(root, 'notes').text = notes
+
+    v_el = ET.SubElement(root, 'vendor')
+    ET.SubElement(v_el, 'name').text = vend_name
+    ET.SubElement(v_el, 'addr1').text = addr1 or ''
+    ET.SubElement(v_el, 'addr2').text = addr2 or ''
+    ET.SubElement(v_el, 'addr3').text = addr3 or ''
+    ET.SubElement(v_el, 'addr4').text = addr4 or ''
+    ET.SubElement(v_el, 'email').text = email or ''
+
+    co = company_info or {}
+    co_el = ET.SubElement(root, 'company')
+    ET.SubElement(co_el, 'name').text = co.get('name', '')
+    ET.SubElement(co_el, 'id').text = co.get('id', '')
+    ET.SubElement(co_el, 'addr1').text = co.get('addr1', '')
+    ET.SubElement(co_el, 'addr2').text = co.get('addr2', '')
+    ET.SubElement(co_el, 'addr3').text = co.get('addr3', '')
+    ET.SubElement(co_el, 'addr4').text = co.get('addr4', '')
+    ET.SubElement(co_el, 'phone').text = co.get('phone', '')
+    ET.SubElement(co_el, 'email').text = co.get('email', '')
+    ET.SubElement(co_el, 'url').text = co.get('url', '')
+
+    entries_el = ET.SubElement(root, 'entries')
+    entries_subtotal = 0.0
+    tax_account_totals = {}
+    for raw_entry in bill.GetEntries():
+        ptr = int(raw_entry.instance)
+        desc = safe_ctypes_string(lib.gncEntryGetDescription, ptr)
+        # Bills don't have an `action` field (see _format_bill_entry).
+        qty_c = lib.gncEntryGetQuantity(ptr)
+        price_c = lib.gncEntryGetBillPrice(ptr)
+        qty = qty_c.num / qty_c.denom if qty_c.denom else 0.0
+        price = price_c.num / price_c.denom if price_c.denom else 0.0
+        net_amount, _entry_tax, breakdown = compute_bill_entry_informational(
+            lib, ptr,
+        )
+        entries_subtotal += net_amount
+        for bd_acct_name, _bd_rate, bd_amount in breakdown:
+            tax_account_totals[bd_acct_name] = (
+                tax_account_totals.get(bd_acct_name, 0.0) + bd_amount
+            )
+
+        tax_label, tax_type = _read_bill_tax_label(lib, ptr)
+
+        e_el = ET.SubElement(entries_el, 'entry')
+        ET.SubElement(e_el, 'description').text = desc
+        ET.SubElement(e_el, 'action').text = ''
+        ET.SubElement(e_el, 'quantity').text = (
+            f"{qty:.4f}".rstrip('0').rstrip('.')
+        )
+        ET.SubElement(e_el, 'unit-price').text = f"{price:.2f}"
+        ET.SubElement(e_el, 'amount').text = f"{net_amount:.2f}"
+        ET.SubElement(e_el, 'tax-label', type=tax_type).text = tax_label
+
+    tax_lines_el = ET.SubElement(root, 'tax-lines')
+    payments_el = ET.SubElement(root, 'payments')
+
+    if is_draft:
+        for acct_name, dollars in tax_account_totals.items():
+            tl = ET.SubElement(tax_lines_el, 'tax-line')
+            ET.SubElement(tl, 'name').text = acct_name.rsplit(':', 1)[-1]
+            ET.SubElement(tl, 'amount').text = f"{dollars:.2f}"
+        grand_total = entries_subtotal + sum(tax_account_totals.values())
+        ET.SubElement(root, 'subtotal').text = f"{entries_subtotal:.2f}"
+        ET.SubElement(root, 'total').text = f"{grand_total:.2f}"
+        ET.SubElement(root, 'draft-tax-notice')
+        return ET.ElementTree(root)
+
+    # Posted: derive tax lines + subtotal from the posting transaction's
+    # splits. Skip the AP-posting split (matches the bill's PostedAcc);
+    # EXPENSE splits make up the subtotal; everything else is a tax
+    # accrual (LIABILITY for accrued payable tax, ASSET for a
+    # recoverable input-tax-credit account, etc.).
+    posted_ap_acct = bill.GetPostedAcc()
+    subtotal_total = 0.0
+    for i in range(posting_txn.CountSplits()):
+        s = posting_txn.GetSplit(i)
+        acct = s.GetAccount()
+        atype = gc.xaccAccountGetType(acct.instance)
+        amt = s.GetAmount().to_double()
+        if (posted_ap_acct is not None
+                and acct.instance == posted_ap_acct.instance):
+            continue
+        if atype == gc.ACCT_TYPE_EXPENSE:
+            subtotal_total += abs(amt)
+        else:
+            tl = ET.SubElement(tax_lines_el, 'tax-line')
+            ET.SubElement(tl, 'name').text = acct.GetName()
+            ET.SubElement(tl, 'amount').text = f"{abs(amt):.2f}"
+
+    grand_total = subtotal_total + sum(
+        float(tl.find('amount').text) for tl in tax_lines_el
+    )
+    ET.SubElement(root, 'subtotal').text = f"{subtotal_total:.2f}"
+    ET.SubElement(root, 'total').text = f"{grand_total:.2f}"
+
+    lot = bill.GetPostedLot()
+    for raw_split in lot.get_split_list():
+        s = Split(instance=raw_split)
+        txn = s.GetParent()
+        if txn is None:
+            continue
+        if gc.gncInvoiceGetInvoiceFromTxn(txn.instance) is not None:
+            continue
+        pay_date = txn.GetDate().strftime("%Y-%m-%d")
+        pay_memo = txn.GetDescription() or ''
+        pay_num = txn.GetNum() or ''
+        pay_amt = abs(s.GetAmount().to_double())
+        p_el = ET.SubElement(payments_el, 'payment')
+        ET.SubElement(p_el, 'date').text = pay_date
+        ET.SubElement(p_el, 'memo').text = pay_memo
+        ET.SubElement(p_el, 'num').text = pay_num
+        ET.SubElement(p_el, 'amount').text = f"{pay_amt:.2f}"
+
+    remaining = lot.get_balance().to_double()
+    ET.SubElement(root, 'amount-remaining').text = f"{abs(remaining):.2f}"
+
+    return ET.ElementTree(root)
+
+
+def render_to_html(bill, book, xslt_path, company_info=None) -> str:
+    """Apply bill.xslt to the bill's XML and return the HTML string."""
+    from lxml import etree as lxml_etree
+
+    xml_tree = bill_to_xml(bill, book, company_info=company_info)
+    xml_str = ET.tostring(xml_tree.getroot(), encoding='unicode')
+    xml_doc = lxml_etree.fromstring(xml_str)
+    xslt_doc = lxml_etree.parse(xslt_path)
+    transform = lxml_etree.XSLT(xslt_doc)
+    return str(transform(xml_doc))
+
+
+def render_to_pdf(bill, book, xslt_path, pdf_path, company_info=None):
+    import weasyprint
+
+    html = render_to_html(bill, book, xslt_path, company_info=company_info)
+    weasyprint.HTML(string=html).write_pdf(pdf_path)
+
+
+def _render_vendor_block(vendor) -> str:
+    """Minimal vendor block — id, name, currency. The bill plaintext
+    re-importer looks up vendors by id, so the block is required for
+    self-contained re-import; address/email aren't needed."""
+    return (
+        f'vendor "{vendor.GetID()}"\n'
+        f'\tname: "{vendor.GetName()}"\n'
+        f'\tcurrency: {vendor.GetCurrency().get_mnemonic()}'
+    )
+
+
+def render_to_plaintext(bill, book, company_info=None) -> str:
+    """Render one vendor bill as canonical plaintext, populated with the
+    Q-017 bill_* informational fields (entry_amount, entry_tax,
+    breakdown, bill_subtotal, bill_tax_total, bill_total). The output is
+    self-contained: taxtable definitions for every referenced table, the
+    vendor header, then the bill block. A `# Bill received from: ...`
+    seller comment (Q-019) tells the recipient who the vendor is."""
+    lib = load_gnc_engine()
+
+    bill_id = bill.GetID()
+    vendor = bill.GetOwner().GetVendor()
+    if vendor is None:
+        raise ValueError(f'bill {bill_id!r} has no vendor owner')
+
+    posting_txn = bill.GetPostedTxn()
+    is_draft = posting_txn is None
+    currency = bill.GetCurrency().get_mnemonic()
+    date_opened = bill.GetDateOpened().strftime('%Y-%m-%d')
+
+    seen_tt = {}
+    entries_data = []
+    for raw_entry in bill.GetEntries():
+        ent_ptr = int(raw_entry.instance)
+        entry_amount, entry_tax, breakdown = compute_bill_entry_informational(
+            lib, ent_ptr,
+        )
+        entries_data.append((raw_entry, entry_amount, entry_tax, breakdown))
+        tt_ptr = lib.gncEntryGetBillTaxTable(ent_ptr)
+        if tt_ptr and int(tt_ptr) not in seen_tt:
+            seen_tt[int(tt_ptr)] = tt_ptr
+
+    blocks = []
+    for tt_ptr in seen_tt.values():
+        blocks.append(_render_taxtable_block(lib, tt_ptr))
+
+    blocks.append(_render_vendor_block(vendor))
+
+    bill_lines = [
+        f'bill "{bill_id}"',
+        f'\tvendor_id: "{vendor.GetID()}"',
+        f'\tcurrency: {currency}',
+        f'\tdate_opened: {date_opened}',
+    ]
+
+    from infrastructure.gnucash.utils import get_account_full_name
+
+    for raw_entry, entry_amount, entry_tax, breakdown in entries_data:
+        ent_ptr = int(raw_entry.instance)
+        desc = safe_ctypes_string(lib.gncEntryGetDescription, ent_ptr)
+        qty_c = lib.gncEntryGetQuantity(ent_ptr)
+        pri_c = lib.gncEntryGetBillPrice(ent_ptr)
+        qty = qty_c.num / qty_c.denom if qty_c.denom else 0.0
+        price = pri_c.num / pri_c.denom if pri_c.denom else 0.0
+        taxable = bool(lib.gncEntryGetBillTaxable(ent_ptr))
+        tax_included = bool(lib.gncEntryGetBillTaxIncluded(ent_ptr))
+        acct_name = get_account_full_name(raw_entry.GetBillAccount())
+        date_str = raw_entry.GetDate().strftime('%Y-%m-%d')
+
+        bill_lines.append('\tentry:')
+        bill_lines.append(f'\t\tdate: {date_str}')
+        bill_lines.append(f'\t\tdescription: "{desc}"')
+        bill_lines.append(f'\t\taccount: "{acct_name}"')
+        bill_lines.append(f'\t\tquantity: {qty:g}')
+        bill_lines.append(f'\t\tprice: {price:g}')
+        bill_lines.append(f'\t\ttaxable: {"true" if taxable else "false"}')
+        bill_lines.append(
+            f'\t\ttax_included: {"true" if tax_included else "false"}'
+        )
+
+        tt_ptr = lib.gncEntryGetBillTaxTable(ent_ptr)
+        if tt_ptr:
+            tt_name = safe_ctypes_string(lib.gncTaxTableGetName, tt_ptr)
+            if tt_name:
+                bill_lines.append(f'\t\ttax_table: "{tt_name}"')
+
+        bill_lines.append(f'\t\tentry_amount: {_fmt_money(entry_amount)}')
+        bill_lines.append(f'\t\tentry_tax: {_fmt_money(entry_tax)}')
+        for bd_acct_name, bd_rate, bd_amount in breakdown:
+            bill_lines.append('\t\tbreakdown:')
+            bill_lines.append(f'\t\t\taccount: "{bd_acct_name}"')
+            bill_lines.append(f'\t\t\trate: {_fmt_rate(bd_rate)}')
+            bill_lines.append(f'\t\t\tamount: {_fmt_money(bd_amount)}')
+
+    if is_draft:
+        bill_lines.append('\tposted: none')
+        bill_lines.append('\tpayment: none')
+    else:
+        ap_name = get_account_full_name(bill.GetPostedAcc())
+        bill_lines.append('\tposted:')
+        bill_lines.append(
+            f'\t\tdate: {bill.GetDatePosted().strftime("%Y-%m-%d")}'
+        )
+        bill_lines.append(
+            f'\t\tdue: {bill.GetDateDue().strftime("%Y-%m-%d")}'
+        )
+        bill_lines.append(f'\t\tap_account: "{ap_name}"')
+        bill_lines.append(f'\t\tmemo: "{posting_txn.GetDescription()}"')
+        bill_lines.append('\t\taccumulate: true')
+
+        lot = bill.GetPostedLot()
+        had_payment = False
+        if lot is not None:
+            for raw_split in lot.get_split_list():
+                s = Split(instance=raw_split)
+                txn = s.GetParent()
+                if txn is None:
+                    continue
+                if gc.gncInvoiceGetInvoiceFromTxn(txn.instance) is not None:
+                    continue
+                pay_date = txn.GetDate().strftime('%Y-%m-%d')
+                bank_name = ''
+                pay_amt = 0.0
+                pay_memo = ''
+                for i in range(txn.CountSplits()):
+                    sp = txn.GetSplit(i)
+                    atype = gc.xaccAccountGetType(sp.GetAccount().instance)
+                    if atype not in (
+                        gc.ACCT_TYPE_RECEIVABLE, gc.ACCT_TYPE_PAYABLE,
+                    ):
+                        bank_name = get_account_full_name(sp.GetAccount())
+                        pay_amt = abs(sp.GetAmount().to_double())
+                        pay_memo = sp.GetMemo() or ''
+                        break
+                bill_lines.append('\tpayment:')
+                bill_lines.append(f'\t\tdate: {pay_date}')
+                bill_lines.append(f'\t\tamount: {pay_amt:g}')
+                bill_lines.append(f'\t\tbank_account: "{bank_name}"')
+                bill_lines.append(f'\t\tmemo: "{pay_memo}"')
+                had_payment = True
+        if not had_payment:
+            bill_lines.append('\tpayment: none')
+
+    subtotal = sum(e[1] for e in entries_data)
+    tax_total = sum(e[2] for e in entries_data)
+    bill_lines.append(f'\tbill_subtotal: {_fmt_money(subtotal)}')
+    bill_lines.append(f'\tbill_tax_total: {_fmt_money(tax_total)}')
+    bill_lines.append(f'\tbill_total: {_fmt_money(subtotal + tax_total)}')
+
+    # Q-019: bill-scoped caveats — vendor name line and (drafts only)
+    # provisional-tax notice. Both prepend to the bill block; the
+    # seller `# Bill received by:` header (file-scoped) is added below.
+    bill_scoped = [f'# Bill from vendor: {vendor.GetName()}']
+    if is_draft:
+        bill_scoped.append(
+            '# Tax figures are provisional — bill not yet posted; '
+            'recomputed at post time.'
+        )
+    bill_lines = bill_scoped + bill_lines
+
+    blocks.append('\n'.join(bill_lines))
+
+    co_header = _render_seller_header(company_info)
+    if co_header:
+        # File-scoped — "this whole rendered document was sent to us".
+        # Reuse the invoice header but swap the "Issued by" prefix for
+        # bill-side phrasing.
+        blocks.insert(
+            0,
+            co_header.replace('# Issued by:', '# Bill received by:', 1),
+        )
+
+    return '\n\n'.join(blocks) + '\n'

--- a/services/invoice_renderer.py
+++ b/services/invoice_renderer.py
@@ -182,7 +182,13 @@ def invoice_to_xml(inv, book, company_info=None):
     ET.SubElement(co_el, 'url').text = co.get('url', '')
 
     entries_el = ET.SubElement(root, 'entries')
-    entries_subtotal = 0.0  # Q-012: accumulate for drafts (no posting tx yet).
+    # Q-019: drafts (cash-basis or accrual) now compute tax from each
+    # entry's tax_table via compute_entry_informational. The net amount
+    # (qty × price adjusted for tax_included) is the per-entry subtotal,
+    # and per-tax-account dollars are aggregated into tax_account_totals
+    # for the <tax-lines> block below.
+    entries_subtotal = 0.0
+    tax_account_totals = {}
     for raw_entry in inv.GetEntries():
         ptr = int(raw_entry.instance)
         desc = safe_ctypes_string(lib.gncEntryGetDescription, ptr)
@@ -191,8 +197,14 @@ def invoice_to_xml(inv, book, company_info=None):
         price_c = lib.gncEntryGetInvPrice(ptr)
         qty = qty_c.num / qty_c.denom if qty_c.denom else 0.0
         price = price_c.num / price_c.denom if price_c.denom else 0.0
-        line_amount = qty * price
-        entries_subtotal += line_amount
+        net_amount, _entry_tax, breakdown = compute_entry_informational(
+            lib, ptr,
+        )
+        entries_subtotal += net_amount
+        for bd_acct_name, _bd_rate, bd_amount in breakdown:
+            tax_account_totals[bd_acct_name] = (
+                tax_account_totals.get(bd_acct_name, 0.0) + bd_amount
+            )
 
         tax_label, tax_type = _read_tax_label(lib, ptr)
 
@@ -201,21 +213,32 @@ def invoice_to_xml(inv, book, company_info=None):
         ET.SubElement(e_el, 'action').text = action
         ET.SubElement(e_el, 'quantity').text = f"{qty:.4f}".rstrip('0').rstrip('.')
         ET.SubElement(e_el, 'unit-price').text = f"{price:.2f}"
-        ET.SubElement(e_el, 'amount').text = f"{line_amount:.2f}"
+        ET.SubElement(e_el, 'amount').text = f"{net_amount:.2f}"
         ET.SubElement(e_el, 'tax-label', type=tax_type).text = tax_label
 
     tax_lines_el = ET.SubElement(root, 'tax-lines')
     payments_el = ET.SubElement(root, 'payments')
 
     if is_draft:
-        # Q-012: drafts have no posting tx and no lot. Show subtotal from
-        # the entries themselves; no per-tax breakdown (would require
-        # walking each entry's tax_table — non-trivial across GnuCash
-        # versions, see issue Q-012 "Known limitation"). No payments,
-        # no amount-remaining. Total = subtotal as a placeholder; the
-        # XSLT shows a DRAFT badge so the user knows tax isn't included.
+        # Q-019: render full tax breakdown for unposted invoices (cash-basis
+        # or plain draft). GnuCash only materialises tax splits on the
+        # posting transaction; before that, recompute the same numbers
+        # from each entry's tax_table. The <draft-tax-notice/> element
+        # tells the XSLT to mark these figures as provisional. Payment
+        # history and amount-remaining still require a posted AR lot, so
+        # they stay omitted on the draft path.
+        for acct_name, dollars in tax_account_totals.items():
+            tl = ET.SubElement(tax_lines_el, 'tax-line')
+            # The posted path uses acct.GetName() (leaf only);
+            # compute_entry_informational produces colon-joined fullnames
+            # ("Liabilities:Tax:GST"). Take the leaf so a draft tax-line
+            # row reads identically to the same row on a posted invoice.
+            ET.SubElement(tl, 'name').text = acct_name.rsplit(':', 1)[-1]
+            ET.SubElement(tl, 'amount').text = f"{dollars:.2f}"
+        grand_total = entries_subtotal + sum(tax_account_totals.values())
         ET.SubElement(root, 'subtotal').text = f"{entries_subtotal:.2f}"
-        ET.SubElement(root, 'total').text = f"{entries_subtotal:.2f}"
+        ET.SubElement(root, 'total').text = f"{grand_total:.2f}"
+        ET.SubElement(root, 'draft-tax-notice')
         return ET.ElementTree(root)
 
     # Posted: derive tax lines + subtotal from the posting transaction's splits.
@@ -548,6 +571,42 @@ def _render_customer_block(cust) -> str:
     )
 
 
+def _render_seller_header(company_info) -> str:
+    """Q-019: emit a `# Issued by: ...` comment header so the recipient
+    of a rendered plaintext invoice / bill knows who issued it. Uses
+    `#` comment syntax so the line is dropped on re-import (we don't
+    want seller info to land as KVPs on the recipient's invoice).
+
+    Returns an empty string when company_info is missing or has no
+    company name — there's nothing useful to render in that case."""
+    if not company_info:
+        return ''
+    name = (company_info.get('name') or '').strip()
+    if not name:
+        return ''
+    parts = [f'Issued by: {name}']
+    company_id = (company_info.get('id') or '').strip()
+    if company_id:
+        # Label matches GnuCash's own slot name ("Company ID") rather
+        # than any one jurisdiction's tax-registration scheme. Users
+        # put a CRA business number, US EIN, UK VAT, HK BR, JP
+        # corporate number, etc. here; the rendered output stays
+        # neutral so the slot value reads correctly regardless.
+        parts.append(f'Company ID: {company_id}')
+    addr_lines = [
+        (company_info.get(k) or '').strip()
+        for k in ('addr1', 'addr2', 'addr3', 'addr4')
+    ]
+    addr_joined = ', '.join(line for line in addr_lines if line)
+    if addr_joined:
+        parts.append(addr_joined)
+    for key in ('phone', 'email', 'url'):
+        val = (company_info.get(key) or '').strip()
+        if val:
+            parts.append(val)
+    return '# ' + ' | '.join(parts)
+
+
 def render_to_plaintext(invoice, book, company_info=None) -> str:
     """Render one invoice as canonical plaintext, populated with the
     Q-017 informational fields (per-entry amount + tax breakdown, plus
@@ -633,14 +692,18 @@ def render_to_plaintext(invoice, book, company_info=None) -> str:
         # Q-017 informational fields. `breakdown:` is a nested block (one
         # per tax-table entry); matches the existing taxtable entry-block
         # convention so the parser can use the same indented-children path.
-        if not is_draft:
-            inv_lines.append(f'\t\tentry_amount: {_fmt_money(entry_amount)}')
-            inv_lines.append(f'\t\tentry_tax: {_fmt_money(entry_tax)}')
-            for bd_acct_name, bd_rate, bd_amount in breakdown:
-                inv_lines.append('\t\tbreakdown:')
-                inv_lines.append(f'\t\t\taccount: "{bd_acct_name}"')
-                inv_lines.append(f'\t\t\trate: {_fmt_rate(bd_rate)}')
-                inv_lines.append(f'\t\t\tamount: {_fmt_money(bd_amount)}')
+        # Q-019: emitted for drafts too — compute_entry_informational works
+        # off the entry's tax_table, which exists pre-posting. The leading
+        # `# Tax figures are provisional` comment on the invoice block
+        # (added below) tells the recipient these numbers will be
+        # recomputed at post time.
+        inv_lines.append(f'\t\tentry_amount: {_fmt_money(entry_amount)}')
+        inv_lines.append(f'\t\tentry_tax: {_fmt_money(entry_tax)}')
+        for bd_acct_name, bd_rate, bd_amount in breakdown:
+            inv_lines.append('\t\tbreakdown:')
+            inv_lines.append(f'\t\t\taccount: "{bd_acct_name}"')
+            inv_lines.append(f'\t\t\trate: {_fmt_rate(bd_rate)}')
+            inv_lines.append(f'\t\t\tamount: {_fmt_money(bd_amount)}')
 
     # Posted / payment blocks (mirror canonical export sentinel form)
     if is_draft:
@@ -696,9 +759,27 @@ def render_to_plaintext(invoice, book, company_info=None) -> str:
     subtotal = sum(e[1] for e in entries_data)
     tax_total = sum(e[2] for e in entries_data)
     inv_lines.append(f'\tinvoice_subtotal: {_fmt_money(subtotal)}')
-    if not is_draft:
-        inv_lines.append(f'\tinvoice_tax_total: {_fmt_money(tax_total)}')
-        inv_lines.append(f'\tinvoice_total: {_fmt_money(subtotal + tax_total)}')
+    # Q-019: tax_total and grand total are now emitted for drafts too,
+    # computed from each entry's tax_table.
+    inv_lines.append(f'\tinvoice_tax_total: {_fmt_money(tax_total)}')
+    inv_lines.append(f'\tinvoice_total: {_fmt_money(subtotal + tax_total)}')
+
+    # Q-019: provisional-tax caveat — invoice-scoped (drafts only),
+    # prepended inside the invoice block. The seller `# Issued by:`
+    # header (also Q-019) is file-scoped and emitted ahead of every
+    # block below.
+    if is_draft:
+        inv_lines.insert(
+            0,
+            '# Tax figures are provisional — invoice not yet posted; '
+            'recomputed at post time.',
+        )
 
     blocks.append('\n'.join(inv_lines))
+
+    seller_header = _render_seller_header(company_info)
+    if seller_header:
+        # File-scoped — "this whole rendered document is from Acme".
+        blocks.insert(0, seller_header)
+
     return '\n\n'.join(blocks) + '\n'

--- a/services/plaintext_parser.py
+++ b/services/plaintext_parser.py
@@ -257,6 +257,13 @@ class PlaintextParser:
         for line_number, line in enumerate(plaintext_lines):
             if line.strip() == "":
                 continue
+            # Q-019: skip `#` comment lines. The print-invoice / print-bill
+            # plaintext renderer prepends caveats (e.g. "tax figures are
+            # provisional", "Issued by: ...") on lines starting with `#`;
+            # the parser must tolerate them so rendered output re-imports
+            # cleanly.
+            if line.lstrip().startswith('#'):
+                continue
 
             leading_spaces = re.match(r'^[\t\s]*', line).group(0)
             (is_indent_valid, line_level, indent_error_msg) = self.verify_line_indentation(leading_spaces)

--- a/tests/fixtures/q019_accounts.txt
+++ b/tests/fixtures/q019_accounts.txt
@@ -1,0 +1,52 @@
+2026-01-01 open Assets
+	type: Asset
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Bank
+	type: Bank
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Accounts Receivable
+	type: Accounts Receivable
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Income
+	type: Income
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Income:Sales
+	type: Income
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Expenses
+	type: Expense
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Expenses:Office Supplies
+	type: Expense
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities
+	type: Liability
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:Accounts Payable
+	type: Accounts Payable
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:Tax
+	type: Liability
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:Tax:GST
+	type: Liability
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:Tax:PST
+	type: Liability
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:Tax:Sales Tax
+	type: Liability
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"

--- a/tests/fixtures/q019_unposted_cash_bill.txt
+++ b/tests/fixtures/q019_unposted_cash_bill.txt
@@ -1,0 +1,31 @@
+taxtable "GST+PST"
+	entry:
+		account: "Liabilities:Tax:GST"
+		rate: 5.0%
+		type: PERCENT
+	entry:
+		account: "Liabilities:Tax:PST"
+		rate: 7.0%
+		type: PERCENT
+
+vendor "V-Q19-1"
+	name: "Office Depot Wholesale"
+	currency: CAD
+
+bill "BILL-Q19-CASH-TAX-400"
+	vendor_id: "V-Q19-1"
+	currency: CAD
+	date_opened: 2026-05-12
+	cash_basis: true
+	due_date: 2026-06-11
+	entry:
+		date: 2026-05-12
+		description: "Office supplies for May"
+		account: "Expenses:Office Supplies"
+		quantity: 4
+		price: 50
+		taxable: true
+		tax_included: false
+		tax_table: "GST+PST"
+	posted: none
+	payment: none

--- a/tests/fixtures/q019_unposted_cash_with_tax.txt
+++ b/tests/fixtures/q019_unposted_cash_with_tax.txt
@@ -1,0 +1,32 @@
+taxtable "GST+PST"
+	entry:
+		account: "Liabilities:Tax:GST"
+		rate: 5.0%
+		type: PERCENT
+	entry:
+		account: "Liabilities:Tax:PST"
+		rate: 7.0%
+		type: PERCENT
+
+customer "C-Q19-1"
+	name: "Beta Industries"
+	currency: CAD
+
+invoice "INV-Q19-CASH-TAX-200"
+	customer_id: "C-Q19-1"
+	currency: CAD
+	date_opened: 2026-05-10
+	cash_basis: true
+	due_date: 2026-06-09
+	entry:
+		date: 2026-05-10
+		description: "Q-019 cash-basis combined-tax line"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 2
+		price: 100
+		taxable: true
+		tax_included: false
+		tax_table: "GST+PST"
+	posted: none
+	payment: none

--- a/tests/fixtures/q019_unposted_draft_with_tax.txt
+++ b/tests/fixtures/q019_unposted_draft_with_tax.txt
@@ -1,0 +1,26 @@
+taxtable "Sales Tax"
+	entry:
+		account: "Liabilities:Tax:Sales Tax"
+		rate: 10.0%
+		type: PERCENT
+
+customer "C-Q19-2"
+	name: "Gamma Holdings"
+	currency: CAD
+
+invoice "INV-Q19-DRAFT-TAX-300"
+	customer_id: "C-Q19-2"
+	currency: CAD
+	date_opened: 2026-05-11
+	entry:
+		date: 2026-05-11
+		description: "Plain accrual draft, single-rate taxable"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 3
+		price: 100
+		taxable: true
+		tax_included: false
+		tax_table: "Sales Tax"
+	posted: none
+	payment: none

--- a/tests/integration/test_cli_print_bill.py
+++ b/tests/integration/test_cli_print_bill.py
@@ -1,0 +1,70 @@
+"""Integration tests for the print-bill CLI command (Q-019).
+
+Mirrors test_cli_print_invoice.py for the vendor-bill side: argument
+validation, error-path exit codes, error-message format.
+"""
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURES = Path('tests/fixtures')
+ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
+
+
+class TestPrintBillErrors:
+
+    def _book_with_accounts(self, tmp_path):
+        runner = CliRunner()
+        gnc = tmp_path / 'book.gnucash'
+        r = runner.invoke(cli, ['import', '--new', str(gnc), ACCOUNTS])
+        assert r.exit_code == 0, f'accounts: {r.output}'
+        time.sleep(1)
+        return gnc
+
+    def test_no_selectors_exits_2(self, tmp_path):
+        """Calling print-bill with no selectors of any kind exits with
+        Click UsageError exit code 2."""
+        gnc = self._book_with_accounts(tmp_path)
+        runner = CliRunner()
+        r = runner.invoke(cli, [
+            'print-bill', str(gnc),
+            '-o', str(tmp_path / 'out.txt'),
+            '--format', 'plaintext',
+        ])
+        assert r.exit_code == 2
+
+    def test_nonexistent_bill_id_exits_nonzero(self, tmp_path):
+        """A bill ID that does not exist in the book exits non-zero."""
+        gnc = self._book_with_accounts(tmp_path)
+        runner = CliRunner()
+        r = runner.invoke(cli, [
+            'print-bill', str(gnc), 'BILL-DOES-NOT-EXIST',
+            '-o', str(tmp_path / 'out.txt'),
+            '--format', 'plaintext',
+        ])
+        assert r.exit_code != 0
+
+    def test_no_match_error_message_has_balanced_parens(self, tmp_path):
+        """The "no bills matched the selection (…)" message must have
+        balanced parentheses. The original pattern
+        `'(' + ', '.join(c) if c else 'none' + ')'` parses as
+        `('(' + ', '.join(c)) if c else ('none' + ')')` — when criteria
+        are present (always, given upfront validation) the closing
+        paren is dropped from the message."""
+        gnc = self._book_with_accounts(tmp_path)
+        runner = CliRunner()
+        r = runner.invoke(cli, [
+            'print-bill', str(gnc), 'BILL-DOES-NOT-EXIST',
+            '-o', str(tmp_path / 'out.txt'),
+            '--format', 'plaintext',
+        ])
+        assert r.exit_code != 0
+        assert 'no bills matched the selection (' in r.output, (
+            f'unexpected message:\n{r.output}'
+        )
+        assert r.output.count('(') == r.output.count(')'), (
+            f'unbalanced parentheses in error message:\n{r.output}'
+        )

--- a/tests/integration/test_cli_print_combined_html_structure.py
+++ b/tests/integration/test_cli_print_combined_html_structure.py
@@ -1,0 +1,168 @@
+"""Combined-output HTML structure tests for print-invoice / print-bill.
+
+When users render multiple invoices or bills into a single HTML / PDF
+file (combined mode), each per-document fragment must have its outer
+`<!DOCTYPE>`, `<html>…</html>`, and `<body>…</body>` shells stripped
+before being wrapped in the combined doc's single outer shell.
+Otherwise the combined output has nested DOCTYPEs and nested `<html>`
+elements — malformed under HTML 4.01 (and any HTML 5 reading).
+
+Two regressions caught by these tests:
+  1. The strip code was `inner.replace('<html>', '')`, which never
+     matched the XSLT's actual `<html lang="en">` opening tag — every
+     fragment kept its full wrapper, combined output had N+1 `<html`
+     opening tags (one outer + one per fragment).
+  2. The strip code didn't remove the per-fragment
+     `<!DOCTYPE html PUBLIC …>` declarations either, so the combined
+     body contained scattered inline DOCTYPEs (also illegal).
+
+Fixed in cli/{invoice,bill}_print_cmd.py: regex strips opening
+`<html…>` / `<body…>` with any attributes, plus `<!DOCTYPE …>`.
+
+Test contract: the XSLT uses `<xsl:output method="html"
+doctype-public="…HTML 4.01…">`, so combined output is HTML 4.01 (not
+XHTML — `<meta charset>` and friends self-close HTML-style without
+the slash). Tests assert structural counts rather than XML
+well-formedness so they reflect the actual format contract.
+"""
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURES = Path('tests/fixtures')
+ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
+
+
+def _fx(name):
+    return (FIXTURES / name).read_text()
+
+
+def _book_with_two_invoices(runner, tmp_path):
+    """Import two cash-basis invoices with different IDs so we can
+    feed both into a combined print-invoice run. Returns the .gnucash
+    path and the two invoice IDs."""
+    gnc = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gnc), ACCOUNTS])
+    assert r.exit_code == 0, f'accounts: {r.output}'
+    time.sleep(1)
+    fx1 = tmp_path / 'inv1.txt'
+    fx1.write_text(_fx('q019_unposted_cash_with_tax.txt'))
+    r = runner.invoke(cli, ['import', str(gnc), str(fx1),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f'inv1: {r.output}'
+    time.sleep(1)
+    # Second invoice — rewrite IDs and customer so the importer treats
+    # it as a new record rather than an update to the first.
+    fx2_text = _fx('q019_unposted_cash_with_tax.txt').replace(
+        'INV-Q19-CASH-TAX-200', 'INV-Q19-CASH-TAX-201',
+    ).replace(
+        '"C-Q19-1"', '"C-Q19-1B"',
+    ).replace(
+        'Beta Industries', 'Beta Two',
+    )
+    fx2 = tmp_path / 'inv2.txt'
+    fx2.write_text(fx2_text)
+    r = runner.invoke(cli, ['import', str(gnc), str(fx2),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f'inv2: {r.output}'
+    time.sleep(1)
+    return gnc, 'INV-Q19-CASH-TAX-200', 'INV-Q19-CASH-TAX-201'
+
+
+def _book_with_two_bills(runner, tmp_path):
+    """Bill-side analogue of _book_with_two_invoices."""
+    gnc = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gnc), ACCOUNTS])
+    assert r.exit_code == 0, f'accounts: {r.output}'
+    time.sleep(1)
+    fx1 = tmp_path / 'bill1.txt'
+    fx1.write_text(_fx('q019_unposted_cash_bill.txt'))
+    r = runner.invoke(cli, ['import', str(gnc), str(fx1),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f'bill1: {r.output}'
+    time.sleep(1)
+    fx2_text = _fx('q019_unposted_cash_bill.txt').replace(
+        'BILL-Q19-CASH-TAX-400', 'BILL-Q19-CASH-TAX-401',
+    ).replace(
+        '"V-Q19-1"', '"V-Q19-1B"',
+    ).replace(
+        'Office Depot Wholesale', 'Office Depot Two',
+    )
+    fx2 = tmp_path / 'bill2.txt'
+    fx2.write_text(fx2_text)
+    r = runner.invoke(cli, ['import', str(gnc), str(fx2),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f'bill2: {r.output}'
+    time.sleep(1)
+    return gnc, 'BILL-Q19-CASH-TAX-400', 'BILL-Q19-CASH-TAX-401'
+
+
+def _assert_one_outer_shell(html):
+    """Combined HTML must have exactly one outer `<!DOCTYPE>` (zero,
+    in our case — the outer wrapper doesn't emit one), one `<html…>`,
+    one `</html>`, one `<body…>`, and one `</body>`. Counts both
+    `<html>` and `<html lang="en">` form via the `<html` token, since
+    the original bug was that `inner.replace('<html>', '')` missed
+    the attributed form."""
+    n_doctype = html.count('<!DOCTYPE')
+    n_html_open = html.count('<html')
+    n_html_close = html.count('</html>')
+    n_body_open = html.count('<body')
+    n_body_close = html.count('</body>')
+
+    assert n_doctype == 0, (
+        f'combined HTML must have zero inline DOCTYPEs (outer wrapper '
+        f'omits the declaration); got {n_doctype}. Pre-fix the '
+        f'per-fragment `<!DOCTYPE html PUBLIC …>` survived the strip. '
+        f'Output:\n{html[:3000]}'
+    )
+    assert n_html_open == 1, (
+        f'combined HTML must have exactly one <html opening tag; '
+        f'got {n_html_open}. Pre-fix the per-fragment <html lang="en"> '
+        f'survived the strip. Output:\n{html[:3000]}'
+    )
+    assert n_html_close == 1, (
+        f'combined HTML must have exactly one </html> closing tag; '
+        f'got {n_html_close}.'
+    )
+    assert n_body_open == 1, (
+        f'combined HTML must have exactly one <body opening tag; '
+        f'got {n_body_open}.'
+    )
+    assert n_body_close == 1, (
+        f'combined HTML must have exactly one </body> closing tag; '
+        f'got {n_body_close}.'
+    )
+
+
+def test_print_invoice_combined_html_has_one_outer_shell(tmp_path):
+    """Combined two-invoice HTML carries exactly one outer wrapper:
+    no inline DOCTYPEs, one <html>, one </html>, one <body>, one
+    </body>. Catches both the `<html lang="en">`-not-stripped and the
+    `<!DOCTYPE>`-not-stripped bugs in one shot."""
+    runner = CliRunner()
+    gnc, id1, id2 = _book_with_two_invoices(runner, tmp_path)
+    out = tmp_path / 'combined.html'
+    r = runner.invoke(cli, [
+        'print-invoice', str(gnc), id1, id2,
+        '--format', 'html', '-o', str(out),
+    ])
+    assert r.exit_code == 0, f'print-invoice: {r.output}'
+    _assert_one_outer_shell(out.read_text())
+
+
+def test_print_bill_combined_html_has_one_outer_shell(tmp_path):
+    """Bill-side mirror of the above. Bills inherit the same combine
+    logic, so any regression in either CLI fails both tests."""
+    runner = CliRunner()
+    gnc, id1, id2 = _book_with_two_bills(runner, tmp_path)
+    out = tmp_path / 'combined.html'
+    r = runner.invoke(cli, [
+        'print-bill', str(gnc), id1, id2,
+        '--format', 'html', '-o', str(out),
+    ])
+    assert r.exit_code == 0, f'print-bill: {r.output}'
+    _assert_one_outer_shell(out.read_text())

--- a/tests/integration/test_cli_print_invoice.py
+++ b/tests/integration/test_cli_print_invoice.py
@@ -85,6 +85,29 @@ class TestPrintInvoiceErrors:
         )
         assert not os.path.exists(pdf_file), "PDF should not be created for unknown invoice"
 
+    def test_no_match_error_message_has_balanced_parens(
+        self, gnucash_with_invoice, tmp_path,
+    ):
+        """The "no invoices matched the selection (…)" message must have
+        balanced parentheses. An operator-precedence bug on the original
+        line — `'(' + ', '.join(c) if c else 'none' + ')'` parsed as
+        `('(' + ', '.join(c)) if c else ('none' + ')')` — dropped the
+        closing paren whenever criteria were present (the common case)."""
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "print-invoice", gnucash_with_invoice,
+            "DOES-NOT-EXIST",
+            "-o", str(tmp_path / "no.txt"),
+            "--format", "plaintext",
+        ])
+        assert result.exit_code != 0
+        assert "no invoices matched the selection (" in result.output, (
+            f"unexpected message:\n{result.output}"
+        )
+        assert result.output.count("(") == result.output.count(")"), (
+            f"unbalanced parentheses in error message:\n{result.output}"
+        )
+
     def test_missing_invoice_id_flag_exits_2(self, gnucash_with_invoice, tmp_path):
         """Omitting --invoice-id exits with code 2 (Click UsageError)."""
         pdf_file = tmp_path / "no.pdf"

--- a/tests/integration/test_q017_print_invoice_plaintext_and_multi.py
+++ b/tests/integration/test_q017_print_invoice_plaintext_and_multi.py
@@ -165,9 +165,13 @@ def test_tampered_entry_tax_breakdown_errors_loudly(tmp_path):
     )
 
 
-def test_draft_invoice_plaintext_subtotal_only(tmp_path):
-    """Unposted invoice has no posted tax splits, so plaintext renders
-    only the subtotal — no entry_tax, no invoice_tax_total, no total."""
+def test_draft_invoice_plaintext_emits_provisional_totals(tmp_path):
+    """Q-019: drafts now render the full informational stack — subtotal,
+    tax_total, total, per-entry entry_tax — computed from each entry's
+    tax_table (independent of posting state). A `# Tax figures are
+    provisional` comment header tells the recipient the numbers will
+    be recomputed at post time. For the fixture's single non-taxable
+    line item, tax_total = 0.00 and total == subtotal."""
     runner = CliRunner()
     gf = _build_book(runner, tmp_path,
                      str(FIXTURES / 'q017_draft_invoice.txt'))
@@ -178,12 +182,19 @@ def test_draft_invoice_plaintext_subtotal_only(tmp_path):
                             '-o', str(out)])
     assert r.exit_code == 0, f'render: {r.output}'
     text = out.read_text()
-    assert 'invoice_subtotal: 50.00' in text
-    assert 'invoice_tax_total' not in text, (
-        f'draft must not emit tax_total:\n{text}'
+    assert '# Tax figures are provisional' in text, (
+        f'draft must carry provisional-tax caveat; got:\n{text}'
     )
-    assert 'invoice_total' not in text.replace('invoice_subtotal', '_____')
-    assert 'entry_tax' not in text
+    assert 'invoice_subtotal: 50.00' in text
+    assert 'invoice_tax_total: 0.00' in text, (
+        f'draft must emit tax_total even when zero (post-Q-019):\n{text}'
+    )
+    assert 'invoice_total: 50.00' in text, (
+        f'draft must emit grand total (post-Q-019):\n{text}'
+    )
+    assert 'entry_tax: 0.00' in text, (
+        f'draft must emit per-entry entry_tax (post-Q-019):\n{text}'
+    )
 
 
 # ── Multi-invoice selection ────────────────────────────────────────────────

--- a/tests/integration/test_q019_draft_tax_render.py
+++ b/tests/integration/test_q019_draft_tax_render.py
@@ -1,0 +1,239 @@
+"""Q-019: drafts (cash-basis OR plain accrual) render full tax info.
+
+GnuCash only materialises tax splits at posting time; before then, the
+posted-path tax extraction returns nothing. Q-019 has the renderers
+compute tax from each entry's tax_table via compute_entry_informational
+so unposted invoices and bills carry the same tax detail as posted
+ones — marked as provisional in HTML / plaintext so the viewer knows
+the figures may change at post time.
+"""
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURES = Path('tests/fixtures')
+ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
+
+
+def _fx(name):
+    return (FIXTURES / name).read_text()
+
+
+def _import_into_fresh_book(runner, tmp_path, fixture_name):
+    gnc = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gnc), ACCOUNTS])
+    assert r.exit_code == 0, f'accounts: {r.output}'
+    time.sleep(1)
+    fx_path = tmp_path / fixture_name
+    fx_path.write_text(_fx(fixture_name))
+    r = runner.invoke(cli, ['import', str(gnc), str(fx_path),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f'{fixture_name}: {r.output}'
+    time.sleep(1)
+    return gnc
+
+
+def _render_invoice_html(gnc, invoice_id):
+    from gnucash import Query
+    from gnucash.gnucash_business import Invoice as BizInvoice
+
+    from repositories.gnucash_repository import GnuCashRepository
+    from services.invoice_renderer import render_to_html
+
+    repo = GnuCashRepository(str(gnc))
+    repo.open()
+    try:
+        q = Query()
+        q.search_for('gncInvoice')
+        q.set_book(repo.book)
+        inv = next(
+            (i for r in q.run() for i in [BizInvoice(instance=r)]
+             if i.GetID() == invoice_id),
+            None,
+        )
+        q.destroy()
+        assert inv is not None, f'invoice {invoice_id!r} not found'
+        xslt = Path(__file__).resolve().parents[2] / 'services' / 'invoice.xslt'
+        return render_to_html(inv, repo.book, str(xslt))
+    finally:
+        repo.close()
+
+
+def _render_invoice_plaintext(gnc, invoice_id):
+    from gnucash import Query
+    from gnucash.gnucash_business import Invoice as BizInvoice
+
+    from repositories.gnucash_repository import GnuCashRepository
+    from services.invoice_renderer import render_to_plaintext
+
+    repo = GnuCashRepository(str(gnc))
+    repo.open()
+    try:
+        q = Query()
+        q.search_for('gncInvoice')
+        q.set_book(repo.book)
+        inv = next(
+            (i for r in q.run() for i in [BizInvoice(instance=r)]
+             if i.GetID() == invoice_id),
+            None,
+        )
+        q.destroy()
+        assert inv is not None, f'invoice {invoice_id!r} not found'
+        return render_to_plaintext(inv, repo.book)
+    finally:
+        repo.close()
+
+
+# ── HTML / PDF render path ─────────────────────────────────────────
+
+def test_cash_basis_unposted_invoice_html_renders_combined_tax(tmp_path):
+    """Cash-basis unposted invoice with GST 5% + PST 7%: the HTML must
+    show one <tax-line> row per tax-table account (per-account
+    aggregation), the correct grand total (200 + 24 = 224), AND a
+    provisional-tax notice so the viewer knows the figures will be
+    recomputed at post time."""
+    runner = CliRunner()
+    gnc = _import_into_fresh_book(
+        runner, tmp_path, 'q019_unposted_cash_with_tax.txt',
+    )
+    html = _render_invoice_html(gnc, 'INV-Q19-CASH-TAX-200')
+
+    # Cash-basis → UNPAID badge (not DRAFT).
+    assert '<span class="badge badge-unpaid">Unpaid</span>' in html
+    assert '<span class="badge badge-draft">Draft</span>' not in html
+
+    # Both per-tax-account rows are present.
+    assert '>GST<' in html, (
+        f'expected GST tax-line row; HTML:\n{html[:2500]}'
+    )
+    assert '>PST<' in html, (
+        f'expected PST tax-line row; HTML:\n{html[:2500]}'
+    )
+
+    # Tax dollars: GST = 200 * 0.05 = 10.00; PST = 200 * 0.07 = 14.00.
+    assert '$10.00' in html, 'expected GST = $10.00 row'
+    assert '$14.00' in html, 'expected PST = $14.00 row'
+
+    # Grand total includes tax (200 + 24 = 224.00).
+    assert 'CAD\xa0224.00' in html or 'CAD&#160;224.00' in html or 'CAD 224.00' in html, (
+        f'expected grand total CAD 224.00; got:\n{html[-2000:]}'
+    )
+
+    # Provisional-tax notice must appear.
+    assert 'provisional' in html.lower(), (
+        f'expected provisional-tax notice; HTML:\n{html[-2000:]}'
+    )
+
+
+def test_plain_accrual_draft_invoice_html_renders_single_tax(tmp_path):
+    """Plain accrual draft (no cash_basis flag) with a single 10% Sales
+    Tax: badge stays DRAFT, but tax detail is now rendered just like the
+    cash-basis case. Single tax-table entry → single tax-line row +
+    `single` tax-label CSS class."""
+    runner = CliRunner()
+    gnc = _import_into_fresh_book(
+        runner, tmp_path, 'q019_unposted_draft_with_tax.txt',
+    )
+    html = _render_invoice_html(gnc, 'INV-Q19-DRAFT-TAX-300')
+
+    # Plain draft → DRAFT badge.
+    assert '<span class="badge badge-draft">Draft</span>' in html
+    assert '<span class="badge badge-unpaid">Unpaid</span>' not in html
+
+    # Single tax-table → one tax-line row, `single` label class.
+    assert 'tax-single' in html, (
+        f'expected single-rate tax-label class; HTML:\n{html[:2500]}'
+    )
+
+    # Tax = 300 * 0.10 = 30.00; grand total = 330.00.
+    assert '$30.00' in html, 'expected tax-line row amount $30.00'
+    assert 'CAD\xa0330.00' in html or 'CAD&#160;330.00' in html or 'CAD 330.00' in html, (
+        f'expected grand total CAD 330.00; got:\n{html[-2000:]}'
+    )
+
+    assert 'provisional' in html.lower(), (
+        f'expected provisional-tax notice on draft; HTML:\n{html[-2000:]}'
+    )
+
+
+# ── Plaintext render path ─────────────────────────────────────────
+
+def test_cash_basis_unposted_invoice_plaintext_emits_breakdown(tmp_path):
+    """Plaintext render must include entry_amount, entry_tax, per-tax
+    breakdown blocks, invoice_subtotal, invoice_tax_total,
+    invoice_total, AND a `#` comment caveat. The comment line ensures
+    the recipient sees that tax values are provisional."""
+    runner = CliRunner()
+    gnc = _import_into_fresh_book(
+        runner, tmp_path, 'q019_unposted_cash_with_tax.txt',
+    )
+    text = _render_invoice_plaintext(gnc, 'INV-Q19-CASH-TAX-200')
+
+    assert '# Tax figures are provisional' in text, (
+        f'expected provisional-tax `#` caveat; got:\n{text}'
+    )
+    # Entry-level informational fields.
+    assert 'entry_amount: 200.00' in text, f'got:\n{text}'
+    assert 'entry_tax: 24.00' in text, f'got:\n{text}'
+
+    # One breakdown block per tax-table entry.
+    assert 'account: "Liabilities:Tax:GST"' in text
+    assert 'account: "Liabilities:Tax:PST"' in text
+    # Combined amounts (per breakdown row).
+    assert 'amount: 10.00' in text, f'expected GST 10.00 breakdown; got:\n{text}'
+    assert 'amount: 14.00' in text, f'expected PST 14.00 breakdown; got:\n{text}'
+
+    # Invoice-level totals.
+    assert 'invoice_subtotal: 200.00' in text
+    assert 'invoice_tax_total: 24.00' in text
+    assert 'invoice_total: 224.00' in text
+
+
+def test_plain_draft_invoice_plaintext_emits_breakdown(tmp_path):
+    """Same coverage as the cash-basis case but for a plain accrual
+    draft — confirms the gates aren't accidentally still cash_basis-only."""
+    runner = CliRunner()
+    gnc = _import_into_fresh_book(
+        runner, tmp_path, 'q019_unposted_draft_with_tax.txt',
+    )
+    text = _render_invoice_plaintext(gnc, 'INV-Q19-DRAFT-TAX-300')
+
+    assert '# Tax figures are provisional' in text
+    assert 'entry_amount: 300.00' in text, f'got:\n{text}'
+    assert 'entry_tax: 30.00' in text, f'got:\n{text}'
+    assert 'account: "Liabilities:Tax:Sales Tax"' in text
+    assert 'amount: 30.00' in text
+    assert 'invoice_subtotal: 300.00' in text
+    assert 'invoice_tax_total: 30.00' in text
+    assert 'invoice_total: 330.00' in text
+
+
+def test_rendered_plaintext_reimports_without_parser_error(tmp_path):
+    """The `# ...` provisional caveat is a new line shape; the parser
+    must skip it so rendered output re-imports cleanly. Renders a draft
+    invoice to plaintext, then `import --new` into a fresh book."""
+    runner = CliRunner()
+    gnc = _import_into_fresh_book(
+        runner, tmp_path, 'q019_unposted_cash_with_tax.txt',
+    )
+    text = _render_invoice_plaintext(gnc, 'INV-Q19-CASH-TAX-200')
+
+    # The caveat must actually be there for this test to mean anything.
+    assert '# Tax figures are provisional' in text
+
+    rendered_path = tmp_path / 'rendered.txt'
+    rendered_path.write_text(text)
+
+    fresh_gnc = tmp_path / 'fresh.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(fresh_gnc), ACCOUNTS])
+    assert r.exit_code == 0, f'accounts: {r.output}'
+    time.sleep(1)
+    r = runner.invoke(cli, ['import', str(fresh_gnc), str(rendered_path),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, (
+        f'rendered draft plaintext must re-import cleanly '
+        f'(the `#` caveat must be skipped by the parser); got:\n{r.output}'
+    )

--- a/tests/integration/test_q019_two_sided_render.py
+++ b/tests/integration/test_q019_two_sided_render.py
@@ -1,0 +1,336 @@
+"""Q-019: invoice / bill rendering shows BOTH sides.
+
+Invoice: customer (Bill To) on one side, our company (From) on the
+other. Bill: vendor (Bill From) on one side, our company (Bill To) on
+the other. Drives the full CLI pipeline — populates real Business →
+Company book options via the GnuCash KvpFrame API, then runs
+`print-invoice` / `print-bill`, which calls `read_book_company_info`
+itself. No `company_info=` injection (that would skip the wiring
+between the reader and the renderer, where bugs hide).
+"""
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURES = Path('tests/fixtures')
+ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
+
+# Our company info — written into the GnuCash book's Business→Company
+# options frame for every test in this module.
+COMPANY = {
+    'Company Name':          'Acme Plaintext Co.',
+    'Company ID':            '123456789RT0001',
+    'Company Phone Number':  '+1-555-0142',
+    'Company Email Address': 'billing@acmeplain.test',
+    'Company Website URL':   'https://acmeplain.test',
+    'Company Address':       '100 Main St\nSuite 200\nToronto ON M5H 1A1',
+}
+
+
+def _fx(name):
+    return (FIXTURES / name).read_text()
+
+
+def _populate_company_options(gnc_path):
+    """Write Acme's Business → Company options into the .gnucash XML
+    directly, mirroring what the GnuCash GUI's File→Properties→Business
+    dialog writes. This is the SAME XML shape that
+    `read_book_company_info` (services/invoice_renderer.py) reads from,
+    so the test exercises the production reader end-to-end.
+
+    Uses lxml (already a project dependency, see render_to_html) so
+    namespace prefixes — many of which the test doesn't enumerate
+    explicitly — survive the round-trip. Stdlib ElementTree would
+    remap unknown prefixes to ns0:/ns1:/..., which GnuCash's XML
+    backend then rejects on the next session-load.
+
+    Why not the SWIG KvpFrame API: GnuCash's Python bindings don't
+    export `KvpValue` as a top-level name in our installed build, and
+    `Business → Company` is a nested-frame slot (options frame →
+    Business frame → string fields) that our flat-slot helpers in
+    `infrastructure/gnucash/kvp.py` don't cover. Direct XML injection
+    is the realistic alternative — the read path is untouched."""
+    import gzip
+
+    from lxml import etree
+
+    slot_ns = 'http://www.gnucash.org/XML/slot'
+    book_ns = 'http://www.gnucash.org/XML/book'
+    gnc_ns = 'http://www.gnucash.org/XML/gnc'
+
+    with open(gnc_path, 'rb') as f:
+        head = f.read(2)
+    is_gzip = head == b'\x1f\x8b'
+
+    if is_gzip:
+        with gzip.open(gnc_path, 'rb') as f:
+            raw = f.read()
+    else:
+        with open(gnc_path, 'rb') as f:
+            raw = f.read()
+
+    tree = etree.fromstring(raw)
+    book = tree.find(f'{{{gnc_ns}}}book')
+    assert book is not None, f'no <gnc:book> in {gnc_path!r}'
+
+    slots = book.find(f'{{{book_ns}}}slots')
+    if slots is None:
+        slots = etree.SubElement(book, f'{{{book_ns}}}slots')
+
+    def _str_slot(parent, key, text):
+        s = etree.SubElement(parent, 'slot')
+        etree.SubElement(s, f'{{{slot_ns}}}key').text = key
+        v = etree.SubElement(s, f'{{{slot_ns}}}value')
+        v.set('type', 'string')
+        v.text = text
+        return s
+
+    options_slot = etree.SubElement(slots, 'slot')
+    etree.SubElement(options_slot, f'{{{slot_ns}}}key').text = 'options'
+    options_value = etree.SubElement(options_slot, f'{{{slot_ns}}}value')
+    options_value.set('type', 'frame')
+
+    biz_slot = etree.SubElement(options_value, 'slot')
+    etree.SubElement(biz_slot, f'{{{slot_ns}}}key').text = 'Business'
+    biz_value = etree.SubElement(biz_slot, f'{{{slot_ns}}}value')
+    biz_value.set('type', 'frame')
+
+    for slot_key, slot_text in COMPANY.items():
+        _str_slot(biz_value, slot_key, slot_text)
+
+    out = etree.tostring(tree, xml_declaration=True, encoding='utf-8')
+    if is_gzip:
+        with gzip.open(gnc_path, 'wb') as f:
+            f.write(out)
+    else:
+        with open(gnc_path, 'wb') as f:
+            f.write(out)
+
+    # Self-check: read back via the production reader. If the renderer
+    # can't see the options we just wrote, the test setup is broken
+    # before any production rendering code runs — fail loudly here so
+    # the failure isn't blamed on the renderer downstream.
+    from services.invoice_renderer import read_book_company_info
+    info = read_book_company_info(str(gnc_path))
+    assert info.get('name') == COMPANY['Company Name'], (
+        f'read_book_company_info did not see the injected options; '
+        f'got: {info!r}'
+    )
+
+
+def _book_with_company(runner, tmp_path, fixture_name):
+    """Common setup: fresh book → accounts → fixture → company options.
+    Options are injected last so no subsequent GnuCash session-save
+    re-serializes the book (which would canonicalise XML namespace
+    prefixes and might reorder slots). `print-invoice` / `print-bill`
+    only open the book READ_ONLY, so the XML-injected slots survive."""
+    gnc = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gnc), ACCOUNTS])
+    assert r.exit_code == 0, f'accounts: {r.output}'
+    time.sleep(1)
+    fx_path = tmp_path / fixture_name
+    fx_path.write_text(_fx(fixture_name))
+    r = runner.invoke(cli, ['import', str(gnc), str(fx_path),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f'{fixture_name}: {r.output}'
+    time.sleep(1)
+    _populate_company_options(gnc)
+    return gnc
+
+
+# ── Invoice two-sided rendering ────────────────────────────────────
+
+def test_invoice_html_renders_both_customer_and_company(tmp_path):
+    """`print-invoice --format html` produces an HTML doc that contains
+    BOTH the customer ('Bill To') block AND our company ('From') block,
+    with all relevant fields populated from book options."""
+    runner = CliRunner()
+    gnc = _book_with_company(
+        runner, tmp_path, 'q019_unposted_cash_with_tax.txt',
+    )
+    out_html = tmp_path / 'invoice.html'
+    r = runner.invoke(cli, [
+        'print-invoice', str(gnc), 'INV-Q19-CASH-TAX-200',
+        '--format', 'html', '-o', str(out_html),
+    ])
+    assert r.exit_code == 0, f'print-invoice: {r.output}'
+
+    html = out_html.read_text()
+
+    # Customer side (Bill To)
+    assert '>Bill To<' in html, f'missing "Bill To" header; HTML:\n{html}'
+    assert 'Beta Industries' in html, (
+        f'customer name must appear in Bill To block; HTML:\n{html}'
+    )
+
+    # Company side (From)
+    assert '>From<' in html, f'missing "From" header; HTML:\n{html}'
+    assert COMPANY['Company Name'] in html, (
+        f'company name must appear in From block; HTML:\n{html}'
+    )
+    assert COMPANY['Company ID'] in html, (
+        f'Company ID (tax registration) value must appear in From '
+        f'block; HTML:\n{html}'
+    )
+    # Address line 1 of the multi-line company address.
+    assert '100 Main St' in html, (
+        f'company address must appear in From block; HTML:\n{html}'
+    )
+    assert COMPANY['Company Phone Number'] in html
+    assert COMPANY['Company Email Address'] in html
+    assert COMPANY['Company Website URL'] in html
+
+
+def test_invoice_plaintext_emits_seller_header(tmp_path):
+    """`print-invoice --format plaintext` emits a `# Issued by: <name> |
+    Company ID: <id> | <addr> | <phone> | <email> | <url>` comment
+    header so the recipient knows who issued the invoice. The header
+    is a parser-skipped comment, so it doesn't leak into the
+    recipient's book on re-import."""
+    runner = CliRunner()
+    gnc = _book_with_company(
+        runner, tmp_path, 'q019_unposted_cash_with_tax.txt',
+    )
+    out_txt = tmp_path / 'invoice.txt'
+    r = runner.invoke(cli, [
+        'print-invoice', str(gnc), 'INV-Q19-CASH-TAX-200',
+        '--format', 'plaintext', '-o', str(out_txt),
+    ])
+    assert r.exit_code == 0, f'print-invoice: {r.output}'
+
+    text = out_txt.read_text()
+    assert text.startswith('# Issued by: '), (
+        f'plaintext must start with seller `#` header; got:\n{text[:500]}'
+    )
+    assert COMPANY['Company Name'] in text
+    assert COMPANY['Company ID'] in text
+    assert COMPANY['Company Phone Number'] in text
+    assert COMPANY['Company Email Address'] in text
+    assert COMPANY['Company Website URL'] in text
+
+
+# ── Bill two-sided rendering ───────────────────────────────────────
+
+_BILL_FIXTURE = 'q019_unposted_cash_bill.txt'
+
+
+def test_bill_html_renders_both_vendor_and_company(tmp_path):
+    """`print-bill --format html` produces a doc that puts the vendor
+    on the 'Bill From' side and our company on the 'Bill To' side
+    (the inverse of an invoice). Tax lines (GST + PST, 4×50 = 200,
+    tax = 5+7 = 12% → 24.00) and provisional notice are also asserted
+    so this test simultaneously covers Q-019's draft-tax behaviour
+    on bills."""
+    runner = CliRunner()
+    gnc = _book_with_company(runner, tmp_path, _BILL_FIXTURE)
+
+    out_html = tmp_path / 'bill.html'
+    r = runner.invoke(cli, [
+        'print-bill', str(gnc), 'BILL-Q19-CASH-TAX-400',
+        '--format', 'html', '-o', str(out_html),
+    ])
+    assert r.exit_code == 0, f'print-bill: {r.output}'
+
+    html = out_html.read_text()
+
+    # Vendor side (Bill From).
+    assert '>Bill From<' in html, (
+        f'missing "Bill From" header; HTML:\n{html}'
+    )
+    assert 'Office Depot Wholesale' in html, (
+        f'vendor name must appear in Bill From block; HTML:\n{html}'
+    )
+
+    # Company side (Bill To — us).
+    assert '>Bill To<' in html, (
+        f'missing "Bill To" header; HTML:\n{html}'
+    )
+    assert COMPANY['Company Name'] in html
+    assert COMPANY['Company ID'] in html
+    assert '100 Main St' in html
+
+    # Tax breakdown (drives Q-019 draft tax for bills).
+    assert '>GST<' in html
+    assert '>PST<' in html
+    assert '$10.00' in html, 'GST 5% on $200 = $10.00'
+    assert '$14.00' in html, 'PST 7% on $200 = $14.00'
+    assert 'CAD\xa0224.00' in html or 'CAD&#160;224.00' in html or 'CAD 224.00' in html, (
+        f'grand total CAD 224.00 must appear; HTML:\n{html[-2000:]}'
+    )
+    assert 'provisional' in html.lower()
+
+
+def test_bill_plaintext_emits_seller_and_vendor_headers(tmp_path):
+    """`print-bill --format plaintext` emits two leading `#` lines: the
+    seller header naming us (the recipient) and a `# Bill from vendor:`
+    line naming the supplier. Both are comments → don't survive
+    re-import."""
+    runner = CliRunner()
+    gnc = _book_with_company(runner, tmp_path, _BILL_FIXTURE)
+
+    out_txt = tmp_path / 'bill.txt'
+    r = runner.invoke(cli, [
+        'print-bill', str(gnc), 'BILL-Q19-CASH-TAX-400',
+        '--format', 'plaintext', '-o', str(out_txt),
+    ])
+    assert r.exit_code == 0, f'print-bill: {r.output}'
+
+    text = out_txt.read_text()
+    assert text.startswith('# Bill received by: '), (
+        f'plaintext must start with `# Bill received by:` header; '
+        f'got:\n{text[:500]}'
+    )
+    assert COMPANY['Company Name'] in text
+    assert COMPANY['Company ID'] in text
+    assert '# Bill from vendor: Office Depot Wholesale' in text
+    assert '# Tax figures are provisional' in text, (
+        f'unposted bill must carry provisional-tax caveat; got:\n{text}'
+    )
+    # Q-017 bill_* informational totals appear.
+    assert 'bill_subtotal: 200.00' in text
+    assert 'bill_tax_total: 24.00' in text
+    assert 'bill_total: 224.00' in text
+
+
+# ── Seller-header round-trip ──────────────────────────────────────
+
+def test_rendered_plaintext_with_seller_header_reimports_cleanly(tmp_path):
+    """A rendered invoice that carries `# Issued by: ...` (because the
+    source book had Business→Company options populated) must re-import
+    cleanly into a fresh book — the parser's `#`-comment skip is what
+    keeps the seller info from leaking into the recipient's KVP slots.
+    The Q-019 draft-tax round-trip test only exercises the
+    `# Tax figures are provisional` caveat; this test adds explicit
+    coverage with the seller header actually present."""
+    runner = CliRunner()
+    gnc = _book_with_company(
+        runner, tmp_path, 'q019_unposted_cash_with_tax.txt',
+    )
+    out_txt = tmp_path / 'rendered.txt'
+    r = runner.invoke(cli, [
+        'print-invoice', str(gnc), 'INV-Q19-CASH-TAX-200',
+        '--format', 'plaintext', '-o', str(out_txt),
+    ])
+    assert r.exit_code == 0, f'print-invoice: {r.output}'
+    rendered = out_txt.read_text()
+    # Precondition: the rendered text must actually carry the seller
+    # header — otherwise this test isn't exercising what it claims.
+    assert rendered.startswith('# Issued by: Acme Plaintext Co.'), (
+        f'rendered text missing seller header — test premise broken; '
+        f'got:\n{rendered[:300]}'
+    )
+
+    fresh_gnc = tmp_path / 'fresh.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(fresh_gnc), ACCOUNTS])
+    assert r.exit_code == 0, f'fresh accounts: {r.output}'
+    time.sleep(1)
+    r = runner.invoke(cli, ['import', str(fresh_gnc), str(out_txt),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, (
+        f'rendered plaintext (with seller `#` header) must re-import '
+        f'cleanly; the parser must skip the `#` lines so they don\'t '
+        f'land as KVPs in the recipient\'s book. Got:\n{r.output}'
+    )

--- a/tests/integration/test_q019_two_sided_render.py
+++ b/tests/integration/test_q019_two_sided_render.py
@@ -35,79 +35,27 @@ def _fx(name):
 
 
 def _populate_company_options(gnc_path):
-    """Write Acme's Business → Company options into the .gnucash XML
-    directly, mirroring what the GnuCash GUI's File→Properties→Business
-    dialog writes. This is the SAME XML shape that
-    `read_book_company_info` (services/invoice_renderer.py) reads from,
-    so the test exercises the production reader end-to-end.
+    """Set Acme's Business → Company options on the book via the proper
+    GnuCash API (`set_book_string_option`, which wraps
+    `qof_instance_set_kvp` with a 3-element nested path). This goes
+    through GnuCash's dirty-tracking + session-save machinery, the
+    same path File→Properties→Business uses in the GUI, so the test
+    setup is faithful to how production users populate these slots.
 
-    Uses lxml (already a project dependency, see render_to_html) so
-    namespace prefixes — many of which the test doesn't enumerate
-    explicitly — survive the round-trip. Stdlib ElementTree would
-    remap unknown prefixes to ns0:/ns1:/..., which GnuCash's XML
-    backend then rejects on the next session-load.
-
-    Why not the SWIG KvpFrame API: GnuCash's Python bindings don't
-    export `KvpValue` as a top-level name in our installed build, and
-    `Business → Company` is a nested-frame slot (options frame →
-    Business frame → string fields) that our flat-slot helpers in
-    `infrastructure/gnucash/kvp.py` don't cover. Direct XML injection
-    is the realistic alternative — the read path is untouched."""
-    import gzip
-
-    from lxml import etree
-
-    slot_ns = 'http://www.gnucash.org/XML/slot'
-    book_ns = 'http://www.gnucash.org/XML/book'
-    gnc_ns = 'http://www.gnucash.org/XML/gnc'
-
-    with open(gnc_path, 'rb') as f:
-        head = f.read(2)
-    is_gzip = head == b'\x1f\x8b'
-
-    if is_gzip:
-        with gzip.open(gnc_path, 'rb') as f:
-            raw = f.read()
-    else:
-        with open(gnc_path, 'rb') as f:
-            raw = f.read()
-
-    tree = etree.fromstring(raw)
-    book = tree.find(f'{{{gnc_ns}}}book')
-    assert book is not None, f'no <gnc:book> in {gnc_path!r}'
-
-    slots = book.find(f'{{{book_ns}}}slots')
-    if slots is None:
-        slots = etree.SubElement(book, f'{{{book_ns}}}slots')
-
-    def _str_slot(parent, key, text):
-        s = etree.SubElement(parent, 'slot')
-        etree.SubElement(s, f'{{{slot_ns}}}key').text = key
-        v = etree.SubElement(s, f'{{{slot_ns}}}value')
-        v.set('type', 'string')
-        v.text = text
-        return s
-
-    options_slot = etree.SubElement(slots, 'slot')
-    etree.SubElement(options_slot, f'{{{slot_ns}}}key').text = 'options'
-    options_value = etree.SubElement(options_slot, f'{{{slot_ns}}}value')
-    options_value.set('type', 'frame')
-
-    biz_slot = etree.SubElement(options_value, 'slot')
-    etree.SubElement(biz_slot, f'{{{slot_ns}}}key').text = 'Business'
-    biz_value = etree.SubElement(biz_slot, f'{{{slot_ns}}}value')
-    biz_value.set('type', 'frame')
-
-    for slot_key, slot_text in COMPANY.items():
-        _str_slot(biz_value, slot_key, slot_text)
-
-    out = etree.tostring(tree, xml_declaration=True, encoding='utf-8')
-    if is_gzip:
-        with gzip.open(gnc_path, 'wb') as f:
-            f.write(out)
-    else:
-        with open(gnc_path, 'wb') as f:
-            f.write(out)
+    The renderer's `read_book_company_info` then reads the resulting
+    XML directly — no production code is bypassed."""
+    from infrastructure.gnucash.kvp import set_book_string_option
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gnc_path))
+    repo.open()
+    try:
+        for slot_key, slot_val in COMPANY.items():
+            assert set_book_string_option(
+                repo.book, 'Business', slot_key, slot_val,
+            ), f'set_book_string_option failed for Business/{slot_key}'
+        repo.save()
+    finally:
+        repo.close()
 
     # Self-check: read back via the production reader. If the renderer
     # can't see the options we just wrote, the test setup is broken
@@ -116,7 +64,7 @@ def _populate_company_options(gnc_path):
     from services.invoice_renderer import read_book_company_info
     info = read_book_company_info(str(gnc_path))
     assert info.get('name') == COMPANY['Company Name'], (
-        f'read_book_company_info did not see the injected options; '
+        f'read_book_company_info did not see the populated options; '
         f'got: {info!r}'
     )
 

--- a/tests/integration/test_set_book_string_option.py
+++ b/tests/integration/test_set_book_string_option.py
@@ -1,0 +1,289 @@
+"""Integration tests for set_book_string_option.
+
+Background — Q-019 needed to populate Business → Company options on a
+test book so the print-invoice / print-bill render path could read them
+via `read_book_company_info`. The first attempt used
+`qof_instance_set_kvp` (variadic) with a 3-element path; ctypes' x86_64
+ABI handling silently no-ops that call for path counts >= 2. The
+working implementation switched to `qof_book_set_string_option(book,
+"options/<section>/<name>", value)` which is non-variadic and lets the C
+side handle GSList construction.
+
+These tests verify the new API is **write-compatible** with what the
+GnuCash GUI's File→Properties dialog would have produced — same slot
+path, same canonical structure, update-replaces-not-appends, no
+duplicates. They use a real GnuCash session (`gnucash.Session`) and a
+real .gnucash file on disk; nothing is mocked.
+"""
+import gzip
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURES = Path('tests/fixtures')
+ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
+
+_BOOK_NS = 'http://www.gnucash.org/XML/book'
+_SLOT_NS = 'http://www.gnucash.org/XML/slot'
+_GNC_NS = 'http://www.gnucash.org/XML/gnc'
+
+
+@pytest.fixture
+def fresh_book(tmp_path):
+    """A fresh .gnucash file imported from the Q-019 accounts fixture.
+    Used as a known starting point with no Business slots."""
+    runner = CliRunner()
+    gnc = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gnc), ACCOUNTS])
+    assert r.exit_code == 0, f'accounts: {r.output}'
+    time.sleep(1)
+    return gnc
+
+
+def _read_xml(gnc_path):
+    """Read the .gnucash file as XML (gzip-aware). Returns the root
+    element. Read-only inspection — no writes — so the namespace
+    prefix preservation concerns from the renderer test don't apply."""
+    with open(gnc_path, 'rb') as f:
+        head = f.read(2)
+    is_gzip = head == b'\x1f\x8b'
+    if is_gzip:
+        with gzip.open(gnc_path, 'rb') as f:
+            return ET.fromstring(f.read())
+    with open(gnc_path, 'rb') as f:
+        return ET.fromstring(f.read())
+
+
+def _walk_slot_value(parent_value_el, key_chain):
+    """Walk a chain of slot keys through `<slot:value type="frame">` →
+    `<slot>` → `<slot:key>` → `<slot:value>`. Returns the leaf
+    `<slot:value>` element, or None if any link is missing.
+
+    This is the exact traversal `read_book_company_info` uses, so a
+    slot reachable via this walk is by definition reachable to the
+    production reader."""
+    cur = parent_value_el
+    for want_key in key_chain:
+        found = None
+        for slot in cur.findall('slot'):
+            k = slot.find(f'{{{_SLOT_NS}}}key')
+            if k is not None and k.text == want_key:
+                found = slot.find(f'{{{_SLOT_NS}}}value')
+                break
+        if found is None:
+            return None
+        cur = found
+    return cur
+
+
+def _read_business_slot(gnc_path, key):
+    """Return the string value at slots → options → Business → <key>
+    or None if absent. Walks the XML directly."""
+    root = _read_xml(gnc_path)
+    book = root.find(f'{{{_GNC_NS}}}book')
+    if book is None:
+        return None
+    slots = book.find(f'{{{_BOOK_NS}}}slots')
+    if slots is None:
+        return None
+    # `slots` is the book's <book:slots>; its children are <slot>s, not
+    # a <slot:value>. Wrap in a synthetic parent to reuse _walk_slot_value.
+    fake_parent = ET.Element('value')
+    fake_parent.extend(slots.findall('slot'))
+    leaf = _walk_slot_value(fake_parent, ['options', 'Business', key])
+    if leaf is None:
+        return None
+    return (leaf.text or '').strip()
+
+
+def _count_business_slot_occurrences(gnc_path, key):
+    """Count how many times the slot appears at the canonical path.
+    Verifies update-semantics: a second write with the same key must
+    REPLACE the existing slot, not append a duplicate. Returns 0 if
+    the slot is absent."""
+    root = _read_xml(gnc_path)
+    book = root.find(f'{{{_GNC_NS}}}book')
+    if book is None:
+        return 0
+    slots = book.find(f'{{{_BOOK_NS}}}slots')
+    if slots is None:
+        return 0
+    # Find every <slot:key>options</slot:key> at the top level, descend
+    # into its frame, find every <slot:key>Business</slot:key>, descend
+    # again, count <slot:key>{key}</slot:key>.
+    count = 0
+    for options_slot in slots.findall('slot'):
+        k = options_slot.find(f'{{{_SLOT_NS}}}key')
+        if k is None or k.text != 'options':
+            continue
+        options_value = options_slot.find(f'{{{_SLOT_NS}}}value')
+        if options_value is None:
+            continue
+        for biz_slot in options_value.findall('slot'):
+            bk = biz_slot.find(f'{{{_SLOT_NS}}}key')
+            if bk is None or bk.text != 'Business':
+                continue
+            biz_value = biz_slot.find(f'{{{_SLOT_NS}}}value')
+            if biz_value is None:
+                continue
+            for field_slot in biz_value.findall('slot'):
+                fk = field_slot.find(f'{{{_SLOT_NS}}}key')
+                if fk is not None and fk.text == key:
+                    count += 1
+    return count
+
+
+def _write_business_options(gnc_path, *pairs):
+    """Open a session, call set_book_string_option once per (key, value)
+    pair, save, close. Returns a list of booleans matching the helper's
+    success result per pair.
+
+    Batched in a single session because GnuCash's backup-file naming
+    uses YYYYMMDDHHMMSS — two opens-save-close cycles in the same
+    second collide on the backup filename and the second save fails
+    with ERR_FILEIO_BACKUP_ERROR. Real callers (the GnuCash GUI, the
+    print-bill setup helper) also batch their writes for the same
+    reason."""
+    import gnucash
+
+    from infrastructure.gnucash.kvp import set_book_string_option
+    sess = gnucash.Session(f'xml://{gnc_path}')
+    try:
+        results = [
+            set_book_string_option(sess.book, 'Business', key, value)
+            for key, value in pairs
+        ]
+        sess.save()
+    finally:
+        sess.end()
+    return results
+
+
+# ── Slot path is what read_book_company_info reads ────────────────
+
+def test_writes_land_at_options_business_key(fresh_book):
+    """The slot written by set_book_string_option must appear at
+    options → Business → <key> in the saved XML — the exact path the
+    `read_book_company_info` reader walks. If the slot landed
+    anywhere else (e.g. a flat key like `options/Business/Company
+    Name`, or under a different parent frame), the renderer's "From"
+    block would silently show empty values, which is exactly the
+    silent-compatibility-break this test prevents."""
+    assert all(_write_business_options(fresh_book, ('Company Name', 'Acme')))
+    val = _read_business_slot(fresh_book, 'Company Name')
+    assert val == 'Acme', (
+        f'expected slot at options/Business/Company Name with value '
+        f'"Acme"; got {val!r}'
+    )
+
+
+def test_renderer_reader_sees_the_written_slot(fresh_book):
+    """End-to-end via the production reader. If
+    read_book_company_info returns the value, every downstream
+    consumer (HTML, plaintext, future API) gets it too."""
+    from services.invoice_renderer import read_book_company_info
+    assert all(_write_business_options(
+        fresh_book,
+        ('Company Name',          'Acme Plaintext Co.'),
+        ('Company Email Address', 'hi@acme.test'),
+        ('Company ID',            '12345RT0001'),
+    ))
+    info = read_book_company_info(str(fresh_book))
+    assert info['name']  == 'Acme Plaintext Co.'
+    assert info['email'] == 'hi@acme.test'
+    assert info['id']    == '12345RT0001'
+
+
+# ── Update semantics: second write replaces first ──────────────────
+
+def test_second_write_replaces_first_value(fresh_book):
+    """Setting the same key twice with different values: the second
+    value wins, and the slot appears exactly once. A duplicate would
+    mean GnuCash's own writes (from File→Properties) would silently
+    create dual slots on the same book — confusing, and the reader's
+    "first match wins" semantics would pick the wrong one.
+
+    Sleeps between session writes because GnuCash's backup-file naming
+    uses a 1-second-granularity timestamp; consecutive saves within
+    the same second collide. Real callers (GUI users, batched test
+    helpers) don't hit this because they batch writes in one session."""
+    assert _write_business_options(fresh_book, ('Company Name', 'First Name'))[0]
+    first_value = _read_business_slot(fresh_book, 'Company Name')
+    assert first_value == 'First Name'
+
+    time.sleep(1.1)
+    assert _write_business_options(fresh_book, ('Company Name', 'Second Name'))[0]
+    second_value = _read_business_slot(fresh_book, 'Company Name')
+    assert second_value == 'Second Name', (
+        f'expected second write to replace; got {second_value!r}'
+    )
+
+    # The critical compatibility check: exactly ONE Company Name slot.
+    n = _count_business_slot_occurrences(fresh_book, 'Company Name')
+    assert n == 1, (
+        f'expected exactly 1 Company Name slot after two writes; '
+        f'found {n}. Duplicates indicate set_book_string_option is '
+        f'appending instead of replacing.'
+    )
+
+
+def test_multiple_distinct_keys_coexist(fresh_book):
+    """Setting different keys (Company Name + Company Email Address +
+    Company ID) puts each at its own slot under the same Business
+    frame — verifying the function doesn't accidentally overwrite
+    sibling fields."""
+    assert all(_write_business_options(
+        fresh_book,
+        ('Company Name',          'Acme'),
+        ('Company Email Address', 'hi@acme.test'),
+        ('Company ID',            '12345RT0001'),
+    ))
+    assert _read_business_slot(fresh_book, 'Company Name')          == 'Acme'
+    assert _read_business_slot(fresh_book, 'Company Email Address') == 'hi@acme.test'
+    assert _read_business_slot(fresh_book, 'Company ID')            == '12345RT0001'
+
+    for key in ('Company Name', 'Company Email Address', 'Company ID'):
+        n = _count_business_slot_occurrences(fresh_book, key)
+        assert n == 1, f'expected exactly 1 slot for {key!r}; found {n}'
+
+
+# ── Non-ASCII value encoding ─────────────────────────────────────
+
+def test_non_ascii_value_round_trips_utf8(fresh_book):
+    """Values containing CJK / accented characters must encode as
+    UTF-8 in the XML and read back unchanged. The user's books span
+    HKD / CNY / JPY locales, so vendor / company names in those
+    scripts must survive the write."""
+    assert _write_business_options(
+        fresh_book,
+        ('Company Name', '香港有限公司 — Société Générale'),
+    )[0]
+    val = _read_business_slot(fresh_book, 'Company Name')
+    assert val == '香港有限公司 — Société Générale', (
+        f'non-ASCII value must round-trip via UTF-8; got {val!r}'
+    )
+
+
+# ── Pre-existing slots are preserved ─────────────────────────────
+
+def test_setting_new_key_preserves_unrelated_slots(fresh_book):
+    """Setting Company Name on a book that already has Company Email
+    Address must not wipe the email slot. Real-world flow: the user
+    fills in their Business options field-by-field over multiple
+    sessions; each set call must be additive. The session-boundary
+    sleep handles the backup-naming collision documented above."""
+    assert _write_business_options(
+        fresh_book, ('Company Email Address', 'hi@acme.test'),
+    )[0]
+    time.sleep(1.1)
+    assert _write_business_options(
+        fresh_book, ('Company Name', 'Acme'),
+    )[0]
+    # Both still present.
+    assert _read_business_slot(fresh_book, 'Company Email Address') == 'hi@acme.test'
+    assert _read_business_slot(fresh_book, 'Company Name')          == 'Acme'

--- a/tests/unit/services/test_invoice_renderer.py
+++ b/tests/unit/services/test_invoice_renderer.py
@@ -192,3 +192,69 @@ class TestReadBookCompanyInfoCompressed:
             assert info['email'] == 'info@zipped.example'
         finally:
             os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _render_seller_header (Q-019)
+# ---------------------------------------------------------------------------
+#
+# `_render_seller_header` builds the `# Issued by: ...` comment that
+# the plaintext invoice renderer puts at the top of each rendered
+# document. Unit-tested here because it's pure-Python (no GnuCash
+# session) and the format is what recipients see byte-for-byte.
+
+class TestRenderSellerHeader:
+    def test_full_company_info_emits_all_fields(self):
+        from services.invoice_renderer import _render_seller_header
+        out = _render_seller_header({
+            'name':  'Acme Inc.',
+            'id':    '12345RT0001',
+            'addr1': '100 Main St',
+            'addr2': '',
+            'addr3': '',
+            'addr4': '',
+            'phone': '+1-555-0000',
+            'email': 'hi@acme.test',
+            'url':   'https://acme.test',
+        })
+        assert out.startswith('# Issued by: Acme Inc.')
+        # Label uses "Company ID:" (jurisdiction-neutral) — matches the
+        # GnuCash slot name. The slot value itself remains the supplier's
+        # tax-registration number (e.g. CRA GST/HST, US EIN, etc.), so
+        # ITC validity isn't affected by the neutral label.
+        assert 'Company ID: 12345RT0001' in out
+        assert '100 Main St' in out
+        assert '+1-555-0000' in out
+        assert 'hi@acme.test' in out
+        assert 'https://acme.test' in out
+        # Pre-fix iteration was `for key, label in (('phone', None), ...)`
+        # and the dead branch `f'{label}: {val}'` would have produced
+        # `None: +1-555-0000` if the label were ever set. Pin the
+        # invariant so the next refactor doesn't reintroduce the
+        # broken structure.
+        assert 'None:' not in out
+
+    def test_missing_company_returns_empty_string(self):
+        from services.invoice_renderer import _render_seller_header
+        assert _render_seller_header(None) == ''
+        assert _render_seller_header({}) == ''
+        # Whitespace-only name counts as missing — plaintext output then
+        # skips the file-scoped seller block entirely.
+        assert _render_seller_header({'name': '   '}) == ''
+
+    def test_partial_company_skips_empty_fields(self):
+        """Address lines and optional contact fields are omitted from
+        the header when blank — no `| |` or trailing `| ` artifacts."""
+        from services.invoice_renderer import _render_seller_header
+        out = _render_seller_header({
+            'name':  'Sole Proprietor',
+            'id':    '',
+            'addr1': '',
+            'addr2': '',
+            'addr3': '',
+            'addr4': '',
+            'phone': '',
+            'email': 'me@example.test',
+            'url':   '',
+        })
+        assert out == '# Issued by: Sole Proprietor | me@example.test'


### PR DESCRIPTION
Closes three integration gaps in the invoice / bill rendering surface and adds the supporting infrastructure for two-sided rendering tests to drive the full CLI pipeline end-to-end.

## Summary

**Draft invoices and bills now render full tax breakdown.** Unposted invoices (cash-basis per Q-018 or plain accrual drafts) historically went through an `is_draft` branch in `invoice_renderer` that emitted subtotal-only — no per-tax-account lines, no tax-inclusive grand total. GnuCash only materialises tax splits on the posting transaction, so the original code couldn't reach the numbers; Q-019 walks each entry's `tax_table` directly via `compute_entry_informational`, aggregates per-tax-account totals, and emits a complete `<tax-lines>` block plus a tax-inclusive `<total>`. A `<draft-tax-notice/>` element marks the figures as provisional in HTML ("Tax is computed from line-item tax tables; invoice not yet posted — figures are provisional.") and the plaintext renderer prepends a `# Tax figures are provisional…` comment header. The Q-018 badge logic (cash-basis → UNPAID, plain draft → DRAFT) is unchanged; only the tax-rendering rule changes.

**Vendor bills are now first-class print targets.** New `print-bill` CLI mirrors `print-invoice` (same `--format {pdf,html,plaintext}`, `--vendor`, `--from`/`--to`, `--bill-id`, `--template`, `-o` flag surface, same multi-bill selection via positional IDs and globs). `services/bill_renderer.py` uses the Bill-side SWIG getters per CLAUDE.md, exposes `compute_bill_entry_informational` as the bill analogue of the invoice helper, and produces an XML shape that mirrors `invoice_to_xml`. `services/bill.xslt` swaps the address roles — **Bill From** = vendor, **Bill To** = our company — so the audit-print use case (review what we recorded against what the vendor sent) is fully supported. Posted-bill tax extraction filters by "not the AP-posting account and not Expense" so both LIABILITY tax-accrual accounts and ASSET ITC-recoverable accounts (Canadian input-tax-credit books) are picked up.

**Two-sided rendering — both customer/vendor AND our company info — is rendered and tested.** The HTML "From" block in `invoice.xslt` already existed but was never tested with a populated company, and it omitted the URL line. The plaintext renderer accepted `company_info` but silently dropped it. Both surfaces now emit a file-scoped seller header: `# Issued by: <name> | Company ID: <id> | <addr> | <phone> | <email> | <url>` on invoices, `# Bill received by: ...` on bills. The "Company ID" label is jurisdiction-neutral (matches the GnuCash slot name verbatim) — the slot value is whatever tax-registration the issuer uses (CRA GST/HST, US EIN, UK VAT, HK BR, JP corporate number); ITC claim validity depends on the value, not on a label naming a specific scheme. Seller info uses `#` comment syntax so it doesn't survive re-import as KVPs on the recipient's book; the plaintext parser was extended to skip any line whose `lstrip()` starts with `#`.

**Book options set via the GnuCash API, not via XML editing.** The two-sided tests need to populate Business → Company book options before exercising the CLI. The first cut wrote those slots by editing the gzipped .gnucash XML directly via lxml, which bypassed GnuCash's session-save machinery. The second commit introduces `set_book_string_option(book, section, name, value)` in `infrastructure/gnucash/kvp.py` — a thin wrapper around `qof_book_set_string_option` (the C function GnuCash's own File→Properties→Business dialog calls into). The variadic `qof_instance_set_kvp` silently no-ops via ctypes for path counts ≥ 2 on x86_64 (the float-register count in `AL` ends up wrong for the varargs region); the non-variadic `qof_book_set_string_option` takes a slash-separated path and lets the C side handle GSList construction. Six dedicated tests prove the new helper is write-compatible with what the GnuCash GUI would have written (same canonical slot path, update-replaces-not-appends, distinct-key coexistence, UTF-8 round-trip, additive writes preserve pre-existing slots).

## Reviewer-caught bugs fixed inline

Four real bugs surfaced from the pre-commit AI review on the first commit pass; each ships with a regression test in the same commit per `feedback_bug_fix_needs_regression_test`.

- **`UsageError` message had unbalanced parentheses** in both `print-invoice` and `print-bill` — `'(' + ', '.join(c) if c else 'none' + ')'` parses as `('(' + ', '.join(c)) if c else ('none' + ')')`, dropping the closing paren whenever criteria are present (the common case). Both CLIs fixed; assertions in `test_cli_print_invoice.py` and `test_cli_print_bill.py` count `(` and `)` in the error message.
- **Combined HTML output had nested `<html lang="en">` shells AND inline `<!DOCTYPE>` declarations.** The original strip code was `inner.replace('<html>', '')`, which never matched the XSLT's attributed opening tag, and didn't touch the DOCTYPE at all. Combine code now uses regexes that match opening tags with any attributes plus the doctype declaration. `test_cli_print_combined_html_structure.py` asserts exactly one outer shell of each tag type and zero inline DOCTYPEs.
- **Dead `label` parameter in `_render_seller_header`** — the iteration was `for key, label in (('phone', None), ...)` with an unreachable `f'{label}: {val}'` branch. Simplified to `for key in ('phone', 'email', 'url')`. New `TestRenderSellerHeader` unit class pins the header format.
- **Seller-header round-trip wasn't covered.** The parser's `#`-skip is what keeps the seller info out of the recipient's book, but the existing draft-tax round-trip test only exercised the provisional caveat (no `company_info` populated). New test in `test_q019_two_sided_render.py` renders an invoice WITH the seller header actually present and re-imports it into a fresh book.

## Test plan

- [ ] `./scripts/test.sh latest` passes (full unit + integration suite — 580 unit + 470 integration = 1050 tests).
- [ ] Render an invoice with a populated Business → Company book — confirm the HTML "From" block shows name, Company ID, address, phone, email, URL.
- [ ] Render a vendor bill with `print-bill <book>.gnucash <BILL-ID> --format html -o bill.html` — confirm "Bill From" = vendor, "Bill To" = your company.
- [ ] Render a cash-basis unposted invoice with taxable entries (`cash_basis: true`, `taxable: true`, `tax_table: "GST+PST"`) — confirm both `<tax-line>` rows render in HTML and the "provisional" notice appears.
- [ ] Render an unposted accrual draft with taxable entries — confirm DRAFT badge stays, tax breakdown still appears with the provisional notice.
- [ ] Render a draft invoice to plaintext, re-import into a fresh book — no parser errors (the `#` caveat lines must be skipped).
- [ ] Render combined multi-invoice HTML / multi-bill HTML — confirm exactly one outer `<html>` shell and no nested DOCTYPEs.
- [ ] Pre-commit hook (lint + tests on all distros + AI review) passed on both commits in this branch.

## Issue tracker

- `docs/issues/Q-019-draft-tax-render-and-two-sided-bill-rendering.md` — new ticket covering this PR
- `docs/issues/Q-018-cash-basis-invoice-marker.md` — note that informational fields now ride along on every unposted invoice
- `docs/issues/Q-012-print-invoice-on-unposted-invoice-crashes.md` — strike the "no per-tax breakdown" known limitation and the "no bill rendering" out-of-scope item; both shipped here
- `docs/issues/README.md` — add Q-019 row to the Quality table
