### PR TITLE
feat(Q-024): unapply a payment from a posted invoice/bill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1171,6 +1171,43 @@ Behaviour:
 
 For after-the-fact recovery — auditing a book that's already accumulated orphans from prior unpost runs — use `find-orphan-payments` (next section).
 
+#### Unapplying a payment without unposting: `unapply-payment`
+
+When a payment was applied to the wrong invoice (or a deposit turned out not to be a payment at all), you want to peel that payment off **without** touching the document — the invoice stays posted and simply returns to Outstanding. That is different from unpost (which drops the document to Draft and destroys the posting). Use `unapply-payment`:
+
+```
+# INV has ONE payment — no selector needed. That payment is detached and
+# the freed amount moved to the named liability; INV returns to Outstanding.
+gnucash-plaintext unapply-payment ledger.gnucash INV-2026-001 --to "Liabilities:Due to customer"
+
+# INV has SEVERAL payments — peel exactly one, named by its bank-tx GUID.
+# The other payments stay applied (INV becomes partially-paid). Here the
+# freed amount is routed to income (e.g. it was really interest income).
+gnucash-plaintext unapply-payment ledger.gnucash INV-2026-001 --txn <bank-tx-guid> --to "Income:Misc"
+
+# THREE payments, two of them wrong — repeat --txn to peel just those two.
+# The third payment stays applied; INV's Outstanding rises by the two amounts.
+gnucash-plaintext unapply-payment ledger.gnucash INV-2026-001 \
+    --txn <wrong-tx-1> --txn <wrong-tx-2> --to "Liabilities:Due to customer"
+
+# Peel EVERY payment — INV returns to fully Outstanding (just-posted state).
+gnucash-plaintext unapply-payment ledger.gnucash INV-2026-001 --all --to "Liabilities:Due to customer"
+
+# A vendor bill instead of a customer invoice.
+gnucash-plaintext unapply-payment ledger.gnucash BILL-2026-001 --bill --to "Liabilities:Due to vendor"
+```
+
+What it does: detaches the named payment's AR/AP split from the invoice/bill's posted lot — so the lot reopens (Outstanding, or partially-paid if other payments remain) — and moves that freed split to the account you name with `--to`. The document stays **posted**; the bank/income transaction is **never deleted** (the money still happened); only the freed split's account changes, so the transaction stays balanced.
+
+- **`--to` is required**, and accepts **any** account type. The payment's prior account was overwritten when it was applied and isn't recorded, so only you know where the freed money belongs. Money you received that is no longer applied to an invoice is, in accounting terms, a payable you may owe back — typically a liability such as `Liabilities:Due to customer` / `Due to shareholder` (which need not be a GnuCash *A/Payable*-type account); you may equally route it to income, a clearing account, or an asset carried negative. It is your call.
+- **Which payment(s)**: one payment → no selector needed; several → `--txn <bank-tx-guid>` to peel one, **repeat `--txn`** to peel a subset (two of three), or `--all` for every payment. On a multi-payment record, omitting all selectors is an error — never an implicit "all". Payments are identified by transaction GUID, so two payments of the same amount are unambiguous.
+- `--bill` targets a vendor bill; `--by-guid` resolves the id argument as an invoice/bill GUID.
+
+To find a payment's bank-tx GUID, run `find-orphan-payments` or read it from the invoice's exported `payment:` blocks (`txn_guid:`).
+
+After unapplying, the freed amount sits in your `--to` account. To re-link it to the *correct* invoice, apply it there as you would any payment (e.g. a `payment:` block with `txn_guid:` retargeting that transaction, or `auto_apply_credit:` if you routed it to an AR credit).
+
+
 Compared to the re-import path:
 
 | | Re-import (`posted: { ... }` → `posted: none`) | `unpost-invoices` / `unpost-bills` |

--- a/cli/main.py
+++ b/cli/main.py
@@ -29,6 +29,7 @@ from cli.import_beancount_cmd import import_beancount
 from cli.import_cmd import import_transactions
 from cli.income_statement_cmd import income_statement
 from cli.invoice_print_cmd import print_invoice
+from cli.unapply_cmd import unapply_payment
 from cli.unpost_cmd import unpost_bills, unpost_invoices
 from cli.validate_cmd import validate_ledger
 
@@ -77,6 +78,7 @@ cli.add_command(archive_customers, name='archive-customers')
 cli.add_command(archive_vendors, name='archive-vendors')
 cli.add_command(unpost_invoices, name='unpost-invoices')
 cli.add_command(unpost_bills, name='unpost-bills')
+cli.add_command(unapply_payment, name='unapply-payment')
 cli.add_command(find_orphan_payments, name='find-orphan-payments')
 cli.add_command(find_prepayments, name='find-prepayments')
 

