### PR TITLE
fix(Q-022): accept owner's-equity deposit accounts for payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,7 +933,7 @@ The same applies symmetrically to bills (AP, opposite signs): overpaying a $100 
 
 #### Bad debt: writing off an uncollectable invoice via `payment:` to an expense
 
-When an invoice will never be paid, write it off instead of receiving cash by giving the `payment:` block an expense account. The transfer account is named by `account:` (the canonical key) or its alias `bank_account:` — despite the legacy name the account need not be a bank. For an **invoice** the account may be an asset (cash actually received) or an expense (the bad-debt write-off); the importer infers the intent from the account type, so no separate keyword is needed.
+When an invoice will never be paid, write it off instead of receiving cash by giving the `payment:` block an expense account. The transfer account is named by `account:` (the canonical key) or its alias `bank_account:` — despite the legacy name the account need not be a bank. For an **invoice** the account may be an asset (cash actually received), an owner's-equity deposit account ([below](#sole-proprietor-deposit-account-paying-into-owners-equity)), or an expense (the bad-debt write-off); the importer infers the intent from the account type, so no separate keyword is needed.
 
 ```
 invoice "INV-2026-007"
@@ -950,7 +950,25 @@ invoice "INV-2026-007"
     memo: "Write off INV-2026-007 — uncollectable"
 ```
 
-The AR lot closes (the invoice reads paid) and the $100 lands in the expense rather than a bank account. **Bills are different**: a bill payment must use an asset account. An unpaid bill *you* owe is debt forgiveness — a gain, not bad debt — which is out of scope, so an expense (or income) on a bill payment is rejected with a clear error. Bad debt only exists for money owed *to* you.
+The AR lot closes (the invoice reads paid) and the $100 lands in the expense rather than a bank account. **Bills are different**: a bill payment must use an asset or owner's-equity account, never an expense. An unpaid bill *you* owe is debt forgiveness — a gain, not bad debt — which is out of scope, so an expense (or income) on a bill payment is rejected with a clear error. Bad debt only exists for money owed *to* you.
+
+#### Sole-proprietor deposit account: paying into owner's equity
+
+A Canadian sole proprietor often has no separate business bank account — the business tax return reports only income and expense, and money the owner receives or spends personally is tracked in owner's equity (drawings / contributions). So a customer's payment can land directly in an owner's-equity deposit account instead of a bank:
+
+```
+invoice "INV-2026-008"
+  ...
+  posted:
+    ar_account: "Assets:Accounts Receivable"
+  payment:
+    date: 2026-02-01
+    amount: 100
+    account: "Equity:Owner equity:Owner's equity"
+    memo: "Customer paid — deposited to owner's equity"
+```
+
+A vendor bill paid out of the owner's personal funds (an owner contribution) works the same way — give the bill's `payment:` an `account:` on owner's equity. So a payment's transfer account may be an asset (bank / cash), owner's equity, or — for an invoice only — an expense (bad-debt write-off). Income is rejected (it would double-count the revenue already booked at posting), as is the AR/AP account itself. (A corporation that routes receipts through a shareholder loan models "due from director" as an *asset*, already covered by the asset case.)
 
 #### Consuming an existing credit on the next invoice / bill: `auto_apply_credit:`
 

