### PR TITLE
Fix posted-tx duplication on export roundtrip

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,6 +855,15 @@ On **import**, `posted: none` and `payment: none` are no-ops — they produce th
 - `payment: none` together with a `payment:` block (contradictory)
 - A `payment:` block when `posted: none` (cannot pay an unposted invoice or bill)
 
+#### Posted-tx linkage: `posted_txn_guid:`
+
+Every exported `posted:` block carries a `posted_txn_guid:` line — the GUID of the AR/AP posting transaction that GnuCash created. Two reasons it's there:
+
+* **External cross-reference.** Scripts, bank-reconciliation tools, and audit pipelines that already track transactions by GUID get a stable handle from the invoice/bill block to "the transaction that recorded this posting". Edit the resulting tx directly in GnuCash and the same GUID survives.
+* **Roundtrip integrity.** The exporter also emits the posting transaction as a normal `* "INV-NNN"` standalone block with the same GUID + `txn_type: I` + owner backref. On re-import, the standalone-tx pass creates that tx first; the invoice's `posted:` handler then finds it by `posted_txn_guid:` and *attaches* it (`gncInvoiceAttachToTxn` + lot creation) instead of calling `PostToAccount`. Without `posted_txn_guid:` the importer would call `PostToAccount`, which always mints a fresh tx — leaving the standalone-imported original orphan (AR/AP split with no lot) and doubling the AR/AP and income/expense balances on every roundtrip.
+
+`posted_txn_guid:` is optional on hand-authored plaintext. When absent, the importer falls back to `PostToAccount` (the original code path) — fine for plaintext that doesn't also include a matching standalone `*` block for the posting tx.
+
 An invoice or bill with **multiple partial payments** can have multiple `payment:` blocks — one per payment transaction:
 
 ```

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -730,6 +730,159 @@ def _retarget_with_prepayment_split(lib, book, existing_tx, bank_acct_name: str,
     return True
 
 
+def _datetime_to_time64(dt) -> int:
+    """Convert a naive `datetime` (e.g. parsed via `strptime(%Y-%m-%d)`) to
+    a GnuCash time64. Matches the SWIG `gncInvoicePostToAccount` path
+    semantics so the link-based POSTED handler produces a byte-identical
+    `date_posted` / `date_due` to the PostToAccount fallback on the same
+    machine (both round-trip through Python's local-TZ `timestamp()`).
+    Pinned in a single helper so a future SWIG-side change can be matched
+    here in one place.
+    """
+    return int(dt.timestamp())
+
+
+_ATTACH_API_VERIFIED = False
+
+
+def _verify_attach_api():
+    """Probe the GnuCash SWIG surface that `_attach_existing_tx_as_posted`
+    depends on at first use. Failing fast with a named symbol is friendlier
+    than a `module has no attribute` deep in the POSTED handler, and gives
+    a clean signal if a future GnuCash version drops one of the setters.
+    Runs once per process.
+    """
+    global _ATTACH_API_VERIFIED
+    if _ATTACH_API_VERIFIED:
+        return
+
+    import gnucash.gnucash_core_c as _gc
+
+    required_swig = [
+        'gncInvoiceAttachToTxn', 'gncInvoiceAttachToLot',
+        'gncInvoiceSetPostedAcc', 'gncInvoiceSetDatePosted',
+        'xaccAccountInsertLot', 'xaccSplitSetLot',
+        # gncInvoice has no public date_due setter; due_date is stored on
+        # the posting transaction (gncInvoiceGetDateDue → xaccTransRetDateDue,
+        # gncInvoicePostToAccount → xaccTransSetDateDue). We set it the same
+        # way.
+        'xaccTransSetDateDue',
+    ]
+    missing_swig = [s for s in required_swig if not hasattr(_gc, s)]
+    if missing_swig:
+        raise RuntimeError(
+            'GnuCash SWIG bindings missing required symbols for '
+            'posted-tx linkage: ' + ', '.join(missing_swig)
+        )
+    _ATTACH_API_VERIFIED = True
+
+
+_BUSINESS_GENERATED_META = {'business_generated': 'true'}
+
+
+def _attach_existing_tx_as_posted(invoice_or_bill, existing_tx, ar_ap_account,
+                                   post_date, due_date, memo, accumulate,
+                                   book, kind: str, id_: str) -> None:
+    """Wire an already-imported transaction as the invoice/bill's posted tx,
+    bypassing `PostToAccount`. Mirrors what `gncInvoicePostToAccount` does
+    internally so the result is indistinguishable to the rest of GnuCash:
+
+      1. Create a fresh GncLot on the AR/AP account.
+      2. Override the tx description to the declared memo (matches what
+         the existing PostToAccount path does immediately after posting)
+         and mark the tx as business-generated in custom KVP.
+      3. Attach the tx's single AR/AP-side split to the lot.
+      4. gncInvoiceAttachToTxn / AttachToLot — bidirectional wiring of
+         tx ↔ invoice and lot ↔ invoice KVP backrefs PLUS the invoice's
+         posted_txn / posted_lot pointers (so explicit SetPostedTxn /
+         SetPostedLot would trip `'invoice->posted_txn == NULL'` /
+         `posted_lot == NULL` assertions and must NOT be called).
+      5. gncInvoiceSetPostedAcc / gncInvoiceSetDatePosted /
+         xaccTransSetDateDue populate the remaining posting fields.
+         `gncInvoice` has no public date_due setter — `gncInvoiceGetDateDue`
+         reads through to `xaccTransRetDateDue(posting_txn)`, so we set
+         due-date on the *transaction* the same way
+         `gncInvoicePostToAccount` does internally.
+
+    Invariants:
+      * Posting txs always have exactly ONE AR/AP-side split — GnuCash's
+        `PostToAccount` collapses AR/AP into a single split regardless of
+        the `accumulate` flag (`accumulate` only affects the income/expense
+        side: True = one income split per income/expense account, False =
+        one per entry). We assert this on the linked tx and refuse to
+        attach a malformed one rather than silently leaving extra AR/AP
+        splits orphan.
+      * `accumulate` is accepted for API parity with PostToAccount but is
+        not used here — the splits are already in the existing tx as
+        authored by the user.
+    """
+    import gnucash.gnucash_core_c as _gc
+    from gnucash import GncLot
+
+    if existing_tx is None:
+        raise ValueError(
+            f'{kind} "{id_}": cannot attach posted tx (lookup returned None)'
+        )
+
+    _verify_attach_api()
+
+    ar_ap_acct_inst = int(ar_ap_account.instance)
+    ar_ap_splits = [
+        sp for sp in existing_tx.GetSplitList()
+        if (a := sp.GetAccount()) is not None
+        and int(a.instance) == ar_ap_acct_inst
+    ]
+    if not ar_ap_splits:
+        raise ValueError(
+            f'{kind} "{id_}": linked posted tx '
+            f'{existing_tx.GetGUID().to_string()} has no split for the '
+            f'declared posting account {get_account_full_name(ar_ap_account)!r}'
+        )
+    if len(ar_ap_splits) > 1:
+        raise ValueError(
+            f'{kind} "{id_}": linked posted tx '
+            f'{existing_tx.GetGUID().to_string()} has '
+            f'{len(ar_ap_splits)} splits in {get_account_full_name(ar_ap_account)!r} '
+            f'but a posting tx must have exactly one AR/AP-side split '
+            f'(GnuCash collapses AR/AP into a single split regardless of '
+            f'the `accumulate` flag). Author the tx with one AR/AP split '
+            f'totalling the invoice/bill amount.'
+        )
+    ar_ap_split = ar_ap_splits[0]
+
+    # Step 1: fresh lot in the AR/AP account (pure SWIG — keeps ctypes
+    # ↔ SWIG bridging out of the lot lifecycle, which is sensitive on
+    # Ubuntu per docs/DEBUGGING_GNUCASH_BINDINGS.md).
+    lot = GncLot(book)
+    _gc.xaccAccountInsertLot(ar_ap_account.instance, lot.instance)
+
+    # Step 2-3: override description, plant business_generated marker in
+    # custom KVP (not Notes — Notes is a user-visible field), set
+    # due-date on the posting tx (where gncInvoiceGetDateDue reads it
+    # from), attach AR/AP split to lot. Merge — don't replace — the KVP
+    # so any user-authored custom keys on the standalone-imported tx
+    # survive: set_custom_metadata overwrites the whole `plaintext_meta`
+    # slot.
+    existing_tx.BeginEdit()
+    existing_tx.SetDescription(memo)
+    existing_custom = get_custom_metadata(existing_tx) or {}
+    existing_custom.update(_BUSINESS_GENERATED_META)
+    set_custom_metadata(existing_tx, existing_custom)
+    _gc.xaccTransSetDateDue(existing_tx.instance,
+                            _datetime_to_time64(due_date))
+    _gc.xaccSplitSetLot(ar_ap_split.instance, lot.instance)
+    existing_tx.CommitEdit()
+
+    # Step 4-5: wire invoice's posted_* properties and KVP backrefs.
+    inv_inst = invoice_or_bill.instance
+    invoice_or_bill.BeginEdit()
+    _gc.gncInvoiceAttachToLot(inv_inst, lot.instance)
+    _gc.gncInvoiceAttachToTxn(inv_inst, existing_tx.instance)
+    _gc.gncInvoiceSetPostedAcc(inv_inst, ar_ap_account.instance)
+    _gc.gncInvoiceSetDatePosted(inv_inst, _datetime_to_time64(post_date))
+    invoice_or_bill.CommitEdit()
+
+
 def _is_falsy(val: str) -> bool:
     """Return True if val is a recognised falsy string (case-insensitive)."""
     return val.strip().lower() in _FALSY_STRINGS
@@ -892,7 +1045,10 @@ def _posted_matches_directive(invoice, posted_dir: 'PlaintextDirective',
     posting_txn = invoice.GetPostedTxn()
     if posting_txn is None:
         return False
-    return posting_txn.GetDescription() == md['memo']
+    if posting_txn.GetDescription() != md['memo']:
+        return False
+    declared_posted_guid = md.get('posted_txn_guid')
+    return not (declared_posted_guid and posting_txn.GetGUID().to_string() != _normalise_guid(declared_posted_guid))
 
 
 def _lot_payment_splits(record):
@@ -2375,15 +2531,34 @@ class GnuCashImporter:
                 due_date = datetime.strptime(entry_directive.metadata['due'], "%Y-%m-%d")
                 memo = entry_directive.metadata['memo']
                 accumulate = entry_directive.metadata['accumulate'] == 'true'
-                invoice.PostToAccount(ar_account, post_date, due_date, memo, accumulate, False)
-                # Override the transaction description GnuCash set automatically,
-                # so the roundtrip preserves the memo field exactly.
-                posting_txn = invoice.GetPostedTxn()
-                if posting_txn:
-                    posting_txn.BeginEdit()
-                    posting_txn.SetDescription(memo)
-                    posting_txn.SetNotes("business_generated: true")
-                    posting_txn.CommitEdit()
+
+                # If the directive links an existing tx as the posted tx
+                # (mirrors Q-016's payment `txn_guid:` linkage), attach
+                # it instead of calling PostToAccount — PostToAccount
+                # always mints a fresh tx, so calling both would leave
+                # the standalone-imported tx orphan with no lot and the
+                # AR account double-counted.
+                declared_posted_guid = entry_directive.metadata.get('posted_txn_guid')
+                linked_tx = None
+                if declared_posted_guid:
+                    guid_norm = _normalise_guid(declared_posted_guid)
+                    linked_tx = _find_transaction_by_guid(book, guid_norm)
+                if linked_tx is not None:
+                    _attach_existing_tx_as_posted(
+                        invoice, linked_tx, ar_account,
+                        post_date, due_date, memo, accumulate,
+                        book, 'invoice', inv_id,
+                    )
+                else:
+                    invoice.PostToAccount(ar_account, post_date, due_date, memo, accumulate, False)
+                    # Override the transaction description GnuCash set automatically,
+                    # so the roundtrip preserves the memo field exactly.
+                    posting_txn = invoice.GetPostedTxn()
+                    if posting_txn:
+                        posting_txn.BeginEdit()
+                        posting_txn.SetDescription(memo)
+                        set_custom_metadata(posting_txn, _BUSINESS_GENERATED_META)
+                        posting_txn.CommitEdit()
             elif entry_directive.type == DirectiveType.PAYMENT:
                 _apply_payment_directive(invoice, entry_directive, book, is_bill=False)
 
@@ -2565,15 +2740,28 @@ class GnuCashImporter:
                 due_date = datetime.strptime(entry_directive.metadata['due'], "%Y-%m-%d")
                 memo = entry_directive.metadata['memo']
                 accumulate = entry_directive.metadata['accumulate'] == 'true'
-                bill.PostToAccount(ap_account, post_date, due_date, memo, accumulate, False)
-                # Override the transaction description GnuCash set automatically,
-                # so the roundtrip preserves the memo field exactly.
-                posting_txn = bill.GetPostedTxn()
-                if posting_txn:
-                    posting_txn.BeginEdit()
-                    posting_txn.SetDescription(memo)
-                    posting_txn.SetNotes("business_generated: true")
-                    posting_txn.CommitEdit()
+
+                declared_posted_guid = entry_directive.metadata.get('posted_txn_guid')
+                linked_tx = None
+                if declared_posted_guid:
+                    guid_norm = _normalise_guid(declared_posted_guid)
+                    linked_tx = _find_transaction_by_guid(book, guid_norm)
+                if linked_tx is not None:
+                    _attach_existing_tx_as_posted(
+                        bill, linked_tx, ap_account,
+                        post_date, due_date, memo, accumulate,
+                        book, 'bill', bill_id,
+                    )
+                else:
+                    bill.PostToAccount(ap_account, post_date, due_date, memo, accumulate, False)
+                    # Override the transaction description GnuCash set automatically,
+                    # so the roundtrip preserves the memo field exactly.
+                    posting_txn = bill.GetPostedTxn()
+                    if posting_txn:
+                        posting_txn.BeginEdit()
+                        posting_txn.SetDescription(memo)
+                        set_custom_metadata(posting_txn, _BUSINESS_GENERATED_META)
+                        posting_txn.CommitEdit()
             elif entry_directive.type == DirectiveType.PAYMENT:
                 _apply_payment_directive(bill, entry_directive, book, is_bill=True)
 

--- a/tests/integration/test_business_objects.py
+++ b/tests/integration/test_business_objects.py
@@ -85,7 +85,8 @@ def test_business_objects_roundtrip(tmp_path):
         for line in text.splitlines():
             stripped = line.lstrip(' \t')
             if stripped.startswith(('guid:', 'customer_guid:', 'vendor_guid:',
-                                    'txn_guid:', 'txn_split_guid:')):
+                                    'txn_guid:', 'txn_split_guid:',
+                                    'posted_txn_guid:')):
                 continue
             keep.append(line)
         return '\n'.join(keep)

--- a/tests/integration/test_posted_tx_roundtrip.py
+++ b/tests/integration/test_posted_tx_roundtrip.py
@@ -1,0 +1,396 @@
+"""
+Regression: posted-tx round-trip via export → fresh-book reimport.
+
+Two properties guarded here:
+  1. Posting-tx GUID is preserved across the roundtrip (the importer
+     attaches the standalone-imported tx instead of minting a fresh one
+     via PostToAccount).
+  2. The book never ends up with duplicate posting txs OR orphan AR/AP
+     splits (splits in an AR/AP account that don't belong to any lot).
+
+Before this fix the exporter emitted the posting tx as a standalone `*`
+block AND the invoice's `posted:` block, but the importer's POSTED
+handler unconditionally called `invoice.PostToAccount(...)` — which
+created a SECOND posting tx with a fresh GUID. The standalone-imported
+original was left orphan (AR split with no lot), and AR/Income balances
+silently doubled per roundtrip. The exporter now emits `posted_txn_guid:`
+and the importer links the existing tx via gncInvoiceAttachToTxn +
+gncInvoiceAttachToLot instead of re-posting.
+"""
+
+import gnucash.gnucash_business as gb
+import gnucash.gnucash_core_c as gc
+from click.testing import CliRunner
+from gnucash import Query
+
+from cli.main import cli
+from infrastructure.gnucash.utils import get_account_full_name
+from repositories.gnucash_repository import GnuCashRepository
+
+ACCOUNTS = """\
+2026-01-01 open Assets
+\ttype: Asset
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Assets:Accounts Receivable
+\ttype: Accounts Receivable
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Liabilities
+\ttype: Liability
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:Accounts Payable
+\ttype: Accounts Payable
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Income
+\ttype: Income
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Income:Sales
+\ttype: Income
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Expenses
+\ttype: Expense
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+2026-01-01 open Expenses:Supplies
+\ttype: Expense
+\tcommodity.namespace: "CURRENCY"
+\tcommodity.mnemonic: "CAD"
+"""
+
+INVOICE_FIXTURE = ACCOUNTS + """
+customer "C001"
+\tname: "Acme"
+\tcurrency: CAD
+
+invoice "INV-001"
+\tcustomer_id: "C001"
+\tcurrency: CAD
+\tdate_opened: 2026-01-01
+\tentry:
+\t\tdate: 2026-01-01
+\t\tdescription: "Service"
+\t\taction: "Hours"
+\t\taccount: "Income:Sales"
+\t\tquantity: 1
+\t\tprice: 100
+\t\ttaxable: false
+\t\ttax_included: false
+\tposted:
+\t\tdate: 2026-01-01
+\t\tdue: 2026-01-31
+\t\tar_account: "Assets:Accounts Receivable"
+\t\tmemo: "Invoice INV-001"
+\t\taccumulate: true
+\tpayment: none
+"""
+
+BILL_FIXTURE = ACCOUNTS + """
+vendor "V001"
+\tname: "Globex"
+\tcurrency: CAD
+
+bill "BILL-001"
+\tvendor_id: "V001"
+\tcurrency: CAD
+\tdate_opened: 2026-01-05
+\tentry:
+\t\tdate: 2026-01-05
+\t\tdescription: "Office supplies"
+\t\taccount: "Expenses:Supplies"
+\t\tquantity: 1
+\t\tprice: 75
+\t\ttaxable: false
+\t\ttax_included: false
+\tposted:
+\t\tdate: 2026-01-05
+\t\tdue: 2026-02-04
+\t\tap_account: "Liabilities:Accounts Payable"
+\t\tmemo: "Bill BILL-001"
+\t\taccumulate: true
+\tpayment: none
+"""
+
+
+def _find_account(root, fullname):
+    if get_account_full_name(root) == fullname:
+        return root
+    for c in root.get_children():
+        r = _find_account(c, fullname)
+        if r is not None:
+            return r
+    return None
+
+
+def _snapshot(gnc_path):
+    """Capture state needed to detect duplicate posting txs + orphan AR/AP
+    splits + balance drift across an export → reimport cycle."""
+    repo = GnuCashRepository(str(gnc_path))
+    repo.open()
+    try:
+        all_txs = repo.get_all_transactions()
+        posting_tx_guids = sorted(
+            tx.GetGUID().to_string()
+            for tx in all_txs
+            if (p := gc.gncInvoiceGetInvoiceFromTxn(tx.instance)) is not None
+            and int(p) != 0
+        )
+        all_tx_guids = sorted(tx.GetGUID().to_string() for tx in all_txs)
+
+        # Walk every AR/AP account; orphan = split with no lot.
+        # Default to 0 for any account named but missing so a roundtrip
+        # that silently drops an empty account doesn't masquerade as a
+        # balance change.
+        root = repo.book.get_root_account()
+        orphan_splits = []
+        balances = {
+            'Assets:Accounts Receivable': 0.0,
+            'Liabilities:Accounts Payable': 0.0,
+            'Income:Sales': 0.0,
+            'Expenses:Supplies': 0.0,
+        }
+        for acct_name in balances:
+            a = _find_account(root, acct_name)
+            if a is None:
+                continue
+            splits = a.GetSplitList() or []
+            balances[acct_name] = round(
+                sum(sp.GetAmount().to_double() for sp in splits), 2)
+            if acct_name in ('Assets:Accounts Receivable',
+                             'Liabilities:Accounts Payable'):
+                for sp in splits:
+                    if sp.GetLot() is None:
+                        orphan_splits.append((
+                            acct_name,
+                            round(sp.GetAmount().to_double(), 2),
+                            sp.GetParent().GetGUID().to_string()
+                                if sp.GetParent() else None,
+                        ))
+
+        # Per-invoice/bill date_posted + date_due — catches TZ drift
+        # between the link path and the PostToAccount fallback. Keyed by
+        # the business-object id (e.g. "INV-001") so dst lookups match
+        # src 1:1 regardless of GUID churn elsewhere. One QOF query
+        # covers both invoices and bills (they share the gncInvoice QOF
+        # type; the owner-side determines which kind they represent).
+        # NO try/except — a query failure must surface, not silently
+        # leave posted_dates empty and make the assertion trivially pass.
+        posted_dates = {}
+        q = Query()
+        try:
+            q.search_for('gncInvoice')
+            q.set_book(repo.book)
+            for raw in q.run():
+                inv = gb.Invoice(instance=raw)
+                if inv.GetPostedTxn() is None:
+                    continue
+                # Key by (owner-kind, id) so the equality check still
+                # detects divergence when a future fixture happens to use
+                # the same id for an invoice and a bill (both come back
+                # from `search_for('gncInvoice')`; only the owner side
+                # tells them apart).
+                owner_kind = ('vendor'
+                              if inv.GetOwner().GetVendor() is not None
+                              else 'customer')
+                posted_dates[(owner_kind, inv.GetID())] = (
+                    inv.GetDatePosted().strftime('%Y-%m-%d'),
+                    inv.GetDateDue().strftime('%Y-%m-%d'),
+                )
+        finally:
+            q.destroy()
+
+        return {
+            'tx_guids': all_tx_guids,
+            'posting_tx_guids': posting_tx_guids,
+            'orphan_splits': orphan_splits,
+            'balances': balances,
+            'posted_dates': posted_dates,
+        }
+    finally:
+        repo.close()
+
+
+def _assert_clean_posted_roundtrip(tmp_path, fixture_text):
+    """Build src book from fixture, export → re-import to fresh book,
+    assert the dest book is byte-identical to src on the dimensions that
+    matter for posting-tx integrity."""
+    runner = CliRunner()
+
+    src_path = tmp_path / 'source.txt'
+    src_path.write_text(fixture_text)
+    src_gnc = tmp_path / 'src.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(src_gnc), str(src_path),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+
+    exported = tmp_path / 'exported.txt'
+    r = runner.invoke(cli, ['export', str(src_gnc), str(exported),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+
+    dst_gnc = tmp_path / 'dst.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(dst_gnc), str(exported),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+
+    src = _snapshot(src_gnc)
+    dst = _snapshot(dst_gnc)
+
+    # No orphan AR/AP splits in either book.
+    assert src['orphan_splits'] == [], (
+        f"source already has orphan AR/AP splits — fixture is buggy: "
+        f"{src['orphan_splits']}")
+    assert dst['orphan_splits'] == [], (
+        f"REGRESSION: dest book has orphan AR/AP splits after roundtrip "
+        f"(split in AR/AP account not attached to any lot — typical sign "
+        f"of duplicate posting txs from standalone-import + PostToAccount "
+        f"both running): {dst['orphan_splits']}")
+
+    # Tx count must not grow. A duplicate posting tx would push dst's
+    # tx count above src's.
+    assert len(dst['tx_guids']) == len(src['tx_guids']), (
+        f"REGRESSION: tx count changed across roundtrip: "
+        f"src={len(src['tx_guids'])} dst={len(dst['tx_guids'])} — "
+        f"likely duplicate posting tx.\n"
+        f"  src tx guids: {src['tx_guids']}\n"
+        f"  dst tx guids: {dst['tx_guids']}")
+
+    # Posting tx GUIDs preserved exactly.
+    assert dst['posting_tx_guids'] == src['posting_tx_guids'], (
+        f"REGRESSION: posting-tx GUID not preserved: "
+        f"src={src['posting_tx_guids']} dst={dst['posting_tx_guids']}")
+
+    # Exactly one wired-as-posting tx per posted invoice/bill (no spurious
+    # extras carrying the same `txn_type: I` KVP).
+    assert len(dst['posting_tx_guids']) == len(set(dst['posting_tx_guids'])), (
+        f"REGRESSION: duplicate posting-tx GUIDs in dest book: "
+        f"{dst['posting_tx_guids']}")
+
+    # Account balances preserved — duplication would double them.
+    assert dst['balances'] == src['balances'], (
+        f"REGRESSION: account balances changed across roundtrip: "
+        f"src={src['balances']} dst={dst['balances']}")
+
+    # date_posted / date_due preserved per invoice/bill. Catches TZ drift
+    # between the link path's `int(d.timestamp())` and SWIG's
+    # PostToAccount-internal conversion (e.g. on HKT a naive
+    # '2026-01-01' resolves to 2025-12-31 16:00 UTC; if the two paths
+    # use different conversions, dst's date strings would shift by one
+    # day relative to src). The fixtures always contain a posted invoice
+    # or bill, so an empty `src['posted_dates']` means the query path
+    # itself is broken — assert non-empty so the equality check below
+    # doesn't pass trivially on `{} == {}`.
+    assert src['posted_dates'], (
+        "source has no posted invoices/bills — fixture or query is broken; "
+        "the date assertion below would pass trivially.")
+    assert dst['posted_dates'] == src['posted_dates'], (
+        f"REGRESSION: posted/due dates changed across roundtrip — "
+        f"likely a timezone or time64 conversion drift:\n"
+        f"  src: {src['posted_dates']}\n"
+        f"  dst: {dst['posted_dates']}")
+
+
+def test_invoice_posted_tx_roundtrip(tmp_path):
+    """Posted invoice round-trips without duplicating the posting tx or
+    orphaning the AR side."""
+    _assert_clean_posted_roundtrip(tmp_path, INVOICE_FIXTURE)
+
+
+def test_bill_posted_tx_roundtrip(tmp_path):
+    """Posted bill round-trips without duplicating the posting tx or
+    orphaning the AP side."""
+    _assert_clean_posted_roundtrip(tmp_path, BILL_FIXTURE)
+
+
+def test_user_kvp_on_posting_tx_survives_attach(tmp_path):
+    """A user-authored custom KVP key on the standalone posting-tx block
+    must survive the linked-attach path. Regression for the
+    `set_custom_metadata` non-merge bug: the attach helper plants the
+    `business_generated` marker into the tx's KVP slot, and if it
+    overwrites (vs merges) the slot the user's key gets nuked.
+
+    Drives a hand-authored fixture (no source-book intermediary needed)
+    that has both the standalone posting tx block with a custom KVP key
+    AND the invoice's `posted:` block with `posted_txn_guid:` pointing
+    at it. After import, the dst book's posting tx must carry both
+    `business_generated: true` and `audit_note` from the user.
+    """
+    fixture = ACCOUNTS + """
+customer "C001"
+\tname: "Acme"
+\tcurrency: CAD
+
+2026-01-01 * "INV-001" "Invoice INV-001"
+\tguid: "11111111111111111111111111111111"
+\taudit_note: "verified by auditor on 2026-01-02"
+\ttxn_type: I
+\towner: customer:C001
+\tAssets:Accounts Receivable 100.00 CAD
+\t\tguid: "22222222222222222222222222222222"
+\t\taction: "Invoice"
+\t\tmemo:"Invoice INV-001"
+\tIncome:Sales -100.00 CAD
+\t\tguid: "33333333333333333333333333333333"
+\t\taction: "Invoice"
+\t\tmemo:"Invoice INV-001"
+
+invoice "INV-001"
+\tcustomer_id: "C001"
+\tcurrency: CAD
+\tdate_opened: 2026-01-01
+\tentry:
+\t\tdate: 2026-01-01
+\t\tdescription: "Service"
+\t\taction: "Hours"
+\t\taccount: "Income:Sales"
+\t\tquantity: 1
+\t\tprice: 100
+\t\ttaxable: false
+\t\ttax_included: false
+\tposted:
+\t\tdate: 2026-01-01
+\t\tdue: 2026-01-31
+\t\tar_account: "Assets:Accounts Receivable"
+\t\tmemo: "Invoice INV-001"
+\t\tposted_txn_guid: "11111111111111111111111111111111"
+\t\taccumulate: true
+\tpayment: none
+"""
+
+    runner = CliRunner()
+    src_path = tmp_path / 'source.txt'
+    src_path.write_text(fixture)
+    gnc = tmp_path / 'k.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gnc), str(src_path),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+
+    # Inspect the posting tx's KVP directly via the same infrastructure
+    # the importer uses, so the test fails sharply if the merge path is
+    # broken.
+    from infrastructure.gnucash.kvp import get_custom_metadata
+    repo = GnuCashRepository(str(gnc))
+    repo.open()
+    try:
+        posting_tx = None
+        for tx in repo.get_all_transactions():
+            inv_ptr = gc.gncInvoiceGetInvoiceFromTxn(tx.instance)
+            if inv_ptr is not None and int(inv_ptr) != 0:
+                posting_tx = tx
+                break
+        assert posting_tx is not None, "no posting tx found after import"
+        meta = get_custom_metadata(posting_tx)
+        assert meta.get('business_generated') == 'true', (
+            f"`business_generated` marker missing — attach helper didn't "
+            f"plant the KVP: {meta!r}")
+        assert meta.get('audit_note') == 'verified by auditor on 2026-01-02', (
+            f"REGRESSION: user-authored `audit_note` KVP on the standalone "
+            f"posting tx was lost by the attach path — `set_custom_metadata` "
+            f"must merge with the existing slot, not overwrite it. "
+            f"Got: {meta!r}")
+    finally:
+        repo.close()

--- a/use_cases/export_business_objects.py
+++ b/use_cases/export_business_objects.py
@@ -308,6 +308,12 @@ class ExportBusinessObjectsUseCase:
                 lines.append(f'		due: {inv.GetDateDue().strftime("%Y-%m-%d")}')
                 lines.append(f'		ar_account: "{ar_name}"')
                 lines.append(f'		memo: "{posted_txn.GetDescription()}"')
+                # Always emit posted_txn_guid (symmetric with Q-016's
+                # always-emit payment txn_guid). On re-import, the importer
+                # links this existing tx instead of calling PostToAccount,
+                # which would otherwise mint a duplicate alongside the
+                # standalone-imported one and orphan the original.
+                lines.append(f'		posted_txn_guid: "{posted_txn.GetGUID().to_string()}"')
                 lines.append('		accumulate: true')
             else:
                 lines.append('	posted: none')
@@ -561,6 +567,7 @@ class ExportBusinessObjectsUseCase:
                 lines.append(f'		due: {inv.GetDateDue().strftime("%Y-%m-%d")}')
                 lines.append(f'		ap_account: "{ap_name}"')
                 lines.append(f'		memo: "{posted_txn.GetDescription()}"')
+                lines.append(f'		posted_txn_guid: "{posted_txn.GetGUID().to_string()}"')
                 lines.append('		accumulate: true')
             else:
                 lines.append('	posted: none')


### PR DESCRIPTION
Every exported invoice/bill `posted:` block carries `posted_txn_guid:` — the GUID of the AR/AP posting transaction. On re-import, the importer attaches that pre-existing transaction (already created by the standalone-tx pass that runs first) to the invoice/bill as its posted tx via `gncInvoiceAttachToTxn` + `gncInvoiceAttachToLot`, instead of calling `PostToAccount`. Symmetric with Q-016's payment-side `txn_guid:` / `txn_split_guid:` linkage.

Without this linkage, `invoice.PostToAccount(...)` always minted a fresh posting tx with a fresh GUID, while the standalone-tx pass had already imported the original. Per roundtrip: an orphan AR/AP split with no lot, doubled AR/AP / income / expense balances, churned posting-tx GUID. Invisible to existing fresh-roundtrip tests because their `_semantic_state` only counts splits on the Bank account and lots that already exist — posting txs touch AR + Income, and the orphan AR split skips the lot-walk.

`gncInvoiceAttachToTxn` and `gncInvoiceAttachToLot` are bidirectional — they set both the tx/lot's invoice-backref KVP slot AND the invoice's posted_txn / posted_lot pointer — so explicit `gncInvoiceSetPostedTxn` / `gncInvoiceSetPostedLot` calls are not needed (and would trip `'invoice->posted_txn == NULL'` / `posted_lot == NULL` assertions).

`gncInvoiceGetDateDue` reads through to `xaccTransRetDateDue(posting_txn)` — due-date is stored on the posting transaction, not on the invoice. The helper sets it via `xaccTransSetDateDue`, matching what `gncInvoicePostToAccount` does internally.

The `business_generated: true` marker now lives in the transaction's custom KVP slot (via `set_custom_metadata`) instead of the user-visible `Notes` field. Same change applied to the existing PostToAccount fallback path so user-edited `notes:` on the standalone-imported posting tx survives a roundtrip on every code path. The attach path merges the marker into any pre-existing custom KVP rather than overwriting the slot, so user-authored keys on the standalone-imported posting tx (e.g. `audit_note:`) survive the attach.

Exactly one AR/AP-side split per posting tx is asserted as an invariant — GnuCash collapses AR/AP into a single split regardless of the `accumulate` flag (which only affects income/expense aggregation). A malformed linked tx with multiple AR/AP splits is rejected with a clear error rather than silently leaving extras orphan.

`_posted_matches_directive` compares `posted_txn_guid:` when declared, so a clean re-import is still a no-op rather than an "updated".

`tests/integration/test_posted_tx_roundtrip.py` covers both invoice and bill, asserting after roundtrip: no orphan AR/AP splits, tx count unchanged, posting-tx GUIDs preserved, AR/AP/income/expense balances preserved, per-invoice/bill `date_posted` + `date_due` preserved (catches TZ/time64 drift between link path and PostToAccount fallback; the date assertion is guarded by a non-empty src check so a query failure can't make the equality check pass trivially; dates are keyed by `(owner_kind, id)` so future fixtures using the same id for an invoice and a bill don't mask divergence). A separate test hand-authors a standalone posting tx with a user-authored custom KVP key and asserts both the user's key and the `business_generated` marker survive the attach. `posted_txn_guid:` joins the strip-list in `test_business_objects.py` so per-run GUID-value churn doesn't disturb golden-text comparisons (same treatment as `txn_guid:`).

Full test suite passes on debian13 (1058/1058). Regression test also verified on ubuntu24.