--- a/cli/unapply_cmd.py
+++ b/cli/unapply_cmd.py
@@ -1,0 +1,110 @@
+"""CLI command: unapply a payment from a posted invoice or bill.
+
+`unapply-payment <book> <id> --to <account> [--txn <guid> | --all] [--by-guid] [--bill]`
+
+Peels a payment off a still-**posted** invoice/bill: the payment's AR/AP split
+is detached from the record's lot (so the invoice returns to Outstanding, or
+partially-paid if other payments remain) and re-homed to `--to <account>`. The
+invoice/bill document is untouched and stays posted; the bank/income
+transaction is never deleted — only the freed split's account changes.
+
+This is NOT unpost: `unpost-invoices` / `unpost-bills` drop the record to Draft
+and destroy the posting transaction. Use unapply-payment when the document is
+correct but a payment was applied to the wrong invoice (or wasn't a payment at
+all) and you need to peel it back without touching the document.
+
+`--to` is required: the freed money had some prior account the apply step
+overwrote and we never recorded, and money no longer applied to an invoice is a
+payable you may owe back — only you know which account represents that in your
+chart (often a LIABILITY "Due to ...", possibly an asset carried negative). Any
+account type is accepted.
+
+Selecting which payment(s):
+  - one payment on the record → no selector needed
+  - several payments → `--txn <bank-tx-guid>` to peel one; repeat `--txn` to
+    peel a subset (e.g. two of three wrong payments); or `--all` for every
+    payment. Omitting all selectors on a multi-payment record is an error
+    (never a guess). Payments are identified by GUID, so equal amounts are
+    unambiguous.
+"""
+
+import sys
+
+import click
+
+from infrastructure.gnucash.guid_lookup import normalise_guid
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from services.gnucash_importer import find_account
+from use_cases.unapply_payment import execute_unapply
+
+
+@click.command('unapply-payment')
+@click.argument('gnucash_file', type=click.Path(exists=True))
+@click.argument('record_id')
+@click.option('--to', 'to_account_name', required=True,
+              help='Account to re-home the freed payment split into (any type; '
+                   'typically the payable/liability you represent it with).')
+@click.option('--txn', 'txn_guids', multiple=True,
+              help='Peel this payment, named by its bank transaction GUID. '
+                   'Repeatable — pass --txn once per payment to peel a subset '
+                   '(e.g. two of three).')
+@click.option('--all', 'unapply_all', is_flag=True, default=False,
+              help='Unapply every payment on the record (→ fully Outstanding).')
+@click.option('--bill', 'is_bill', is_flag=True, default=False,
+              help='Target a vendor bill instead of a customer invoice.')
+@click.option('--by-guid', 'by_guid', is_flag=True, default=False,
+              help='Resolve RECORD_ID as an invoice/bill GUID rather than its id.')
+def unapply_payment(gnucash_file, record_id, to_account_name, txn_guids,
+                    unapply_all, is_bill, by_guid):
+    """Detach a payment from a posted invoice/bill and re-home it to --to."""
+    if txn_guids and unapply_all:
+        raise click.ClickException('--txn and --all are mutually exclusive.')
+    try:
+        txn_guids = [normalise_guid(g) for g in txn_guids]
+    except ValueError as e:
+        raise click.ClickException(str(e)) from e
+
+    kind = 'bill' if is_bill else 'invoice'
+    repo = GnuCashRepository(gnucash_file)
+    repo.open(mode=SessionMode.NORMAL)
+    try:
+        to_account = find_account(repo.book.get_root_account(), to_account_name)
+        if to_account is None:
+            raise click.ClickException(
+                f'--to account {to_account_name!r} not found in the book')
+        result = execute_unapply(
+            repo.book, record_id, to_account, is_bill=is_bill,
+            by_guid=by_guid, txn_guids=txn_guids, unapply_all=unapply_all)
+        if result.status == 'unapplied':
+            repo.save()
+    finally:
+        repo.close()
+
+    label = result.guid and f'{result.id} ({result.guid})' or result.id
+
+    if result.status == 'unapplied':
+        n = len(result.unapplied)
+        noun = 'payment' if n == 1 else 'payments'
+        click.echo(f'{label}: unapplied {n} {noun} → {result.to_account}')
+        for tx_guid, amount, currency in result.unapplied:
+            click.echo(f'   • {currency} {amount}  (was payment tx {tx_guid})')
+        state = 'Outstanding' if result.remaining_balance != 0 else 'fully paid'
+        click.echo(f'   {kind} lot balance now {abs(result.remaining_balance):.2f} '
+                   f'({state}); document still posted.')
+        return
+
+    # Error statuses → exit non-zero with a clear message.
+    msgs = {
+        'not_found': f'{kind} {result.id!r} not found',
+        'ambiguous_id': (f'{result.id!r} matches multiple records — rerun with '
+                         f'--by-guid <guid>'),
+        'not_posted': f'{result.id!r} is not posted — nothing to unapply',
+        'no_payments': f'{result.id!r} is posted but has no payments to unapply',
+        'need_selector': result.detail,
+        'txn_not_found': result.detail,
+    }
+    raise click.ClickException(msgs.get(result.status, f'unapply failed: {result.status}'))
+
+
+if __name__ == '__main__':
+    sys.exit(unapply_payment())