--- a/docs/issues/Q-022-payment-transfer-account-allows-owner-equity.md
+++ b/docs/issues/Q-022-payment-transfer-account-allows-owner-equity.md
@@ -1,0 +1,47 @@
+---
+id: Q-022
+title: Invoice/bill payment validation rejects owner's-equity deposit accounts
+category: quality
+severity: medium
+status: closed
+---
+
+## Problem
+
+Q-021 added validation that an invoice payment's transfer account must be an asset (cash) or an expense (bad-debt write-off), and a bill payment's must be an asset. That matrix only imagined "cash vs bad debt" and never considered **balance-sheet clearing / deposit accounts**, so it rejects a legitimate, common bookkeeping pattern: a **Canadian sole proprietor** has no separate business bank account — the T2125 business return reports only income and expense — so customer receipts (and vendor bills paid from personal funds) flow through **owner's equity** (`Equity:Owner equity:Owner's equity`), an `ACCT_TYPE_EQUITY` account. The importer raised "an invoice payment must use an asset account (cash payment) or an expense account (bad-debt write-off)" and refused the import.
+
+(The corporate "shareholder loan" variant is *not* affected: a corp models "due from director" as an **asset**, which the asset case already accepts. Only the sole-prop owner's-equity account was blocked.)
+
+## Why it matters
+
+It blocked a real user from importing their books. The deposit-account model is correct double-entry accounting — `ApplyPayment` to an equity transfer account closes the AR/AP lot and records the receipt against owner's equity exactly as a bank account would — so there was no accounting reason to reject it; the validation was simply too narrow.
+
+## Fix
+
+Allow an `ACCT_TYPE_EQUITY` (10) account as a payment's transfer account on **both** sides (invoice and bill), alongside the existing asset case. The two documented Q-021 guards are kept:
+
+- an **expense** remains **invoice-only** (a bill paid to an expense is debt forgiveness — a gain booked to income — out of scope), and
+- **income** is still rejected on an invoice payment (it would double-count the revenue already recognised at posting), as are the AR/AP account itself and structural types (root, trading).
+
+So the accepted transfer accounts are now: invoice → asset | owner's equity | expense; bill → asset | owner's equity.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `services/gnucash_importer.py` | `_validate_payment_account_type` accepts `_EQUITY_ACCT_TYPE` (10) on both sides; docstring and the two rejection messages updated to name the owner's-equity deposit account and explain the sole-proprietor rationale. |
+| `tests/integration/test_payment_to_equity_clearing_account.py` | Regression: an invoice payment and a bill payment, each into `Equity:Owner equity:Owner's equity`, close the AR/AP lot and move the balance into owner's equity. |
+| `tests/fixtures/q022_clearing_accounts.txt`, `q022_invoice_paid_to_equity.txt`, `q022_bill_paid_to_equity.txt` | Account tree with the sole-prop owner's-equity hierarchy, plus the invoice and bill that pay into it. |
+| `README.md` | New "Sole-proprietor deposit account: paying into owner's equity" subsection; the bad-debt section now lists owner's equity as a valid transfer account for both sides. |
+
+## Tests
+
+Both new tests pass on GnuCash 3.8 and 5.10. The Q-021 bad-debt guardrails (`test_invoice_bad_debt.py` — invoice→income rejected, bill→expense rejected, invoice→expense write-off works) and the 13-test `test_prepayment_settlement.py` suite still pass, confirming the relaxation didn't weaken the kept guards or regress the clearing path.
+
+## Related issues
+
+- **Q-021** — added the payment account-type validation this issue relaxes. The over-restriction was a gap in Q-021's matrix, not a behaviour Q-021 intended; the bad-debt and income/bill-expense guards Q-021 documented are preserved.
+
+---
+
+**Created**: 2026-06-05

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -66,3 +66,4 @@ and in the **Status** column below.
 | [Q-019](Q-019-draft-tax-render-and-two-sided-bill-rendering.md) | Draft tax breakdown + `print-bill` + two-sided rendering with company info | medium | closed |
 | [Q-020](Q-020-num-only-roundtrip-and-import-dedup-signature.md) | Num-only roundtrip relabels Num as Description; `import_from_file` dedup ignores `doc_link` / `tx_num` / `owner` | high | open |
 | [Q-021](Q-021-return-of-credit-bad-debt-and-prepayment-clearing.md) | Return of credit (refund), bad-debt write-off, and prepayment clearing via `lot_owner` | high | closed |
