### PR TITLE
fix(Q-023): enforce owner-attachment on prepayment residual credit lots

### DIFF
--- a/cli/find_prepayments_cmd.py
+++ b/cli/find_prepayments_cmd.py
@@ -21,6 +21,7 @@ refund it (drop the lot's source bank tx via
 import click
 
 from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from use_cases.export_transactions import find_ownerless_credit_lots
 from use_cases.unpost_business_objects import find_prepayments_in_book
 
 
@@ -65,8 +66,24 @@ def find_prepayments(gnucash_file, customer_id, vendor_id):
     try:
         credits_ = find_prepayments_in_book(
             repo.book, customer_id=customer_id, vendor_id=vendor_id)
+        ownerless = find_ownerless_credit_lots(repo.book)
     finally:
         repo.close()
+
+    # Guard: an open AR/AP credit lot with no LOT owner is a data defect — the
+    # credit belongs to no customer/vendor, so the `open_prepayment:` summary
+    # (and export-accounts) silently omit it. Every legitimate path attaches the
+    # owner, so this should never appear; surface it loudly if it ever does.
+    if ownerless:
+        click.echo('', err=True)
+        click.echo(
+            f'⚠  {len(ownerless)} open credit lot(s) have NO owner attached — '
+            f'a bug: such a credit is unattributable and is hidden from the '
+            f'open_prepayment summary / export-accounts. Please report it.',
+            err=True)
+        for acct, amount, mnem in ownerless:
+            click.echo(f'   • {acct}  {mnem} {amount:.2f}  (ownerless credit lot)',
+                       err=True)
 
     if not credits_:
         scope = ''

--- a/docs/issues/Q-023-retarget-prepayment-residual-credit-owner.md
+++ b/docs/issues/Q-023-retarget-prepayment-residual-credit-owner.md
@@ -1,0 +1,48 @@
+---
+id: Q-023
+title: Prepayment residual credit lots must be owner-attached (else invisible to the open_prepayment summary)
+category: quality
+severity: medium
+status: closed
+---
+
+## Problem
+
+When an existing over-paying deposit is linked to an invoice/bill (deposit > outstanding) via the `txn_guid:` retarget-with-prepayment path, the residual pre-payment lot was created but the customer/vendor was never attached as its owner. The `open_prepayment:` per-account summary and the `export-accounts` lot-walk surface only owner-attached credit lots (they resolve the owner via `gncOwnerGetOwnerFromLot`), so the residual credit existed in the book yet was invisible there — downstream tooling reading the summary saw no open credit and showed no badge.
+
+This is a class of defect, not a one-off: **an ownerless AR/AP credit lot is never a valid state.** A credit that belongs to no owner can't be applied to that owner's next invoice, can't be refunded, and is hidden from every owner-keyed view. The omission was latent because the ownerless lot predates the `open_prepayment:` summary (Q-021) that first read the lot's owner — nothing read it back when these paths were written. Two paths created ownerless residual lots: the retarget-split path (`_retarget_with_prepayment_split`) and the loose-sibling parking on re-import of a `prepayment:` field (Q-015).
+
+## Fix
+
+Enforce owner-attachment on **every** path that creates a residual credit lot, via one shared helper `_attach_record_owner_to_lot`:
+
+- `_retarget_with_prepayment_split` (initial overpayment link) attaches the owner;
+- the `prepayment:` re-import loose-sibling parking loop attaches the owner to each parked lot.
+
+`record.GetOwner()` returns the Customer/Vendor instance (the python-gnucash decorator unwraps the `GncOwner`), so a `GncOwner` is built from it via `gncOwnerInitCustomer` / `gncOwnerInitVendor` before attaching with `gncOwnerAttachToLot` — passing the raw Customer pointer is a silent no-op.
+
+Because an export of an owner-attached residual now carries `lot_owner:` on that split, a fresh re-import attaches it during the standalone-tx pass; the `prepayment:` validation therefore counts residual siblings that are **already parked** (in their owner lot), not only loose ones, so the round-trip neither errors nor double-creates.
+
+**Guard so it can't silently regress:** `find-prepayments` now reports any open non-invoice AR/AP credit lot whose lot has no owner as a loud warning (account + amount), via `find_ownerless_credit_lots`. The healthy invariant is that no such lot exists.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `services/gnucash_importer.py` | `_attach_record_owner_to_lot` helper; called from `_retarget_with_prepayment_split` (now takes `record`) and from the `prepayment:` loose-sibling parking loop; the prepayment validation counts already-parked residual siblings, not only loose ones. |
+| `use_cases/export_transactions.py` | `find_ownerless_credit_lots(book)` / `_ownerless_open_credit_lots(account)` — the inverse of `open_prepayments_for_account`: open non-invoice AR/AP credit lots with no lot owner. |
+| `cli/find_prepayments_cmd.py` | Emits a warning listing any ownerless credit lot found in the book. |
+| `tests/integration/test_retarget_prepayment_credit_visible.py` | export-accounts visibility (invoice + bill); the no-ownerless-lot invariant after a retarget overpayment; and the CLI guard firing on a crafted ownerless lot. |
+
+## Tests
+
+The visibility and invariant tests fail on the pre-fix code (no `open_prepayment:` block; an ownerless lot present) and pass after. The guard test crafts an ownerless lot directly and asserts both `find_ownerless_credit_lots` and the `find-prepayments` warning surface it. Verified on GnuCash 3.8 and 5.10; the overpayment-handling, fresh-roundtrip, find-prepayments, and prepayment-settlement suites still pass.
+
+## Related issues
+
+- **Q-015** — introduced the retarget-with-prepayment mechanic and the `prepayment:` re-import parking whose residual lots this fixes.
+- **Q-021** — added the `open_prepayment:` summary / `gncOwnerGetOwnerFromLot` lot-walk that requires the lot owner, and the standalone `lot_owner:` attach this mirrors.
+
+---
+
+**Created**: 2026-06-05

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -67,3 +67,4 @@ and in the **Status** column below.
 | [Q-020](Q-020-num-only-roundtrip-and-import-dedup-signature.md) | Num-only roundtrip relabels Num as Description; `import_from_file` dedup ignores `doc_link` / `tx_num` / `owner` | high | open |
 | [Q-021](Q-021-return-of-credit-bad-debt-and-prepayment-clearing.md) | Return of credit (refund), bad-debt write-off, and prepayment clearing via `lot_owner` | high | closed |
 | [Q-022](Q-022-payment-transfer-account-allows-owner-equity.md) | Invoice/bill payment validation rejects owner's-equity deposit accounts | medium | closed |
+| [Q-023](Q-023-retarget-prepayment-residual-credit-owner.md) | Retarget-with-prepayment residual credit is not owner-attached, invisible to the open_prepayment summary | medium | closed |

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -796,7 +796,38 @@ def _attach_lot_owner_split(book, split, split_account, kind, owner_id, owner_gu
         lib.gncOwnerAttachToLot(attach_p, new_lot)
 
 
-def _retarget_with_prepayment_split(lib, book, existing_tx, bank_acct_name: str,
+def _attach_record_owner_to_lot(lib, record, lot_ptr):
+    """Attach an invoice/bill record's owner (customer/vendor) to `lot_ptr`.
+
+    A residual pre-payment credit lot MUST be owner-attached: otherwise
+    gncOwnerGetOwnerFromLot can't resolve it and the `open_prepayment:` summary
+    / find-prepayments lot-walk silently omit the credit, and the owner can
+    never apply or be refunded it. An ownerless credit lot is not a valid state.
+
+    `record.GetOwner()` returns the Customer/Vendor instance (the python-gnucash
+    decorator unwraps the GncOwner), so a GncOwner is built from it via
+    gncOwnerInit* before attaching — passing the raw Customer pointer straight to
+    gncOwnerAttachToLot is a silent no-op. Mirrors the attach in
+    `_attach_lot_owner_split`.
+    """
+    lib.gncOwnerInitCustomer.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    lib.gncOwnerInitCustomer.restype  = None
+    lib.gncOwnerInitVendor.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    lib.gncOwnerInitVendor.restype  = None
+    lib.gncOwnerAttachToLot.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    lib.gncOwnerAttachToLot.restype  = None
+    ref = record.GetOwner()
+    buf = ctypes.create_string_buffer(256)
+    owner_p = ctypes.cast(buf, ctypes.c_void_p)
+    if record.GetOwnerType() == _GNC_OWNER_VENDOR:
+        lib.gncOwnerInitVendor(owner_p, int(ref.instance))
+    else:
+        lib.gncOwnerInitCustomer(owner_p, int(ref.instance))
+    lib.gncOwnerAttachToLot(owner_p, lot_ptr)
+
+
+def _retarget_with_prepayment_split(lib, book, record, existing_tx,
+                                    bank_acct_name: str,
                                     post_account, invoice_lot,
                                     invoice_portion: float,
                                     prepayment_portion: float) -> bool:
@@ -892,6 +923,10 @@ def _retarget_with_prepayment_split(lib, book, existing_tx, bank_acct_name: str,
     new_lot_ptr = lib.gnc_lot_new(int(book.instance))
     lib.xaccAccountInsertLot(int(post_account.instance), new_lot_ptr)
     lib.gnc_lot_add_split(new_lot_ptr, int(new_split.instance))
+
+    # The residual is the record owner's credit; attach the owner so the lot is
+    # owner-attached and visible to the open_prepayment summary / find-prepayments.
+    _attach_record_owner_to_lot(lib, record, new_lot_ptr)
 
     existing_tx.CommitEdit()
     return True
@@ -1566,6 +1601,7 @@ def _apply_payment_directive(record, pay_dir, book, is_bill):
                 # prepay lot. Their absolute amounts must sum to the
                 # declared prepayment (defensive check).
                 loose_siblings = []
+                actual_prepay = 0.0
                 for raw_sp in existing_tx.GetSplitList():
                     if raw_sp.GetGUID().to_string().replace('-', '').lower() == target_split_guid:
                         continue
@@ -1574,11 +1610,16 @@ def _apply_payment_directive(record, pay_dir, book, is_bill):
                         continue
                     if get_account_full_name(sp_acct) != get_account_full_name(post_acct):
                         continue
-                    if raw_sp.GetLot() is not None:
-                        continue
-                    loose_siblings.append(raw_sp)
-                actual_prepay = sum(abs(sp.GetAmount().to_double())
-                                    for sp in loose_siblings)
+                    # A residual prepayment split on this tx. Count it toward the
+                    # declared prepayment whether it is still loose (a legacy
+                    # export) or already parked in its owner lot: an export that
+                    # carries `lot_owner:` on the residual has the standalone-tx
+                    # import attach it first, so by now it is no longer loose.
+                    # Park only the loose ones; already-parked siblings keep the
+                    # owner lot the lot_owner import gave them.
+                    actual_prepay += abs(raw_sp.GetAmount().to_double())
+                    if raw_sp.GetLot() is None:
+                        loose_siblings.append(raw_sp)
                 if abs(actual_prepay - declared_prepay) > 1e-6:
                     raise Exception(
                         f'declared `prepayment: {declared_prepay}` does not '
@@ -1596,6 +1637,10 @@ def _apply_payment_directive(record, pay_dir, book, is_bill):
                     new_lot_ptr = lib.gnc_lot_new(int(book.instance))
                     lib.xaccAccountInsertLot(int(post_acct.instance), new_lot_ptr)
                     lib.gnc_lot_add_split(new_lot_ptr, int(sib.instance))
+                    # The residual is the record owner's credit — attach the
+                    # owner so the parked lot is visible to the open_prepayment
+                    # summary / find-prepayments, not a silent ownerless credit.
+                    _attach_record_owner_to_lot(lib, record, new_lot_ptr)
                 existing_tx.CommitEdit()
             return
 
@@ -1643,7 +1688,7 @@ def _apply_payment_directive(record, pay_dir, book, is_bill):
                     f'{invoice_remaining_abs:.2f}).'
                 )
             if not _retarget_with_prepayment_split(
-                    lib, book, existing_tx, bank_acct_name,
+                    lib, book, record, existing_tx, bank_acct_name,
                     post_acct, lot, invoice_remaining_abs, expected_prepay):
                 raise Exception(
                     f'Could not find counter-split in tx {txn_guid!r} — '

--- a/tests/integration/test_retarget_prepayment_credit_visible.py
+++ b/tests/integration/test_retarget_prepayment_credit_visible.py
@@ -1,0 +1,240 @@
+"""Linking an over-paying existing deposit to an invoice must leave the residual
+credit **owner-attached**, so it is visible to `find-prepayments` /
+`export-accounts` (which only surface credits on owner-attached lots).
+
+The `ApplyPayment` overpayment path attaches the owner automatically, and the
+standalone-credit `lot_owner:` path attaches it explicitly. The `txn_guid:`
+retarget-with-prepayment path (`_retarget_with_prepayment_split`) creates the
+residual pre-payment lot but historically forgot to attach the owner, so the
+credit existed in the book yet was invisible to the credit-listing commands —
+no badge for downstream tools. This pins that the retarget residual is surfaced.
+"""
+
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+ACCOUNTS_PATH = 'tests/fixtures/payment_roundtrip_accounts.txt'
+FIXTURES_DIR = Path('tests/fixtures')
+
+
+def _fixture(name):
+    return (FIXTURES_DIR / name).read_text()
+
+
+def _setup_book(runner, tmp_path):
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS_PATH])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    return gf
+
+
+def _import_text(runner, gf, content, name, tmp_path, biz=True):
+    p = tmp_path / name
+    p.write_text(content)
+    args = ['import', str(gf), str(p)]
+    if biz:
+        args.append('--include-business-objects')
+    return runner.invoke(cli, args)
+
+
+def _bank_tx_guid(gf, amount, bank='Assets.Bank'):
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        def find(acct, name):
+            if acct.get_full_name() == name:
+                return acct
+            for child in acct.get_children():
+                got = find(child, name)
+                if got:
+                    return got
+            return None
+        b = find(repo.book.get_root_account(), bank)
+        for sp in b.GetSplitList():
+            if abs(sp.GetAmount().to_double() - amount) < 0.001:
+                return sp.GetParent().GetGUID().to_string()
+        return None
+    finally:
+        repo.close()
+
+
+def _ownerless_credit_lots(gf):
+    """The book's open AR/AP credit lots that have no owner — the healthy
+    invariant is an empty list."""
+    from repositories.gnucash_repository import GnuCashRepository
+    from use_cases.export_transactions import find_ownerless_credit_lots
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        return find_ownerless_credit_lots(repo.book)
+    finally:
+        repo.close()
+
+
+def _craft_ownerless_ar_credit(gf, amount=-77.0):
+    """Directly park an AR credit split in a lot with NO owner attached — the
+    exact defect the guard must catch (what a buggy import path would leave)."""
+    import ctypes
+
+    from gnucash import GncNumeric, Split, Transaction
+
+    from infrastructure.gnucash.engine import load_gnc_engine
+    from repositories.gnucash_repository import GnuCashRepository
+
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        book = repo.book
+
+        def find(acct, name):
+            if acct.get_full_name() == name:
+                return acct
+            for child in acct.get_children():
+                got = find(child, name)
+                if got:
+                    return got
+            return None
+
+        root = book.get_root_account()
+        ar = find(root, 'Assets.Accounts Receivable')
+        bank = find(root, 'Assets.Bank')
+        comm = ar.GetCommodity()
+
+        trans = Transaction(book)
+        trans.BeginEdit()
+        trans.SetCurrency(comm)
+        trans.SetDate(1, 1, 2026)
+        cents = int(round(amount * 100))
+        s_ar = Split(book)
+        s_ar.SetParent(trans)
+        s_ar.SetAccount(ar)
+        s_ar.SetValue(GncNumeric(cents, 100))
+        s_ar.SetAmount(GncNumeric(cents, 100))
+        s_bk = Split(book)
+        s_bk.SetParent(trans)
+        s_bk.SetAccount(bank)
+        s_bk.SetValue(GncNumeric(-cents, 100))
+        s_bk.SetAmount(GncNumeric(-cents, 100))
+        trans.CommitEdit()
+
+        lib = load_gnc_engine()
+        lib.gnc_lot_new.argtypes = [ctypes.c_void_p]
+        lib.gnc_lot_new.restype = ctypes.c_void_p
+        lib.xaccAccountInsertLot.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        lib.xaccAccountInsertLot.restype = None
+        lib.gnc_lot_add_split.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        lib.gnc_lot_add_split.restype = None
+        lot = lib.gnc_lot_new(int(book.instance))
+        lib.xaccAccountInsertLot(int(ar.instance), lot)
+        lib.gnc_lot_add_split(lot, int(s_ar.instance))
+
+        repo.save()
+    finally:
+        repo.close()
+
+
+def _setup_retarget_overpayment(runner, tmp_path):
+    """Build the book where an external $150 deposit is linked to a $100 invoice
+    for customer C004, declaring the $50 residual as a pre-payment (the
+    `txn_guid:` retarget-with-prepayment path). Returns the book path."""
+    gf = _setup_book(runner, tmp_path)
+    # Pre-create the external $150 deposit (bank-side tx with an Imbalance
+    # counter-split), the way a bank-feed import would.
+    r = _import_text(runner, gf, _fixture('q015_oh_retarget_over_pre_bank.txt'),
+                     'pre_bank.txt', tmp_path, biz=False)
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    bank_guid = _bank_tx_guid(gf, 150.0)
+    assert bank_guid is not None
+    biz = _fixture('q015_oh_retarget_over_biz.txt').replace('{txn_guid}', bank_guid)
+    r = _import_text(runner, gf, biz, 'inv.txt', tmp_path)
+    assert r.exit_code == 0, f'retarget+prepayment import failed: {r.output}'
+    time.sleep(1)
+    return gf
+
+
+def test_retarget_overpayment_residual_credit_in_export_accounts(tmp_path):
+    """`export-accounts` emits the per-account `open_prepayment:` summary from
+    owner-attached AR/AP lots (gncOwnerGetOwnerFromLot). The retargeted residual
+    must carry its owner so the credit shows up here — otherwise it is a silent
+    open credit invisible to downstream badge tooling."""
+    runner = CliRunner()
+    gf = _setup_retarget_overpayment(runner, tmp_path)
+
+    out = tmp_path / 'accounts.txt'
+    r = runner.invoke(cli, ['export-accounts', str(gf), str(out)])
+    assert r.exit_code == 0, r.output
+    text = out.read_text()
+
+    assert 'open_prepayment:' in text, (
+        f'the retargeted $50 residual must surface as an open_prepayment block; '
+        f'export-accounts output:\n{text}'
+    )
+    assert 'customer: "C004"' in text, text
+    assert 'amount: 50.00 CAD' in text, text
+
+
+def test_bill_retarget_overpayment_residual_credit_in_export_accounts(tmp_path):
+    """Symmetric vendor case: linking an over-paying outflow to a bill must
+    leave the residual vendor credit owner-attached and visible."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+
+    r = _import_text(runner, gf, _fixture('q015_oh_bill_retarget_over_pre_bank.txt'),
+                     'pre_bank.txt', tmp_path, biz=False)
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    bank_guid = _bank_tx_guid(gf, -150.0)
+    assert bank_guid is not None
+    biz = _fixture('q015_oh_bill_retarget_over_biz.txt').replace('{txn_guid}', bank_guid)
+    r = _import_text(runner, gf, biz, 'bill.txt', tmp_path)
+    assert r.exit_code == 0, f'bill retarget+prepayment import failed: {r.output}'
+    time.sleep(1)
+
+    out = tmp_path / 'accounts.txt'
+    r = runner.invoke(cli, ['export-accounts', str(gf), str(out)])
+    assert r.exit_code == 0, r.output
+    text = out.read_text()
+    assert 'open_prepayment:' in text, (
+        f'the retargeted $50 vendor residual must surface; output:\n{text}'
+    )
+    assert 'vendor: "V003"' in text, text
+    assert 'amount: 50.00 CAD' in text, text
+
+
+def test_retarget_overpayment_leaves_no_ownerless_credit_lot(tmp_path):
+    """Structural invariant: a residual credit must always be owner-attached.
+    Catches the bug class directly — on the pre-fix code the residual lot was
+    ownerless and this list was non-empty."""
+    runner = CliRunner()
+    gf = _setup_retarget_overpayment(runner, tmp_path)
+    assert _ownerless_credit_lots(gf) == [], (
+        f'a retarget overpayment must not leave an ownerless credit lot; '
+        f'found: {_ownerless_credit_lots(gf)}'
+    )
+
+
+def test_find_prepayments_warns_on_ownerless_credit_lot(tmp_path):
+    """The CLI guard: if an ownerless credit lot ever exists, find-prepayments
+    must surface it loudly rather than let it hide. Crafts the defect directly."""
+    runner = CliRunner()
+    gf = _setup_book(runner, tmp_path)
+    _craft_ownerless_ar_credit(gf, amount=-77.0)
+    time.sleep(1)
+
+    # The guard sees the ownerless lot...
+    found = _ownerless_credit_lots(gf)
+    assert len(found) == 1 and abs(found[0][1] - 77.0) < 0.01, found
+
+    # ...and find-prepayments warns about it.
+    r = runner.invoke(cli, ['find-prepayments', str(gf)])
+    assert r.exit_code == 0, r.output
+    out = r.output.lower()
+    assert 'no owner' in out or 'ownerless' in out, r.output
+    assert '77' in r.output, r.output

--- a/use_cases/export_transactions.py
+++ b/use_cases/export_transactions.py
@@ -136,6 +136,72 @@ def open_prepayments_for_account(account):
             for _when, kind, oid, guid, amount in sorted(creds, key=lambda c: c[0])]
 
 
+def _ownerless_open_credit_lots(account):
+    """Open, non-invoice credit lots on an AR/AP account whose LOT carries no
+    owner (gncOwnerGetOwnerFromLot fails) — the inverse of
+    open_prepayments_for_account. Such a lot holds a real credit balance but is
+    invisible to the `open_prepayment:` summary and unattributable to any
+    customer/vendor, so it always signals a bug in whatever created the lot
+    (every legitimate path attaches the owner). Returns absolute balances."""
+    import ctypes as _ctypes
+
+    from infrastructure.gnucash.engine import load_gnc_engine as _load
+
+    class _Num(_ctypes.Structure):
+        _fields_ = [('num', _ctypes.c_int64), ('denom', _ctypes.c_int64)]
+
+    _lib = _load()
+    try:
+        for n, r, a in [
+            ('xaccAccountGetLotList', _ctypes.c_void_p, [_ctypes.c_void_p]),
+            ('gnc_lot_get_balance', _Num, [_ctypes.c_void_p]),
+            ('gnc_lot_is_closed', _ctypes.c_int, [_ctypes.c_void_p]),
+            ('gncInvoiceGetInvoiceFromLot', _ctypes.c_void_p, [_ctypes.c_void_p]),
+            ('gncOwnerGetOwnerFromLot', _ctypes.c_int, [_ctypes.c_void_p, _ctypes.c_void_p]),
+        ]:
+            f = getattr(_lib, n)
+            f.restype = r
+            f.argtypes = a
+    except AttributeError:
+        return []
+
+    bad = []
+    g = _lib.xaccAccountGetLotList(int(account.instance))
+    while g:
+        node = _ctypes.cast(g, _ctypes.POINTER(_ctypes.c_void_p * 3)).contents
+        lot = node[0]
+        if lot and not _lib.gnc_lot_is_closed(lot):
+            b = _lib.gnc_lot_get_balance(lot)
+            bal = b.num / b.denom if b.denom else 0.0
+            if abs(bal) > 1e-9 and not _lib.gncInvoiceGetInvoiceFromLot(lot):
+                obuf = _ctypes.create_string_buffer(256)
+                op = _ctypes.cast(obuf, _ctypes.c_void_p).value
+                if _lib.gncOwnerGetOwnerFromLot(lot, op) != 1:
+                    bad.append(abs(bal))
+        g = node[1]
+    return bad
+
+
+def find_ownerless_credit_lots(book):
+    """Every open non-invoice AR/AP credit lot in the book whose lot has no
+    owner — a data defect (a credit that belongs to no customer/vendor, hidden
+    from the open_prepayment summary). Returns (account_full_name, amount,
+    mnemonic) tuples. An empty list is the healthy invariant."""
+    out = []
+
+    def walk(acct):
+        if acct.GetType() in (11, 12):  # ACCT_TYPE_RECEIVABLE / PAYABLE
+            commodity = acct.GetCommodity()
+            mnem = commodity.get_mnemonic() if commodity else ''
+            for amount in _ownerless_open_credit_lots(acct):
+                out.append((acct.get_full_name(), amount, mnem))
+        for child in acct.get_children():
+            walk(child)
+
+    walk(book.get_root_account())
+    return out
+
+
 class ExportTransactionsUseCase:
     """Use case for exporting transactions to plaintext with full metadata"""
 


### PR DESCRIPTION
## Summary

A residual pre-payment credit is a customer/vendor credit, so its lot must always be owner-attached. The `txn_guid:` retarget-with-prepayment path created the residual lot but never attached the owner, and the `prepayment:` re-import loose-sibling parking did the same. The `open_prepayment:` per-account summary and the `export-accounts` lot-walk surface only owner-attached lots (they resolve the owner via `gncOwnerGetOwnerFromLot`), so such a credit existed in the book yet was invisible there — no badge for downstream tooling, no way to apply or refund it. An ownerless AR/AP credit lot is never a valid state; the omission was latent because it predates the Q-021 summary that first reads the lot's owner.

## Fix

Enforce owner-attachment on every path that creates a residual credit lot, through one shared helper `_attach_record_owner_to_lot`:
- `_retarget_with_prepayment_split` (initial overpayment link) now attaches the owner;
- the `prepayment:` re-import loose-sibling parking loop attaches it to each parked lot.

`record.GetOwner()` returns the Customer/Vendor instance (the python-gnucash decorator unwraps the `GncOwner`), so a `GncOwner` is built from it via `gncOwnerInitCustomer` / `gncOwnerInitVendor` before `gncOwnerAttachToLot` — passing the raw Customer pointer is a silent no-op.

An export of an owner-attached residual now carries `lot_owner:` on that split, so a fresh re-import attaches it during the standalone-tx pass. The `prepayment:` validation therefore counts residual siblings that are already parked in their owner lot, not only loose ones, so the round-trip neither errors nor double-creates.

## Guard

`find-prepayments` now reports any open non-invoice AR/AP credit lot whose lot has no owner as a loud warning (account + amount), via `find_ownerless_credit_lots` — so if any future path reintroduces an ownerless credit it is surfaced, not hidden. The healthy invariant is that no such lot exists.

## Tests

`tests/integration/test_retarget_prepayment_credit_visible.py`: export-accounts visibility for the invoice (customer) and bill (vendor) retarget-overpayment; the no-ownerless-lot invariant after a retarget overpayment; and the CLI guard firing on a directly-crafted ownerless lot. The visibility and invariant tests fail on the pre-fix code and pass after. Verified on GnuCash 3.8 and 5.10; the full integration suite (497 tests) passes on 5.10, including the overpayment-handling, fresh-roundtrip, find-prepayments, and prepayment-settlement suites.

Documented as issue Q-023.