--- a/docs/issues/Q-024-unapply-payment.md
+++ b/docs/issues/Q-024-unapply-payment.md
@@ -1,0 +1,59 @@
+---
+id: Q-024
+title: Unapply a payment from a posted invoice/bill without unposting it
+category: quality
+severity: medium
+status: closed
+---
+
+## Problem
+
+There was no way to take a payment *off* an invoice/bill while leaving the document posted. Removing a payment via re-import falls through to the destructive unpost-rebuild-repost path, which drops the record to Draft and detaches everything — wrong when the document is correct and only the payment is misplaced. The motivating case: an income/deposit transaction was linked to an invoice but turned out not to belong to it. You can't delete the transaction (the money really moved), and unpost-then-repost is not the right move; the right move is to revert to the state *before that payment was applied* — still **posted**, just **not paid** (or partially paid if other payments remain).
+
+This is a distinct operation from unpost/void:
+
+| | unapply-payment | unpost / void |
+|---|---|---|
+| document | untouched, stays **posted** | drops to **Draft** |
+| posting tx / lot | kept (lot just reopens) | destroyed |
+| the payment | detached → re-homed, kept | orphaned bank tx |
+
+## Fix
+
+A new `unapply-payment` CLI command, sibling to `unpost-invoices`:
+
+```
+gnucash-plaintext unapply-payment <book> <id> --to <account> [--txn <guid> | --all] [--bill] [--by-guid]
+```
+
+It detaches a payment's AR/AP split from the record's posted lot (`gnc_lot_remove_split`, probed safe on all 10 GnuCash builds) so the lot reopens — invoice returns to Outstanding, or partially-paid if other payments remain — and re-homes the freed split to `--to <account>` (`xaccSplitSetAccount`; the amount is unchanged so the transaction stays balanced). The document stays posted; the bank/income transaction is never deleted.
+
+Key decisions:
+
+- **`--to` is required, any account type.** The freed split's prior account (Imbalance, Income, a clearing account) was overwritten by the apply step and never recorded, and money no longer applied to an invoice is a payable you may owe back — only the user knows which account represents that in their chart (often a `LIABILITY` "Due to shareholder", possibly an asset carried negative). There is no defensible silent default, so the destination must be named; the account type is not constrained (same lesson as Q-022).
+- **Identity by GUID, never amount.** Two payments can share an amount, and floats can't represent decimals exactly, so the selector (`--txn`) and every internal match key on the payment transaction's GUID. Amounts are read exactly (`gnc_numeric` → `Decimal`/`Fraction`), never via `to_double`.
+- **Selection.** One payment on the record → no selector needed; several → `--txn <bank-tx-guid>` to peel one, **repeated `--txn`** to peel a subset (e.g. two of three wrong payments), or `--all` for every payment; omitting all selectors on a multi-payment record is an error, never a guess.
+- **Payment enumeration is version-robust.** A payment is any transaction with a split in the lot other than the record's own posting transaction — no dependence on `xaccTransGetTxnType == 'P'`, which isn't reliably set on every version for retargeted / shared-bank-tx payments (it silently dropped the multi-invoice case on GnuCash 3.8).
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `use_cases/unapply_payment.py` | `unapply_payments` / `execute_unapply`: resolve the record, enumerate lot payments by GUID, detach + re-home the selected split(s), exact `Decimal` amounts. |
+| `cli/unapply_cmd.py` | `unapply-payment` command with `--to` (required), `--txn`, `--all`, `--bill`, `--by-guid`; clear per-status errors. |
+| `cli/main.py` | Register `unapply-payment`. |
+| `tests/integration/test_unapply_payment.py` | 11 tests (below). |
+
+## Tests
+
+On GnuCash 3.8 and 5.10: single-payment reopen + re-home; one-of-two payments → partial state; **two-of-three payments via repeated `--txn`** (the third stays applied); `--all` → fully Outstanding; **one of several invoices sharing one bank tx** (only that invoice reopens; the shared tx survives); **two same-amount payments selected by GUID** (the case that defeats amount-matching); bill (AP) side; the invoice stays posted and round-trips; and the guards (`--to` required, unknown invoice, unknown `--to` account, multi-payment-without-selector).
+
+## Related issues
+
+- **Q-014 / Q-015 / Q-016** — the apply paths (`ApplyPayment`, the `txn_guid:` / `txn_split_guid:` retarget) this reverses; the payment-enumeration helper is shared with the unpost orphan-detection.
+- **Q-021 / Q-023** — owner-attached credit lots; a future enhancement could re-home an unapplied payment back onto AR as an owner-attached credit rather than to a plain account.
+- **Q-022** — the "don't constrain account types" lesson applied to `--to`.
+
+---
+
+**Created**: 2026-06-05

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -68,3 +68,4 @@ and in the **Status** column below.
 | [Q-021](Q-021-return-of-credit-bad-debt-and-prepayment-clearing.md) | Return of credit (refund), bad-debt write-off, and prepayment clearing via `lot_owner` | high | closed |
 | [Q-022](Q-022-payment-transfer-account-allows-owner-equity.md) | Invoice/bill payment validation rejects owner's-equity deposit accounts | medium | closed |
 | [Q-023](Q-023-retarget-prepayment-residual-credit-owner.md) | Retarget-with-prepayment residual credit is not owner-attached, invisible to the open_prepayment summary | medium | closed |
+| [Q-024](Q-024-unapply-payment.md) | Unapply a payment from a posted invoice/bill without unposting it | medium | closed |