+| [Q-022](Q-022-payment-transfer-account-allows-owner-equity.md) | Invoice/bill payment validation rejects owner's-equity deposit accounts | medium | closed |

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -1395,6 +1395,7 @@ def _emit_orphan_warning_before_unpost(record, kind: str, ident: str,
 # Account-type categories for a payment's transfer (non-AR/AP) account.
 _ASSET_ACCT_TYPES = {0, 1, 2, 5, 6}   # BANK, CASH, ASSET, STOCK, MUTUAL
 _EXPENSE_ACCT_TYPE = 9                 # EXPENSE
+_EQUITY_ACCT_TYPE = 10                 # EQUITY
 
 
 def _payment_xfer_account_name(md):
@@ -1415,24 +1416,39 @@ def _payment_xfer_account_name(md):
 
 
 def _validate_payment_account_type(account, is_bill, name):
-    """Constrain a payment's transfer account by side. An invoice payment may
-    go to an asset (cash received) or an expense (a bad-debt write-off); a bill
-    payment must go to an asset — an unpaid bill we owe is debt forgiveness (a
-    gain), which is out of scope, so an expense is rejected. Other types
-    (income on an invoice would be a credit memo; equity; AR/AP itself) are
-    never valid."""
+    """Constrain a payment's transfer account by side. The account where a
+    payment lands may be:
+
+    - an **asset** (bank / cash received or paid) — the ordinary payment, either
+      side;
+    - **owner's equity** — an entity-aware deposit / clearing account, either
+      side. A Canadian sole proprietor has no separate business bank: the
+      business tax return reports only income and expense, so customer receipts
+      (and bills paid from personal funds) flow through `Equity:Owner equity`
+      rather than a bank. (A corporation that routes through a shareholder loan
+      models "due from director" as an *asset*, which the asset case already
+      covers.)
+    - an **expense** — a bad-debt write-off, **invoices only**. An unpaid bill we
+      owe is debt forgiveness (a gain booked to income), out of scope, so an
+      expense on a bill is rejected.
+
+    Other types are rejected: income on an invoice double-counts the revenue
+    already recognised at posting; AR/AP itself, the root, trading, etc. are
+    never a payment counter account."""
     t = account.GetType()
-    if t in _ASSET_ACCT_TYPES:
+    if t in _ASSET_ACCT_TYPES or t == _EQUITY_ACCT_TYPE:
         return
     if not is_bill and t == _EXPENSE_ACCT_TYPE:
         return  # invoice bad-debt write-off
     if is_bill:
         raise Exception(
-            f"a bill payment must use an asset account; {name!r} is not "
-            f"(an unpaid bill is debt forgiveness — a gain — out of scope)")
+            f"a bill payment must use an asset or owner's-equity account; "
+            f"{name!r} is neither (an unpaid bill is debt forgiveness — a gain "
+            f"— so an expense is out of scope)")
     raise Exception(
-        f"an invoice payment must use an asset account (cash payment) or an "
-        f"expense account (bad-debt write-off); {name!r} is neither")
+        f"an invoice payment must use an asset account (cash received), an "
+        f"owner's-equity deposit account, or an expense account (bad-debt "
+        f"write-off); {name!r} is none of these")
 
 
 def _apply_payment_directive(record, pay_dir, book, is_bill):

--- a/tests/fixtures/q022_bill_paid_to_equity.txt
+++ b/tests/fixtures/q022_bill_paid_to_equity.txt
@@ -1,0 +1,27 @@
+vendor "V022"
+	name: "Sole Prop Vendor"
+	currency: CAD
+
+bill "BILL-EQ"
+	vendor_id: "V022"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Supplies"
+		account: "Expenses"
+		quantity: 1
+		price: 60
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "BILL-EQ"
+		accumulate: true
+	payment:
+		date: 2026-02-01
+		amount: 60
+		account: "Equity:Owner equity:Owner's equity"
+		memo: "Paid vendor from personal funds — owner contribution"

--- a/tests/fixtures/q022_clearing_accounts.txt
+++ b/tests/fixtures/q022_clearing_accounts.txt
@@ -1,0 +1,44 @@
+2026-01-01 open Assets
+  type: Asset
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Accounts Receivable
+  type: Accounts Receivable
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Bank
+  type: Bank
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Income
+  type: Income
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Income:Sales
+  type: Income
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities
+  type: Liability
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Liabilities:Accounts Payable
+  type: Accounts Payable
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Expenses
+  type: Expense
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open Equity
+  type: Equity
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open "Equity:Owner equity"
+  type: Equity
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"
+2026-01-01 open "Equity:Owner equity:Owner's equity"
+  type: Equity
+  commodity.namespace: "CURRENCY"
+  commodity.mnemonic: "CAD"

--- a/tests/fixtures/q022_invoice_paid_to_equity.txt
+++ b/tests/fixtures/q022_invoice_paid_to_equity.txt
@@ -1,0 +1,27 @@
+customer "C022"
+	name: "Sole Prop Customer"
+	currency: CAD
+
+invoice "INV-EQ"
+	customer_id: "C022"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		date: 2026-01-01
+		description: "Consulting"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ar_account: "Assets:Accounts Receivable"
+		memo: "INV-EQ"
+		accumulate: true
+	payment:
+		date: 2026-02-01
+		amount: 100
+		account: "Equity:Owner equity:Owner's equity"
+		memo: "Customer paid — sole prop deposits to owner's equity"

