### PR TITLE
fix(Q-025): hint at --strategy update when a GUID-matched edit is skipped

### DIFF
--- a/cli/import_cmd.py
+++ b/cli/import_cmd.py
@@ -295,6 +295,18 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
             click.echo(f"  Conflicts:    {len(result.conflicts)}")
             click.echo(f"  Errors:       {result.error_count}")
 
+            # Hint: some skipped "duplicates" actually had edited content — the
+            # default strategy matches them by GUID and skips, so the edit was
+            # dropped. Point the user at --strategy update (no behaviour change).
+            changed = getattr(result, 'guid_changed_skips', 0)
+            if changed:
+                noun = 'transaction' if changed == 1 else 'transactions'
+                click.echo(
+                    f"\n  Note: {changed} skipped {noun} matched an existing GUID "
+                    f"but had different content — looks like an edit. To apply "
+                    f"such edits in place (preserving the GUID), re-run with "
+                    f"--strategy update.", err=True)
+
             # Surface the actual error text, not just the count, so the user
             # knows what failed and why — e.g. a prepayment-settlement split
             # that found no open credit, or an owner/account mismatch. Goes to

--- a/docs/issues/Q-025-edited-guid-match-skipped-silently.md
+++ b/docs/issues/Q-025-edited-guid-match-skipped-silently.md
@@ -1,0 +1,43 @@
+---
+id: Q-025
+title: Editing a transaction by re-import is silently skipped as a "duplicate"
+category: quality
+severity: low
+status: closed
+---
+
+## Problem
+
+To edit a transaction in place you re-import it with its `guid:` under `--strategy update`. But under the **default** strategy (`skip`), a transaction whose `guid:` matches an existing one is skipped as a duplicate — and the import summary just says `Skipped: 1 (duplicates)`, with no indication that the incoming content actually *differed*. A user who edits a transaction's splits and re-imports (without knowing about `--strategy update`) sees "Nothing to import", their edit silently dropped, and concludes editing isn't supported.
+
+## Fix
+
+Hint only — no behaviour change. When the default strategy skips a GUID match, compare the incoming directive's splits to the existing transaction; if they differ, count it and print a hint after the summary:
+
+```
+  Note: 1 skipped transaction matched an existing GUID but had different
+  content — looks like an edit. To apply such edits in place (preserving the
+  GUID), re-run with --strategy update.
+```
+
+A plain re-import of unchanged transactions does **not** trigger the hint (the content is identical, so it really is a duplicate). The comparison is exact — each split's (account path, `Fraction(num, denom)` amount), never `to_double` — so an unchanged re-import never false-positives and an edited amount always does.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `use_cases/import_transactions.py` | `_guid_match_content_differs(child, existing_tx)`; the default-strategy GUID-match branch counts changed-content skips into `ImportResult.guid_changed_skips`. |
+| `cli/import_cmd.py` | Emit the `--strategy update` hint to stderr when `guid_changed_skips > 0`. |
+| `tests/integration/test_import_edit_hint.py` | Edited GUID match → hint + book unchanged; unchanged GUID match → skipped, no hint; `--strategy update` → edit applied. |
+
+## Tests
+
+On GnuCash 3.8 and 5.10, plus the existing dedup / import / roundtrip guardrails (which must keep skipping unchanged re-imports without the hint).
+
+## Related issues
+
+- **Q-020** — the duplicate-vs-conflict signature matcher; this adds the analogous content check to the GUID-match fast path, which previously skipped unconditionally.
+
+---
+
+**Created**: 2026-06-06

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -69,3 +69,4 @@ and in the **Status** column below.
 | [Q-022](Q-022-payment-transfer-account-allows-owner-equity.md) | Invoice/bill payment validation rejects owner's-equity deposit accounts | medium | closed |
 | [Q-023](Q-023-retarget-prepayment-residual-credit-owner.md) | Retarget-with-prepayment residual credit is not owner-attached, invisible to the open_prepayment summary | medium | closed |
 | [Q-024](Q-024-unapply-payment.md) | Unapply a payment from a posted invoice/bill without unposting it | medium | closed |
+| [Q-025](Q-025-edited-guid-match-skipped-silently.md) | Editing a transaction by re-import is silently skipped as a "duplicate" | low | closed |