--- a/tests/integration/test_unapply_payment.py
+++ b/tests/integration/test_unapply_payment.py
@@ -1,0 +1,432 @@
+"""`unapply-payment` peels a payment off a still-posted invoice/bill.
+
+The payment's AR/AP split is detached from the record's lot (so the invoice
+returns to Outstanding, or partial if other payments remain) and re-homed to
+`--to <account>`; the document stays posted and the bank tx is never deleted.
+`--to` is required and accepts any account type.
+"""
+
+import time
+from fractions import Fraction
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+ACCOUNTS = 'tests/fixtures/payment_roundtrip_accounts.txt'
+
+INV_ONE_PAYMENT = """\
+customer "C1"
+\tname: "Cust One"
+\tcurrency: CAD
+
+invoice "INV-1"
+\tcustomer_id: "C1"
+\tcurrency: CAD
+\tdate_opened: 2026-01-01
+\tentry:
+\t\tdate: 2026-01-01
+\t\tdescription: "Svc"
+\t\taccount: "Income:Sales"
+\t\tquantity: 1
+\t\tprice: 100
+\t\ttaxable: false
+\t\ttax_included: false
+\tposted:
+\t\tdate: 2026-01-01
+\t\tdue: 2026-01-31
+\t\tar_account: "Assets:Accounts Receivable"
+\t\tmemo: "INV-1"
+\t\taccumulate: true
+\tpayment:
+\t\tdate: 2026-01-15
+\t\tamount: 40
+\t\tbank_account: "Assets:Bank"
+\t\tmemo: "partial 40"
+"""
+
+INV_TWO_PAYMENTS = INV_ONE_PAYMENT.replace('"INV-1"', '"INV-2"').replace(
+    'memo: "INV-1"', 'memo: "INV-2"') + """\
+\tpayment:
+\t\tdate: 2026-01-20
+\t\tamount: 30
+\t\tbank_account: "Assets:Bank"
+\t\tmemo: "partial 30"
+"""
+
+
+def _runner():
+    return CliRunner()
+
+
+def _new_book(runner, tmp_path):
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    return gf
+
+
+def _import(runner, gf, text, name, tmp_path):
+    p = tmp_path / name
+    p.write_text(text)
+    r = runner.invoke(cli, ['import', str(gf), str(p),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    return r
+
+
+def _bal(gf, name):
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        out = {}
+
+        def walk(a):
+            out[a.get_full_name()] = round(a.GetBalance().to_double(), 2)
+            for c in a.get_children():
+                walk(c)
+        walk(repo.book.get_root_account())
+        return out.get(name, 0.0)
+    finally:
+        repo.close()
+
+
+def _bank_tx_count(gf, bank='Assets.Bank'):
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        def find(a, name):
+            if a.get_full_name() == name:
+                return a
+            for c in a.get_children():
+                g = find(c, name)
+                if g:
+                    return g
+            return None
+        b = find(repo.book.get_root_account(), bank)
+        return len({s.GetParent().GetGUID().to_string() for s in b.GetSplitList()})
+    finally:
+        repo.close()
+
+
+def test_unapply_single_payment_reopens_invoice_and_rehomes(tmp_path):
+    runner = _runner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf, INV_ONE_PAYMENT, 'inv.txt', tmp_path)
+
+    # before: AR = 100 (posting) - 40 (payment) = 60 outstanding
+    assert _bal(gf, 'Assets.Accounts Receivable') == 60.0
+
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'INV-1',
+                            '--to', 'Liabilities'])
+    assert r.exit_code == 0, r.output
+    assert 'unapplied 1 payment' in r.output, r.output
+    time.sleep(1)
+
+    # AR back to full outstanding; the $40 re-homed to Liabilities; bank intact.
+    assert _bal(gf, 'Assets.Accounts Receivable') == 100.0
+    assert abs(_bal(gf, 'Liabilities')) == 40.0
+    assert _bal(gf, 'Assets.Bank') == 40.0
+    assert _bank_tx_count(gf) == 1, 'bank tx must not be deleted'
+
+
+def test_unapply_one_of_two_payments_leaves_partial(tmp_path):
+    runner = _runner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf, INV_TWO_PAYMENTS, 'inv.txt', tmp_path)
+    # AR = 100 - 40 - 30 = 30 outstanding
+    assert _bal(gf, 'Assets.Accounts Receivable') == 30.0
+
+    # find the $30 payment tx guid
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        def find(a, name):
+            if a.get_full_name() == name:
+                return a
+            for c in a.get_children():
+                g = find(c, name)
+                if g:
+                    return g
+            return None
+        bank = find(repo.book.get_root_account(), 'Assets.Bank')
+        guid30 = next(s.GetParent().GetGUID().to_string()
+                      for s in bank.GetSplitList()
+                      if Fraction(s.GetAmount().num(), s.GetAmount().denom()) == 30)
+    finally:
+        repo.close()
+
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'INV-2',
+                            '--txn', guid30, '--to', 'Liabilities'])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    # the $40 stays applied → outstanding 60 (partial); the $30 re-homed
+    assert _bal(gf, 'Assets.Accounts Receivable') == 60.0
+    assert abs(_bal(gf, 'Liabilities')) == 30.0
+
+
+def test_unapply_all_returns_fully_outstanding(tmp_path):
+    runner = _runner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf, INV_TWO_PAYMENTS, 'inv.txt', tmp_path)
+
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'INV-2',
+                            '--all', '--to', 'Liabilities'])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    assert _bal(gf, 'Assets.Accounts Receivable') == 100.0   # fully outstanding
+    assert abs(_bal(gf, 'Liabilities')) == 70.0              # 40 + 30 re-homed
+
+
+def test_multi_payment_without_selector_errors(tmp_path):
+    runner = _runner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf, INV_TWO_PAYMENTS, 'inv.txt', tmp_path)
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'INV-2',
+                            '--to', 'Liabilities'])
+    assert r.exit_code != 0
+    assert '2 payments' in r.output and ('--txn' in r.output or '--all' in r.output), r.output
+    # book untouched
+    assert _bal(gf, 'Assets.Accounts Receivable') == 30.0
+
+
+def test_to_is_required(tmp_path):
+    runner = _runner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf, INV_ONE_PAYMENT, 'inv.txt', tmp_path)
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'INV-1'])
+    assert r.exit_code != 0
+    assert '--to' in r.output, r.output
+
+
+def test_unapply_unknown_invoice_errors(tmp_path):
+    runner = _runner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf, INV_ONE_PAYMENT, 'inv.txt', tmp_path)
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'NOPE',
+                            '--to', 'Liabilities'])
+    assert r.exit_code != 0
+    assert 'not found' in r.output.lower(), r.output
+
+
+def test_unapply_to_unknown_account_errors(tmp_path):
+    runner = _runner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf, INV_ONE_PAYMENT, 'inv.txt', tmp_path)
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'INV-1',
+                            '--to', 'Nonexistent:Account'])
+    assert r.exit_code != 0
+    assert 'not found' in r.output.lower(), r.output
+
+
+BILL_ONE_PAYMENT = """\
+vendor "V1"
+\tname: "Vend One"
+\tcurrency: CAD
+
+bill "BILL-1"
+\tvendor_id: "V1"
+\tcurrency: CAD
+\tdate_opened: 2026-01-01
+\tentry:
+\t\tdate: 2026-01-01
+\t\tdescription: "Supplies"
+\t\taccount: "Expenses:Supplies"
+\t\tquantity: 1
+\t\tprice: 100
+\t\ttaxable: false
+\tposted:
+\t\tdate: 2026-01-01
+\t\tdue: 2026-01-31
+\t\tap_account: "Liabilities:Accounts Payable"
+\t\tmemo: "BILL-1"
+\t\taccumulate: true
+\tpayment:
+\t\tdate: 2026-01-15
+\t\tamount: 40
+\t\tbank_account: "Assets:Bank"
+\t\tmemo: "partial 40"
+"""
+
+
+def _all_splits(gf, account):
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        def find(a, name):
+            if a.get_full_name() == name:
+                return a
+            for c in a.get_children():
+                g = find(c, name)
+                if g:
+                    return g
+            return None
+        acct = find(repo.book.get_root_account(), account)
+        # Exact amount via num()/denom() as a Fraction — never to_double()
+        # (float can't represent decimals exactly) and never to_decimal()
+        # (its signature varies across GnuCash versions). The caller keys on
+        # the split GUID; the amount is only an exact coarse filter.
+        def _exact(s):
+            a = s.GetAmount()
+            return Fraction(a.num(), a.denom())
+        return [(s.GetGUID().to_string(),                 # split's own guid
+                 s.GetParent().GetGUID().to_string(),     # parent tx guid
+                 _exact(s)) for s in acct.GetSplitList()]
+    finally:
+        repo.close()
+
+
+def test_unapply_one_of_several_invoices_on_one_bank_tx(tmp_path):
+    """One $400 bank tx pays INV A/B/C ($100/$120/$180). Unapply B only:
+    B reopens to Outstanding $120; A and C stay paid; the bank tx survives."""
+    runner = _runner()
+    gf = _new_book(runner, tmp_path)
+
+    # pre-existing $400 bank tx with 3 AR splits
+    p = tmp_path / 'bank.txt'
+    p.write_text(Path('tests/fixtures/q016_multi_invoice_bank.txt').read_text())
+    r = runner.invoke(cli, ['import', str(gf), str(p)])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+
+    splits = _all_splits(gf, 'Assets.Accounts Receivable')
+    bank_guid = next(txg for _spg, txg, a in _all_splits(gf, 'Assets.Bank')
+                     if a == 400)
+    sg = {a: spg for spg, _txg, a in splits}   # keys are exact Decimals
+    inv_text = Path('tests/fixtures/q016_multi_invoice_invoices.txt').read_text().format(
+        bank_txn_guid=bank_guid,
+        split_guid_a=sg[-100], split_guid_b=sg[-120], split_guid_c=sg[-180])
+    p2 = tmp_path / 'invs.txt'
+    p2.write_text(inv_text)
+    r = runner.invoke(cli, ['import', str(gf), str(p2), '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+
+    # all 3 paid → AR net 0
+    assert _bal(gf, 'Assets.Accounts Receivable') == 0.0
+
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'INV-Q16-B-120',
+                            '--to', 'Liabilities'])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+
+    # only B reopened: AR = +400 posting − 100(A) − 180(C) = +120 (B outstanding)
+    assert _bal(gf, 'Assets.Accounts Receivable') == 120.0
+    assert abs(_bal(gf, 'Liabilities')) == 120.0   # B's -120 re-homed
+    assert _bank_tx_count(gf) == 1, 'the shared bank tx must survive'
+
+
+def test_unapply_bill_payment(tmp_path):
+    runner = _runner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf, BILL_ONE_PAYMENT, 'bill.txt', tmp_path)
+    # AP = -100 posting + 40 payment = -60 (owe 60)
+    assert _bal(gf, 'Liabilities.Accounts Payable') == -60.0
+
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'BILL-1', '--bill',
+                            '--to', 'Liabilities'])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    # AP back to fully owed; the +40 re-homed
+    assert _bal(gf, 'Liabilities.Accounts Payable') == -100.0
+    assert abs(_bal(gf, 'Liabilities')) == 40.0
+
+
+def test_invoice_stays_posted_after_unapply_and_roundtrips(tmp_path):
+    runner = _runner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf, INV_ONE_PAYMENT, 'inv.txt', tmp_path)
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'INV-1', '--to', 'Liabilities'])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    out = tmp_path / 'exp.txt'
+    r = runner.invoke(cli, ['export', str(gf), str(out), '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    text = out.read_text()
+    # still a posted invoice (not draft / not none), now with no payment
+    assert 'invoice "INV-1"' in text
+    assert 'posted:' in text and 'posted: none' not in text, text
+
+
+# Two payments of the SAME amount — the case that breaks any amount-based
+# matching (a float key collides, and even exact amounts can't disambiguate
+# two identical payments). Selection must be by transaction GUID.
+INV_TWO_SAME = INV_ONE_PAYMENT.replace('"INV-1"', '"INV-SAME"').replace(
+    'memo: "INV-1"', 'memo: "INV-SAME"').replace('memo: "partial 40"', 'memo: "first 40"') + """\
+\tpayment:
+\t\tdate: 2026-01-20
+\t\tamount: 40
+\t\tbank_account: "Assets:Bank"
+\t\tmemo: "second 40"
+"""
+
+
+def test_unapply_one_of_two_same_amount_payments_by_guid(tmp_path):
+    runner = _runner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf, INV_TWO_SAME, 'inv.txt', tmp_path)
+    # AR = 100 - 40 - 40 = 20 outstanding
+    assert _bal(gf, 'Assets.Accounts Receivable') == 20.0
+
+    # two $40 bank txs — distinguishable only by GUID, not amount
+    forties = sorted({txg for _spg, txg, a in _all_splits(gf, 'Assets.Bank')
+                      if a == 40})
+    assert len(forties) == 2, forties
+
+    # peel exactly one of them, named by its GUID
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'INV-SAME',
+                            '--txn', forties[0], '--to', 'Liabilities'])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+
+    # one $40 remains applied → outstanding 60; exactly one $40 re-homed; both
+    # bank txs still present (nothing deleted)
+    assert _bal(gf, 'Assets.Accounts Receivable') == 60.0
+    assert abs(_bal(gf, 'Liabilities')) == 40.0
+    assert _bank_tx_count(gf) == 2
+
+
+# Three payments, two wrong — repeatable --txn peels exactly the named subset.
+INV_THREE = INV_ONE_PAYMENT.replace('"INV-1"', '"INV-3P"').replace(
+    'memo: "INV-1"', 'memo: "INV-3P"').replace('memo: "partial 40"', 'memo: "p40"') + """\
+\tpayment:
+\t\tdate: 2026-01-18
+\t\tamount: 30
+\t\tbank_account: "Assets:Bank"
+\t\tmemo: "p30"
+\tpayment:
+\t\tdate: 2026-01-20
+\t\tamount: 20
+\t\tbank_account: "Assets:Bank"
+\t\tmemo: "p20"
+"""
+
+
+def test_unapply_two_of_three_payments_via_repeated_txn(tmp_path):
+    runner = _runner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf, INV_THREE, 'inv.txt', tmp_path)
+    # AR = 100 - 40 - 30 - 20 = 10 outstanding
+    assert _bal(gf, 'Assets.Accounts Receivable') == 10.0
+
+    bank = {a: txg for _spg, txg, a in _all_splits(gf, 'Assets.Bank')}
+    g40, g20 = bank[40], bank[20]
+
+    # peel the $40 and $20, leaving the $30 applied
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'INV-3P',
+                            '--txn', g40, '--txn', g20, '--to', 'Liabilities'])
+    assert r.exit_code == 0, r.output
+    assert 'unapplied 2 payments' in r.output, r.output
+    time.sleep(1)
+
+    # the $30 stays applied → outstanding 70; the $40+$20 = $60 re-homed
+    assert _bal(gf, 'Assets.Accounts Receivable') == 70.0
+    assert abs(_bal(gf, 'Liabilities')) == 60.0
+    assert _bank_tx_count(gf) == 3, 'all three bank txs survive'