--- a/tests/integration/test_payment_to_equity_clearing_account.py
+++ b/tests/integration/test_payment_to_equity_clearing_account.py
@@ -1,0 +1,72 @@
+"""A payment's transfer account may be an owner's-equity deposit / clearing
+account, not only a bank (or, for invoices, a bad-debt expense). A Canadian sole
+proprietor has no separate business bank — the business tax return reports only
+income and expense — so customer receipts and personally-paid vendor bills flow
+through `Equity:Owner equity:Owner's equity`. Both invoice and bill payments
+must accept it.
+"""
+
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+ACCOUNTS_PATH = 'tests/fixtures/q022_clearing_accounts.txt'
+FIXTURES_DIR = Path('tests/fixtures')
+EQUITY = "Equity.Owner equity.Owner's equity"
+
+
+def _new_book(runner, tmp_path):
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS_PATH])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    return gf
+
+
+def _import(runner, gf, fixture_name, tmp_path):
+    p = tmp_path / fixture_name
+    p.write_text((FIXTURES_DIR / fixture_name).read_text())
+    return runner.invoke(cli, ['import', str(gf), str(p),
+                               '--include-business-objects'])
+
+
+def _balance(gf, name):
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        out = {}
+
+        def walk(a):
+            out[a.get_full_name()] = round(a.GetBalance().to_double(), 2)
+            for c in a.get_children():
+                walk(c)
+        walk(repo.book.get_root_account())
+        return out.get(name, 0.0)
+    finally:
+        repo.close()
+
+
+def test_invoice_payment_to_owner_equity_closes_ar(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    r = _import(runner, gf, 'q022_invoice_paid_to_equity.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    # AR cleared (invoice settled); the $100 receipt landed in owner's equity.
+    assert _balance(gf, 'Assets.Accounts Receivable') == 0.0
+    assert abs(_balance(gf, EQUITY)) == 100.0
+
+
+def test_bill_payment_to_owner_equity_closes_ap(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    r = _import(runner, gf, 'q022_bill_paid_to_equity.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    # AP cleared (bill settled); the $60 was paid from personal funds via equity.
+    assert _balance(gf, 'Liabilities.Accounts Payable') == 0.0
+    assert abs(_balance(gf, EQUITY)) == 60.0


### PR DESCRIPTION
## Summary

Q-021's payment validation constrained an invoice payment's transfer account to an asset (cash) or an expense (bad-debt write-off), and a bill payment's to an asset. That matrix only modelled "cash vs bad debt" and overlooked balance-sheet clearing/deposit accounts, so it rejected a legitimate, common pattern.

A Canadian sole proprietor has no separate business bank account — the T2125 business return reports only income and expense — so customer receipts, and vendor bills paid from personal funds, flow through owner's equity (`Equity:Owner equity:Owner's equity`), an `ACCT_TYPE_EQUITY` account. The importer refused these with "an invoice payment must use an asset account (cash payment) or an expense account (bad-debt write-off)".

## Fix

Allow an equity account as a payment's transfer account on **both** the invoice and bill sides. Applying a payment to an equity transfer account closes the AR/AP lot and books the receipt against owner's equity exactly as a bank account would, so there is no accounting reason to reject it.

The two documented Q-021 guards are kept: an expense stays invoice-only (a bill paid to an expense is debt forgiveness, a gain booked to income, out of scope), and income is still rejected on an invoice payment (it would double-count the revenue recognised at posting), as are the AR/AP account itself and structural types. The corporate "shareholder loan" variant was never affected — a corp models "due from director" as an asset, already covered by the asset case.

## Tests

`tests/integration/test_payment_to_equity_clearing_account.py` drives an invoice payment and a bill payment, each into `Equity:Owner equity:Owner's equity`, and asserts the AR/AP lot closes and the balance lands in owner's equity. Passes on GnuCash 3.8 and 5.10; the Q-021 bad-debt guardrails and the 13-test prepayment-settlement suite still pass.

Documented as issue Q-022; README gains a "Sole-proprietor deposit account: paying into owner's equity" section.