--- a/tests/integration/test_import_edit_hint.py
+++ b/tests/integration/test_import_edit_hint.py
@@ -1,0 +1,124 @@
+"""Default-strategy import skips a GUID-matched transaction as a "duplicate".
+When the incoming content actually DIFFERS (the user edited the tx), the edit is
+silently dropped — so the import now hints at `--strategy update`. This is a
+hint only: behaviour is unchanged (still skipped by default).
+"""
+
+import time
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+ACCOUNTS = 'tests/fixtures/payment_roundtrip_accounts.txt'
+TX = '2026-01-01 * "Deposit"\n\tAssets:Bank 200.00 CAD\n\tIncome -200.00 CAD\n'
+
+
+def _new_book(runner, tmp_path):
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    return gf
+
+
+def _import(runner, gf, text, name, tmp_path, *extra):
+    p = tmp_path / name
+    p.write_text(text)
+    return runner.invoke(cli, ['import', str(gf), str(p), *extra])
+
+
+def _bal(gf, name):
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        out = {}
+
+        def walk(a):
+            out[a.get_full_name()] = round(a.GetBalance().to_double(), 2)
+            for c in a.get_children():
+                walk(c)
+        walk(repo.book.get_root_account())
+        return out.get(name, 0.0)
+    finally:
+        repo.close()
+
+
+def _guid200(gf):
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        def find(a, n):
+            if a.get_full_name() == n:
+                return a
+            for c in a.get_children():
+                g = find(c, n)
+                if g:
+                    return g
+            return None
+        bank = find(repo.book.get_root_account(), 'Assets.Bank')
+        s = next(s for s in bank.GetSplitList()
+                 if abs(s.GetAmount().to_double() - 200.0) < 0.01)
+        return s.GetParent().GetGUID().to_string().replace('-', '')
+    finally:
+        repo.close()
+
+
+def _edited(guid):
+    return (f'2026-01-01 * "Deposit"\n\tguid: "{guid}"\n'
+            f'\tAssets:Bank 200.00 CAD\n'
+            f'\tAssets:Accounts Receivable -200.00 CAD\n')
+
+
+def _unchanged(guid):
+    return (f'2026-01-01 * "Deposit"\n\tguid: "{guid}"\n'
+            f'\tAssets:Bank 200.00 CAD\n\tIncome -200.00 CAD\n')
+
+
+def test_edited_guid_match_skipped_with_hint_and_unchanged(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    assert _import(runner, gf, TX, 'tx.txt', tmp_path).exit_code == 0
+    time.sleep(1)
+    guid = _guid200(gf)
+
+    r = _import(runner, gf, _edited(guid), 'edit.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+    # hint fired (content differs) and the edit was NOT applied by default
+    assert 'strategy update' in r.output.lower(), r.output
+    assert 'different content' in r.output.lower(), r.output
+    time.sleep(1)
+    assert _bal(gf, 'Income') == -200.0                       # unchanged
+    assert _bal(gf, 'Assets.Accounts Receivable') == 0.0
+
+
+def test_unchanged_guid_match_skipped_without_hint(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    assert _import(runner, gf, TX, 'tx.txt', tmp_path).exit_code == 0
+    time.sleep(1)
+    guid = _guid200(gf)
+
+    r = _import(runner, gf, _unchanged(guid), 'same.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+    assert 'Skipped:      1' in r.output, r.output
+    # identical content → it really is a duplicate → NO edit hint
+    assert 'strategy update' not in r.output.lower(), r.output
+
+
+def test_strategy_update_applies_the_edit(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    assert _import(runner, gf, TX, 'tx.txt', tmp_path).exit_code == 0
+    time.sleep(1)
+    guid = _guid200(gf)
+
+    r = _import(runner, gf, _edited(guid), 'edit.txt', tmp_path,
+                '--strategy', 'update')
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    # edit applied in place: the Income split is now on AR
+    assert _bal(gf, 'Income') == 0.0
+    assert _bal(gf, 'Assets.Accounts Receivable') == -200.0

--- a/use_cases/import_transactions.py
+++ b/use_cases/import_transactions.py
@@ -32,6 +32,11 @@ class ImportResult:
         self.conflicts = []
         self.errors = []
         self.new_transactions = []  # Transaction objects created during this import
+        # GUID-match skips (default strategy) whose incoming content actually
+        # DIFFERS from the existing transaction — i.e. the user edited the tx
+        # but the edit was skipped as a "duplicate". Drives a hint at
+        # --strategy update. A plain re-import of unchanged txs does not count.
+        self.guid_changed_skips = 0
 
     def get_summary(self) -> str:
         """Get summary string"""
@@ -43,6 +48,48 @@ class ImportResult:
         lines.append(f"Conflicts: {len(self.conflicts)}")
         lines.append(f"Errors: {self.error_count}")
         return "\n".join(lines)
+
+
+def _guid_match_content_differs(child, existing_tx) -> bool:
+    """True when an incoming transaction directive's content differs from the
+    existing transaction it matched by GUID — i.e. the user edited it.
+
+    Compares each split's (account path, exact amount) as a sorted multiset.
+    Amounts are compared exactly via `Fraction(num, denom)`, never float, so an
+    unchanged re-import never reports a difference and an edited amount always
+    does. Used only to decide whether to hint at `--strategy update`; it never
+    changes import behaviour."""
+    from decimal import Decimal, InvalidOperation
+    from fractions import Fraction
+
+    from infrastructure.gnucash.utils import get_account_full_name
+
+    def _incoming():
+        out = []
+        for s in child.children:
+            acct = s.props.get('account')
+            if not acct:
+                continue
+            raw = str(s.props.get('amount', '0')).replace('+', '').strip()
+            try:
+                val = str(Fraction(Decimal(raw)))
+            except (InvalidOperation, ValueError, ZeroDivisionError):
+                val = raw
+            out.append((acct, val))
+        return sorted(out)
+
+    def _existing():
+        out = []
+        for sp in existing_tx.GetSplitList():
+            a = sp.GetAccount()
+            if a is None:
+                continue
+            amt = sp.GetAmount()
+            out.append((get_account_full_name(a),
+                        str(Fraction(amt.num(), amt.denom()))))
+        return sorted(out)
+
+    return _incoming() != _existing()
 
 
 class ImportTransactionsUseCase:
@@ -322,9 +369,18 @@ class ImportTransactionsUseCase:
                                 for s in child.children
                                 if s.props.get('account')
                             )
+                            # If the incoming content actually differs from the
+                            # existing tx, the user is editing — but the default
+                            # strategy skips it. Count that so the CLI can hint
+                            # at --strategy update (it is not a true duplicate).
+                            changed = _guid_match_content_differs(
+                                child, existing_guid_map[guid])
+                            if changed:
+                                result.guid_changed_skips += 1
                             logging.warning(
-                                "Skipping duplicate (GUID match): %s \"%s\" [%s]\n"
+                                "Skipping %s (GUID match): %s \"%s\" [%s]\n"
                                 "  matched existing transaction by GUID: %s",
+                                'EDITED transaction' if changed else 'duplicate',
                                 _date, _desc, _splits, guid,
                             )
                             result.skipped_count += 1


### PR DESCRIPTION
## Summary

To edit a transaction in place you re-import it with its guid: under --strategy update. But under the default strategy (skip), a transaction whose guid: matches an existing one is skipped as a duplicate, and the summary only says "Skipped: 1 (duplicates)". A user who edits a transaction's splits and re-imports without knowing about --strategy update sees "Nothing to import", their edit silently dropped, and concludes editing isn't supported.

This adds a hint — no behaviour change. When the default strategy skips a GUID match, the importer compares the incoming directive's splits to the existing transaction; if they differ (the user edited it), it counts that and the CLI prints after the summary:

    Note: 1 skipped transaction matched an existing GUID but had different content — looks like an edit. To apply such edits in place (preserving the GUID), re-run with --strategy update.

A plain re-import of unchanged transactions does not trigger the hint — the content is identical, so it really is a duplicate. The comparison is exact: each split's (account path, Fraction(num, denom) amount), never to_double, so an unchanged re-import never false-positives and an edited amount always does. Behaviour is unchanged: the transaction is still skipped by default; only the message is more helpful.

## Tests

tests/integration/test_import_edit_hint.py (3), on GnuCash 3.8 and 5.10: an edited GUID match is skipped, prints the hint, and leaves the book unchanged; an unchanged GUID match is skipped with no hint; --strategy update applies the edit in place. The Q-020 dedup, cli-import, and roundtrip guardrails still pass (unchanged re-imports keep skipping silently).

Documented as issue Q-025.