--- a/use_cases/unapply_payment.py
+++ b/use_cases/unapply_payment.py
@@ -1,0 +1,212 @@
+"""Unapply a payment from a posted invoice/bill — without unposting it.
+
+This is the non-destructive inverse of applying a payment. It detaches a
+payment's AR/AP split from the record's posted lot, so the lot reopens — the
+invoice returns to **Outstanding** (or partially-paid if other payments remain)
+— and re-homes that freed split to a user-named account (`--to`). The
+invoice/bill document is untouched and stays **posted**; the bank/income
+transaction is never deleted. Only the freed split's *account* changes (its
+amount is unchanged, so the transaction stays balanced).
+
+Why `--to` is required: an applied payment's AR/AP split had some prior account
+(Imbalance, Income, a clearing account, …) that the apply step overwrote and
+that we never recorded. Money received that is no longer applied to an invoice
+is, in accounting terms, something you may owe back — a payable — but only the
+user knows which account represents that in their chart (it may be a `LIABILITY`
+"Due to shareholder", or even an asset they carry negative). So the destination
+is theirs to name; there is no defensible silent default.
+
+Distinct from unpost: `unpost` drops the record to Draft and destroys the
+posting transaction; `unapply-payment` keeps it posted and only peels off
+payment(s).
+
+Identity is by GUID, never by amount: two payments can share an amount, so the
+selector (`--txn`) and every internal match key on the payment transaction's
+GUID. Amounts are computed exactly (`gnc_numeric` → `Decimal`), never via
+`to_double`. Mechanism (probed on all 10 supported GnuCash builds, no version
+gate): `gnc_lot_remove_split(lot, ar_ap_split)` then
+`xaccSplitSetAccount(split, to)`.
+"""
+
+import ctypes
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import List, Optional
+
+from gnucash.gnucash_core import Book
+
+from infrastructure.gnucash.engine import GncNumericC, load_gnc_engine
+from services.gnucash_importer import (
+    _find_bill_by_guid,
+    _find_bills_by_id,
+    _find_invoice_by_guid,
+    _find_invoices_by_id,
+)
+from use_cases.unpost_business_objects import _resolve_one
+
+
+@dataclass
+class UnapplyResult:
+    """Outcome of unapply-payment for one invoice/bill id."""
+    id: str
+    guid: str = ''
+    kind: str = 'invoice'          # 'invoice' or 'bill'
+    status: str = ''               # see below
+    to_account: str = ''
+    # one (tx_guid, amount_str, currency) per payment peeled off
+    unapplied: List[tuple] = field(default_factory=list)
+    remaining_balance: Decimal = Decimal('0')  # lot's outstanding after unapply
+    detail: str = ''               # human note for error statuses
+
+    # status values:
+    #   'unapplied'      — one or more payments peeled off
+    #   'not_found'      — no such invoice/bill id
+    #   'ambiguous_id'   — legacy duplicate ids; rerun --by-guid
+    #   'not_posted'     — record has no posted lot
+    #   'no_payments'    — posted but nothing applied to peel
+    #   'need_selector'  — >1 payment and neither --txn nor --all given
+    #   'txn_not_found'  — --txn names a tx that is not a payment on this record
+
+
+def _norm_guid(g: str) -> str:
+    return (g or '').replace('-', '').lower()
+
+
+def _amount(numc: GncNumericC) -> Decimal:
+    """Exact value of a gnc_numeric, never via float."""
+    if not numc.denom:
+        return Decimal('0')
+    return Decimal(numc.num) / Decimal(numc.denom)
+
+
+def unapply_payments(book: Book, record, to_account, *, kind='invoice',
+                     txn_guids: Optional[List[str]] = None,
+                     unapply_all: bool = False,
+                     report_id: str = '', report_guid: str = '') -> UnapplyResult:
+    """Peel payment(s) off `record`'s posted lot and re-home the freed AR/AP
+    split(s) to `to_account` (a SWIG Account). Mutates the book in place; the
+    caller is responsible for saving."""
+    res = UnapplyResult(id=report_id or record.GetID(), guid=report_guid,
+                        kind=kind, to_account=to_account.get_full_name())
+
+    lot = record.GetPostedLot()
+    if lot is None:
+        res.status = 'not_posted'
+        return res
+
+    posting = record.GetPostedTxn()
+    posting_guid = _norm_guid(posting.GetGUID().to_string()) if posting else ''
+
+    lib = load_gnc_engine()
+    for name, restype, argtypes in [
+        ('gnc_lot_get_split_list',   ctypes.c_void_p, [ctypes.c_void_p]),
+        ('gnc_lot_remove_split',     None,            [ctypes.c_void_p, ctypes.c_void_p]),
+        ('gnc_lot_get_balance',      GncNumericC,     [ctypes.c_void_p]),
+        ('xaccSplitGetParent',       ctypes.c_void_p, [ctypes.c_void_p]),
+        ('xaccSplitGetAccount',      ctypes.c_void_p, [ctypes.c_void_p]),
+        ('xaccSplitSetAccount',      None,            [ctypes.c_void_p, ctypes.c_void_p]),
+        ('xaccSplitGetAmount',       GncNumericC,     [ctypes.c_void_p]),
+        ('xaccAccountGetType',       ctypes.c_int,    [ctypes.c_void_p]),
+        ('xaccTransGetCurrency',     ctypes.c_void_p, [ctypes.c_void_p]),
+        ('gnc_commodity_get_mnemonic', ctypes.c_char_p, [ctypes.c_void_p]),
+        ('xaccTransBeginEdit',       None,            [ctypes.c_void_p]),
+        ('xaccTransCommitEdit',      None,            [ctypes.c_void_p]),
+        ('qof_instance_get_guid',    ctypes.c_void_p, [ctypes.c_void_p]),
+        ('guid_to_string_buff',      ctypes.c_char_p, [ctypes.c_void_p, ctypes.c_char_p]),
+    ]:
+        f = getattr(lib, name)
+        f.restype = restype
+        f.argtypes = argtypes
+
+    def _txg(tx_ptr) -> str:
+        gp = lib.qof_instance_get_guid(tx_ptr)
+        buf = ctypes.create_string_buffer(40)
+        lib.guid_to_string_buff(gp, buf)
+        return buf.value.decode('ascii').replace('-', '')
+
+    # Walk the lot's AR/AP-side splits and group them by parent transaction.
+    # A payment is ANY transaction with a split in the lot other than the
+    # record's own posting transaction — no dependence on txn_type 'P' (which
+    # isn't reliably set on every version for retargeted/shared-tx payments).
+    # Keyed by transaction GUID, never by amount (amounts can collide).
+    payments = {}   # tx_guid -> {'splits': [ptr], 'amount': Decimal, 'currency': str}
+    g = lib.gnc_lot_get_split_list(int(lot.instance))
+    seen = set()
+    while g:
+        arr = ctypes.cast(g, ctypes.POINTER(ctypes.c_void_p * 2)).contents
+        sp = arr[0]
+        g = arr[1]
+        if not sp or sp in seen:
+            continue
+        seen.add(sp)
+        if lib.xaccAccountGetType(lib.xaccSplitGetAccount(sp)) not in (11, 12):
+            continue
+        tx = lib.xaccSplitGetParent(sp)
+        tg = _txg(tx)
+        if tg == posting_guid:
+            continue                      # the invoice/bill's own posting split
+        entry = payments.get(tg)
+        if entry is None:
+            cur = lib.xaccTransGetCurrency(tx)
+            mn = lib.gnc_commodity_get_mnemonic(cur) if cur else None
+            entry = {'splits': [], 'amount': Decimal('0'),
+                     'currency': mn.decode('ascii', 'replace') if mn else ''}
+            payments[tg] = entry
+        entry['splits'].append(sp)
+        entry['amount'] += abs(_amount(lib.xaccSplitGetAmount(sp)))
+
+    if not payments:
+        res.status = 'no_payments'
+        return res
+
+    if unapply_all:
+        targets = set(payments)
+    elif txn_guids:
+        wants = {_norm_guid(g) for g in txn_guids}
+        missing = wants - set(payments)
+        if missing:
+            res.status = 'txn_not_found'
+            res.detail = ('not payments on ' + res.id + ': '
+                          + ', '.join(sorted(missing))
+                          + '; payments: ' + ', '.join(sorted(payments)))
+            return res
+        targets = wants                       # peel exactly the named subset
+    else:
+        if len(payments) > 1:
+            res.status = 'need_selector'
+            res.detail = (f'{res.id} has {len(payments)} payments — pass '
+                          f'--txn <guid> (repeatable) to peel specific ones, or '
+                          f'--all to unapply all. payments: '
+                          + ', '.join(sorted(payments)))
+            return res
+        targets = set(payments)
+
+    to_ptr = int(to_account.instance)
+    for tg in sorted(targets):
+        for sp in payments[tg]['splits']:
+            tx = lib.xaccSplitGetParent(sp)
+            lib.xaccTransBeginEdit(tx)
+            lib.gnc_lot_remove_split(int(lot.instance), sp)   # reopen the lot
+            lib.xaccSplitSetAccount(sp, to_ptr)               # re-home off AR/AP
+            lib.xaccTransCommitEdit(tx)
+        amt = payments[tg]['amount'].quantize(Decimal('0.01'))
+        res.unapplied.append((tg, str(amt), payments[tg]['currency']))
+
+    res.remaining_balance = _amount(lib.gnc_lot_get_balance(int(lot.instance)))
+    res.status = 'unapplied'
+    return res
+
+
+def execute_unapply(book: Book, ident: str, to_account, *, is_bill=False,
+                    by_guid=False, txn_guids=None, unapply_all=False) -> UnapplyResult:
+    """Resolve one invoice/bill id (or guid) and unapply payment(s) from it."""
+    kind = 'bill' if is_bill else 'invoice'
+    by_id_fn = _find_bills_by_id if is_bill else _find_invoices_by_id
+    by_guid_fn = _find_bill_by_guid if is_bill else _find_invoice_by_guid
+    rec, rid, rguid = _resolve_one(book, ident, by_guid, by_id_fn, by_guid_fn)
+    if rec is None and rguid == '__ambiguous__':
+        return UnapplyResult(id=rid, kind=kind, status='ambiguous_id')
+    if rec is None:
+        return UnapplyResult(id=rid, kind=kind, status='not_found')
+    return unapply_payments(book, rec, to_account, kind=kind, txn_guids=txn_guids,
+                            unapply_all=unapply_all, report_id=rid, report_guid=rguid)


### PR DESCRIPTION
## Summary

Add `unapply-payment`, the non-destructive inverse of applying a payment. It peels a payment off a still-posted invoice/bill — the AR/AP split is detached from the record's posted lot so the lot reopens (invoice returns to Outstanding, or partially-paid if other payments remain) — and re-homes the freed split to a user-named account. The document stays posted and the bank/income transaction is never deleted; only the freed split's account changes, so the transaction stays balanced.

This fills the gap between "the document is wrong" (unpost/void, which drops to Draft and destroys the posting) and "a payment is misplaced" (this). The motivating case: an income/deposit transaction was linked to an invoice but didn't belong to it — you can't delete the transaction and unpost-then-repost is wrong; the right move is to revert to the state before that payment, still posted, not paid.

## CLI

```
gnucash-plaintext unapply-payment <book> <id> --to <account> [--txn <guid> ...] [--all] [--bill] [--by-guid]
```

- `--to` is required and accepts any account type. The freed split's prior account was overwritten by the apply step and never recorded, and money no longer applied to an invoice is a payable you may owe back — only the user knows which account represents that (often a LIABILITY "Due to ...", possibly an asset carried negative). No defensible silent default, so it must be named; type is unconstrained (Q-022 lesson).
- Selection: one payment → no selector; several → `--txn <bank-tx-guid>` to peel one, repeated `--txn` to peel a subset (e.g. two of three wrong payments), or `--all` for every payment. Omitting all selectors on a multi-payment record is an error, never a guess.

## Identity by GUID, never amount

Two payments can share an amount and floats can't represent decimals exactly, so the selector and every internal match key on the payment transaction's GUID; amounts are read exactly (gnc_numeric → Decimal/Fraction), never via to_double. Payment enumeration is also version-robust: a payment is any transaction with a split in the lot other than the record's own posting transaction — not filtered on txn_type 'P', which isn't reliably set on every GnuCash version for retargeted / shared-bank-tx payments (it silently dropped the multi-invoice case on 3.8). The detach primitive gnc_lot_remove_split was probed safe on all 10 supported builds.

## Tests

tests/integration/test_unapply_payment.py (12), passing on GnuCash 3.8 and 5.10: single-payment reopen + re-home; one-of-two → partial; two-of-three via repeated --txn; --all → fully Outstanding; one of several invoices sharing one bank tx (only that invoice reopens, the shared tx survives); two same-amount payments selected by GUID (defeats amount-matching); bill (AP) side; invoice stays posted and round-trips; guards (--to required, unknown invoice, unknown --to account, multi-payment-without-selector).

Documented as issue Q-024; README gains an "Unapplying a payment without unposting" section.