### PR TITLE
fix(Q-026,Q-027): per-record payment amount allocation + account GUID roundtrip

### DIFF
--- a/docs/issues/Q-026-multi-invoice-payment-amount-allocation.md
+++ b/docs/issues/Q-026-multi-invoice-payment-amount-allocation.md
@@ -1,0 +1,41 @@
+---
+id: Q-026
+title: One bank tx paying multiple invoices/bills exports the bank total as each record's payment amount
+category: quality
+severity: medium
+status: closed
+---
+
+## Problem
+
+When a single bank transaction pays several invoices/bills (the Q-016 shared-bank-tx shape — one bank split plus one AR/AP split per record), the exporter wrote each record's `payment: amount:` as the **whole bank-tx total** instead of that record's own allocation. A $400 wire across three invoices ($100/$120/$180) exported `amount: 400` on **every** invoice. Both exporters were affected: the round-trip business-object export (`export_business_objects.py`) and the `print-invoice` / `print-bill` render (`invoice_renderer.py`, `bill_renderer.py`) — each read the bank-side split's amount rather than the AR/AP split sitting in the record's own lot.
+
+It is an audit-fidelity bug: re-import attaches each portion by `txn_split_guid:` (by GUID), so the wrong `amount:` round-trips invisibly and the reconstructed book is correct — which is why no test caught it. The structural roundtrip tests compare reconstructed state (lots/balances/GUIDs), and that state does not depend on the `amount:` text; single-invoice tests can't expose it because with one AR split the allocation equals the bank total.
+
+## Fix
+
+Emit each record's **own allocation** — the AR/AP split in its lot (`in_lot_ar_ap_split` / the lot split `s`) — not the bank-side total. While here, format the amount **exactly and currency-correctly**: a new `format_amount_for_commodity` reads the value via `num()/denom()` into a `Decimal` and quantizes to the commodity's own decimal count (`get_fraction()`), never via `to_double()`. So a 2-decimal currency exports `100.00` and a 0-decimal currency (JPY, fraction 1) exports `1000` — driven by the book's commodity definition. The sibling `prepayment:` residual is summed exactly (Fraction) and formatted the same way.
+
+Note: GnuCash's commodity table records KRW with fraction 100 (2 decimals) despite real-world KRW being 0-decimal; the exporter faithfully follows whatever fraction the book's commodity defines.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `infrastructure/gnucash/utils.py` | `format_amount_for_commodity(number, commodity)` — exact, currency-decimal-count formatting (no `to_double`). |
+| `use_cases/export_business_objects.py` | Payment `amount:` from the in-lot AR/AP split; exact `prepayment:` sum; both formatted via the new helper. |
+| `services/invoice_renderer.py`, `services/bill_renderer.py` | Payment `amount:` from the lot split, currency-formatted. |
+| `tests/fixtures/business_objects_only.txt` | Reference updated to the currency-decimal payment amounts (`210.00`, …). |
+| `tests/integration/test_multi_invoice_payment_amount.py` | New: per-invoice and per-bill allocation on a shared bank tx; print-invoice render allocation; JPY 0-decimal amount. |
+
+## Tests
+
+On GnuCash 3.8 and 5.10: multi-invoice export emits `100.00/120.00/180.00` (not `400`), multi-bill emits `90.00/110.00/160.00`, the print-invoice render emits the allocation, and a JPY invoice exports `1000` (0-decimal). The `business_objects_only.txt` roundtrip and the overpayment / fresh-roundtrip suites still pass.
+
+## Related issues
+
+- **Q-016** — the shared-bank-tx multi-invoice mechanism (`txn_split_guid:`) whose per-record amount this corrects.
+
+---
+
+**Created**: 2026-06-06

--- a/docs/issues/Q-027-account-guid-not-preserved-on-import.md
+++ b/docs/issues/Q-027-account-guid-not-preserved-on-import.md
@@ -1,0 +1,37 @@
+---
+id: Q-027
+title: Account GUIDs are not preserved on import, so they drift every roundtrip
+category: quality
+severity: medium
+status: closed
+---
+
+## Problem
+
+The exporter emits `guid:` on every `open` account directive (for external cross-reference, like every other object), and `'guid'` is a known account metadata key — but `create_account` never applied it. GnuCash minted a fresh GUID for each account on import, so account GUIDs **drifted on every export → import roundtrip**. The transaction, split, posting-tx, and customer/vendor/invoice/bill GUIDs were all already preserved; accounts were the lone exception, leaving external references to accounts by GUID broken across a roundtrip.
+
+Found via a double-roundtrip probe (export → import → export): every GUID matched except the account GUIDs, which were re-minted.
+
+## Fix
+
+`create_account` now applies the declared `guid:` to the freshly created account via the existing `_set_object_guid` helper (ctypes `qof_instance_set_guid`, with the same book-wide uniqueness guard used for customers/vendors). Only newly created accounts are affected — re-import of an existing account returns early as before. Hand-written files may still omit `guid:` (GnuCash assigns one on first import); on re-export that GUID is then preserved.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `services/gnucash_importer.py` | `create_account` sets the account GUID from the declared `guid:` via `_set_object_guid`. |
+| `tests/integration/test_multi_invoice_payment_amount.py` | `test_double_roundtrip_preserves_every_guid`: export → fresh import → export must keep **every** guid-bearing line identical (account, tx, split, posting, owner). |
+
+## Tests
+
+The double-roundtrip test fails on the pre-fix code (account `guid:` lines differ between the two exports) and passes after. Verified on GnuCash 3.8 and 5.10; the business-objects roundtrip and the rest of the suite still pass.
+
+## Related issues
+
+- **Q-006** — full GUID emission + the `_set_object_guid` mechanism for forcing a created object's GUID; this extends it to accounts.
+- **Q-016** — transaction/split GUID preservation; accounts were the remaining gap.
+
+---
+
+**Created**: 2026-06-06

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -70,3 +70,5 @@ and in the **Status** column below.
 | [Q-023](Q-023-retarget-prepayment-residual-credit-owner.md) | Retarget-with-prepayment residual credit is not owner-attached, invisible to the open_prepayment summary | medium | closed |
 | [Q-024](Q-024-unapply-payment.md) | Unapply a payment from a posted invoice/bill without unposting it | medium | closed |
 | [Q-025](Q-025-edited-guid-match-skipped-silently.md) | Editing a transaction by re-import is silently skipped as a "duplicate" | low | closed |
+| [Q-026](Q-026-multi-invoice-payment-amount-allocation.md) | One bank tx paying multiple invoices/bills exports the bank total as each record's payment amount | medium | closed |
+| [Q-027](Q-027-account-guid-not-preserved-on-import.md) | Account GUIDs are not preserved on import, so they drift every roundtrip | medium | closed |

--- a/infrastructure/gnucash/utils.py
+++ b/infrastructure/gnucash/utils.py
@@ -212,6 +212,24 @@ def to_string_with_decimal_point_placed(number: GncNumeric) -> str:
         return '0.' + '0' * (point_place - len(numerator)) + numerator
 
 
+def format_amount_for_commodity(number, commodity) -> str:
+    """Exact amount string at the commodity's own decimal count.
+
+    GnuCash records each commodity's smallest unit as `get_fraction()` (100 for
+    a 2-decimal currency like CAD, 1 for JPY/0-decimal, 1000 for 3-decimal). We
+    read the value exactly via num()/denom() (or numerator/denominator for a
+    Fraction) into a Decimal and quantize to that many places — never via
+    `to_double()` (precision loss) and never guessing decimals from the
+    numeric's own denominator (which may not be the commodity's SCU)."""
+    frac = commodity.get_fraction() if commodity is not None else 100
+    places = max(0, len(str(int(frac))) - 1)
+    if isinstance(number, Fraction):
+        d = Decimal(number.numerator) / Decimal(number.denominator)
+    else:
+        d = Decimal(number.num()) / Decimal(number.denom())
+    return str(d.quantize(Decimal(1).scaleb(-places)))
+
+
 def escape_string(s: str) -> str:
     """
     Escape special characters in string for plaintext format.

--- a/services/bill_renderer.py
+++ b/services/bill_renderer.py
@@ -362,7 +362,10 @@ def render_to_plaintext(bill, book, company_info=None) -> str:
         f'\tdate_opened: {date_opened}',
     ]
 
-    from infrastructure.gnucash.utils import get_account_full_name
+    from infrastructure.gnucash.utils import (
+        format_amount_for_commodity,
+        get_account_full_name,
+    )
 
     for raw_entry, entry_amount, entry_tax, breakdown in entries_data:
         ent_ptr = int(raw_entry.instance)
@@ -429,7 +432,6 @@ def render_to_plaintext(bill, book, company_info=None) -> str:
                     continue
                 pay_date = txn.GetDate().strftime('%Y-%m-%d')
                 bank_name = ''
-                pay_amt = 0.0
                 pay_memo = ''
                 for i in range(txn.CountSplits()):
                     sp = txn.GetSplit(i)
@@ -438,12 +440,17 @@ def render_to_plaintext(bill, book, company_info=None) -> str:
                         gc.ACCT_TYPE_RECEIVABLE, gc.ACCT_TYPE_PAYABLE,
                     ):
                         bank_name = get_account_full_name(sp.GetAccount())
-                        pay_amt = abs(sp.GetAmount().to_double())
                         pay_memo = sp.GetMemo() or ''
                         break
+                # This bill's payment amount is its own allocation — the AP
+                # split in its lot (`s`) — not the bank-side total, which would
+                # over-report when one bank tx pays several bills. Format exactly
+                # at the AP commodity's decimal count (no to_double).
+                pay_amt = format_amount_for_commodity(
+                    s.GetAmount().abs(), s.GetAccount().GetCommodity())
                 bill_lines.append('\tpayment:')
                 bill_lines.append(f'\t\tdate: {pay_date}')
-                bill_lines.append(f'\t\tamount: {pay_amt:g}')
+                bill_lines.append(f'\t\tamount: {pay_amt}')
                 bill_lines.append(f'\t\tbank_account: "{bank_name}"')
                 bill_lines.append(f'\t\tmemo: "{pay_memo}"')
                 had_payment = True

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -2080,6 +2080,17 @@ class GnuCashImporter:
         account.SetDescription(description)
         account.SetTaxRelated(tax_related)
 
+        # Preserve the account's GUID across export → import, like the
+        # transaction/split/business-object paths already do. The exporter
+        # emits `guid:` on every `open` directive for external cross-reference;
+        # without honouring it the importer would mint a fresh GUID, so account
+        # GUIDs would drift on every roundtrip. Only applies to a freshly
+        # created account (existing ones return above).
+        declared_guid = directive.metadata.get('guid')
+        if declared_guid:
+            _set_object_guid(book, account, 'account', account_fullname,
+                             _normalise_guid(declared_guid))
+
         custom_meta = {k: v for k, v in directive.metadata.items()
                        if k not in KNOWN_ACCOUNT_METADATA_KEYS and v is not None}
         if custom_meta:

--- a/services/invoice_renderer.py
+++ b/services/invoice_renderer.py
@@ -658,7 +658,10 @@ def render_to_plaintext(invoice, book, company_info=None) -> str:
         inv_lines.append(f'\tnotes: "{invoice.GetNotes()}"')
 
     # Per-entry blocks with informational fields
-    from infrastructure.gnucash.utils import get_account_full_name
+    from infrastructure.gnucash.utils import (
+        format_amount_for_commodity,
+        get_account_full_name,
+    )
 
     for raw_entry, entry_amount, entry_tax, breakdown in entries_data:
         ent_ptr = int(raw_entry.instance)
@@ -734,21 +737,26 @@ def render_to_plaintext(invoice, book, company_info=None) -> str:
                 if gc.gncInvoiceGetInvoiceFromTxn(txn.instance) is not None:
                     continue
                 pay_date = txn.GetDate().strftime('%Y-%m-%d')
-                # bank-side split = the non-AR side; find any
+                # bank-side split = the non-AR side; find any (for the account
+                # name + memo only)
                 bank_name = ''
-                pay_amt = 0.0
                 pay_memo = ''
                 for i in range(txn.CountSplits()):
                     sp = txn.GetSplit(i)
                     atype = gc.xaccAccountGetType(sp.GetAccount().instance)
                     if atype not in (gc.ACCT_TYPE_RECEIVABLE, gc.ACCT_TYPE_PAYABLE):
                         bank_name = get_account_full_name(sp.GetAccount())
-                        pay_amt = abs(sp.GetAmount().to_double())
                         pay_memo = sp.GetMemo() or ''
                         break
+                # This invoice's payment amount is its own allocation — the AR
+                # split in its lot (`s`) — not the bank-side total, which would
+                # over-report when one bank tx pays several invoices. Format
+                # exactly at the AR commodity's decimal count (no to_double).
+                pay_amt = format_amount_for_commodity(
+                    s.GetAmount().abs(), s.GetAccount().GetCommodity())
                 inv_lines.append('\tpayment:')
                 inv_lines.append(f'\t\tdate: {pay_date}')
-                inv_lines.append(f'\t\tamount: {pay_amt:g}')
+                inv_lines.append(f'\t\tamount: {pay_amt}')
                 inv_lines.append(f'\t\tbank_account: "{bank_name}"')
                 inv_lines.append(f'\t\tmemo: "{pay_memo}"')
                 had_payment = True

--- a/tests/fixtures/business_objects_only.txt
+++ b/tests/fixtures/business_objects_only.txt
@@ -83,7 +83,7 @@ invoice "INV-2026-003"
 		accumulate: true
 	payment:
 		date: 2026-01-25
-		amount: 210
+		amount: 210.00
 		bank_account: "Assets:Bank"
 		memo: "Payment for INV-2026-003"
 
@@ -109,12 +109,12 @@ invoice "INV-2026-004"
 		accumulate: true
 	payment:
 		date: 2026-02-10
-		amount: 100
+		amount: 100.00
 		bank_account: "Assets:Bank"
 		memo: "Partial payment 1 for INV-2026-004"
 	payment:
 		date: 2026-02-20
-		amount: 100
+		amount: 100.00
 		bank_account: "Assets:Bank"
 		memo: "Partial payment 2 for INV-2026-004"
 
@@ -140,12 +140,12 @@ invoice "INV-2026-005"
 		accumulate: true
 	payment:
 		date: 2026-02-15
-		amount: 200
+		amount: 200.00
 		bank_account: "Assets:Bank"
 		memo: "First payment for INV-2026-005"
 	payment:
 		date: 2026-02-28
-		amount: 220
+		amount: 220.00
 		bank_account: "Assets:Bank"
 		memo: "Final payment for INV-2026-005"
 
@@ -204,7 +204,7 @@ bill "BILL-2026-003"
 		accumulate: true
 	payment:
 		date: 2026-01-25
-		amount: 200
+		amount: 200.00
 		bank_account: "Assets:Bank"
 		memo: "Payment for BILL-2026-003"
 
@@ -228,12 +228,12 @@ bill "BILL-2026-004"
 		accumulate: true
 	payment:
 		date: 2026-02-10
-		amount: 100
+		amount: 100.00
 		bank_account: "Assets:Bank"
 		memo: "Partial payment 1 for BILL-2026-004"
 	payment:
 		date: 2026-02-20
-		amount: 100
+		amount: 100.00
 		bank_account: "Assets:Bank"
 		memo: "Partial payment 2 for BILL-2026-004"
 
@@ -257,11 +257,11 @@ bill "BILL-2026-005"
 		accumulate: true
 	payment:
 		date: 2026-02-15
-		amount: 200
+		amount: 200.00
 		bank_account: "Assets:Bank"
 		memo: "First payment for BILL-2026-005"
 	payment:
 		date: 2026-02-28
-		amount: 200
+		amount: 200.00
 		bank_account: "Assets:Bank"
 		memo: "Final payment for BILL-2026-005"

--- a/tests/integration/test_multi_invoice_payment_amount.py
+++ b/tests/integration/test_multi_invoice_payment_amount.py
@@ -1,0 +1,220 @@
+"""A single bank tx paying multiple invoices/bills must export each record's
+`payment: amount:` as that record's own allocation (its AR/AP split in its own
+lot), NOT the whole bank-tx total.
+
+Re-import attaches each portion by `txn_split_guid:` (by GUID), so a wrong
+`amount:` round-trips invisibly — the structural roundtrip test can't see it.
+These tests assert the exported amount text directly.
+"""
+
+import re
+import time
+from fractions import Fraction
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+ACCOUNTS = 'tests/fixtures/payment_roundtrip_accounts.txt'
+
+
+def _new_book(runner, tmp_path):
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    return gf
+
+
+def _splits(gf, account):
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        def find(a, n):
+            if a.get_full_name() == n:
+                return a
+            for c in a.get_children():
+                g = find(c, n)
+                if g:
+                    return g
+            return None
+        ac = find(repo.book.get_root_account(), account)
+        return [(s.GetGUID().to_string(),
+                 s.GetParent().GetGUID().to_string(),
+                 Fraction(s.GetAmount().num(), s.GetAmount().denom()))
+                for s in ac.GetSplitList()]
+    finally:
+        repo.close()
+
+
+def _import_text(runner, gf, text, name, tmp_path):
+    p = tmp_path / name
+    p.write_text(text)
+    r = runner.invoke(cli, ['import', str(gf), str(p), '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+
+
+def _export(runner, gf, tmp_path):
+    out = tmp_path / 'exp.txt'
+    r = runner.invoke(cli, ['export', str(gf), str(out), '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    return out.read_text()
+
+
+def _payment_amounts(text):
+    """Map invoice/bill id -> its first payment block's `amount:` value."""
+    out = {}
+    cur = None
+    in_payment = False
+    for line in text.splitlines():
+        st = line.strip()
+        m = re.match(r'(?:invoice|bill) "([^"]+)"', st)
+        if m:
+            cur = m.group(1)
+            in_payment = False
+            continue
+        if cur and st == 'payment:':
+            in_payment = True
+            continue
+        if cur and in_payment and st.startswith('amount:'):
+            out[cur] = st.split('amount:', 1)[1].strip()
+            in_payment = False
+    return out
+
+
+def _build_multi_invoice(runner, tmp_path):
+    gf = _new_book(runner, tmp_path)
+    _import_text(runner, gf, Path('tests/fixtures/q016_multi_invoice_bank.txt').read_text(),
+                 'bank.txt', tmp_path)
+    ar = _splits(gf, 'Assets.Accounts Receivable')
+    bank_guid = next(t for _s, t, a in _splits(gf, 'Assets.Bank') if a == 400)
+    sg = {a: s for s, _t, a in ar}
+    inv = Path('tests/fixtures/q016_multi_invoice_invoices.txt').read_text().format(
+        bank_txn_guid=bank_guid, split_guid_a=sg[-100], split_guid_b=sg[-120],
+        split_guid_c=sg[-180])
+    _import_text(runner, gf, inv, 'inv.txt', tmp_path)
+    return gf
+
+
+def _build_multi_bill(runner, tmp_path):
+    gf = _new_book(runner, tmp_path)
+    _import_text(runner, gf, Path('tests/fixtures/q016_multi_bill_bank.txt').read_text(),
+                 'bank.txt', tmp_path)
+    ap = _splits(gf, 'Liabilities.Accounts Payable')
+    bank_guid = next(t for _s, t, a in _splits(gf, 'Assets.Bank') if a == -360)
+    sg = {a: s for s, _t, a in ap}
+    bills = Path('tests/fixtures/q016_multi_bill_bills.txt').read_text().format(
+        bank_txn_guid=bank_guid, split_guid_a=sg[90], split_guid_b=sg[110],
+        split_guid_c=sg[160])
+    _import_text(runner, gf, bills, 'bills.txt', tmp_path)
+    return gf
+
+
+def test_multi_invoice_export_amount_is_per_invoice_allocation(tmp_path):
+    runner = CliRunner()
+    gf = _build_multi_invoice(runner, tmp_path)
+    amts = _payment_amounts(_export(runner, gf, tmp_path))
+    assert amts.get('INV-Q16-A-100') == '100.00', amts
+    assert amts.get('INV-Q16-B-120') == '120.00', amts
+    assert amts.get('INV-Q16-C-180') == '180.00', amts
+
+
+def test_multi_bill_export_amount_is_per_bill_allocation(tmp_path):
+    runner = CliRunner()
+    gf = _build_multi_bill(runner, tmp_path)
+    amts = _payment_amounts(_export(runner, gf, tmp_path))
+    assert amts.get('BILL-Q16-A-90') == '90.00', amts
+    assert amts.get('BILL-Q16-B-110') == '110.00', amts
+    assert amts.get('BILL-Q16-C-160') == '160.00', amts
+
+
+def test_print_invoice_render_amount_is_per_invoice_allocation(tmp_path):
+    runner = CliRunner()
+    gf = _build_multi_invoice(runner, tmp_path)
+    out = tmp_path / 'inv.txt'
+    r = runner.invoke(cli, ['print-invoice', str(gf), 'INV-Q16-B-120',
+                            '--format', 'plaintext', '--output', str(out)])
+    assert r.exit_code == 0, r.output
+    assert _payment_amounts(out.read_text()).get('INV-Q16-B-120') == '120.00', out.read_text()
+
+
+# A zero-decimal currency (JPY: GnuCash SCU fraction = 1) must export whole
+# amounts — `1000`, never `1000.00` — proving the amount is formatted to the
+# commodity's own decimal count. (GnuCash's table records KRW with fraction 100
+# / 2 decimals despite real-world KRW being 0-decimal; the exporter faithfully
+# follows whatever fraction the book's commodity defines.)
+def _jpy_accounts(mnem):
+    return '\n'.join(
+        f'2026-01-01 open {name}\n'
+        f'\ttype: {atype}\n'
+        f'\tcommodity.namespace: "CURRENCY"\n'
+        f'\tcommodity.mnemonic: "{mnem}"'
+        for name, atype in [
+            ('Assets', 'Asset'),
+            ('Assets:Accounts Receivable', 'Accounts Receivable'),
+            ('Assets:Bank', 'Bank'),
+            ('Income', 'Income'),
+            ('Income:Sales', 'Income'),
+        ]) + '\n'
+
+
+def _zero_decimal_invoice(mnem):
+    return (
+        f'customer "C-{mnem}"\n\tname: "Co"\n\tcurrency: {mnem}\n\n'
+        f'invoice "INV-{mnem}"\n\tcustomer_id: "C-{mnem}"\n\tcurrency: {mnem}\n'
+        '\tdate_opened: 2026-01-01\n'
+        '\tentry:\n\t\tdate: 2026-01-01\n\t\tdescription: "Svc"\n'
+        '\t\taccount: "Income:Sales"\n\t\tquantity: 1\n\t\tprice: 1000\n'
+        '\t\ttaxable: false\n\t\ttax_included: false\n'
+        '\tposted:\n\t\tdate: 2026-01-01\n\t\tdue: 2026-01-31\n'
+        '\t\tar_account: "Assets:Accounts Receivable"\n\t\tmemo: "INV"\n'
+        '\t\taccumulate: true\n'
+        '\tpayment:\n\t\tdate: 2026-01-15\n\t\tamount: 1000\n'
+        '\t\tbank_account: "Assets:Bank"\n\t\tmemo: "paid"\n')
+
+
+@pytest.mark.parametrize('mnem', ['JPY'])
+def test_zero_decimal_currency_payment_amount_has_no_decimals(tmp_path, mnem):
+    runner = CliRunner()
+    gf = tmp_path / 'book.gnucash'
+    acc = tmp_path / 'acc.txt'
+    acc.write_text(_jpy_accounts(mnem))
+    assert runner.invoke(cli, ['import', '--new', str(gf), str(acc)]).exit_code == 0
+    time.sleep(1)
+    _import_text(runner, gf, _zero_decimal_invoice(mnem), 'inv.txt', tmp_path)
+    amts = _payment_amounts(_export(runner, gf, tmp_path))
+    assert amts.get(f'INV-{mnem}') == '1000', amts   # 0-decimal: no ".00"
+
+
+def test_double_roundtrip_preserves_every_guid(tmp_path):
+    """export → import (fresh book) → export must preserve EVERY GUID — account,
+    transaction, split, posting-tx, and customer/vendor/invoice/bill. Account
+    GUIDs were silently re-minted on import, so they drifted each roundtrip;
+    this pins that all guid-bearing lines are identical across the 2nd roundtrip.
+    """
+    import difflib
+    runner = CliRunner()
+    gf_a = _build_multi_invoice(runner, tmp_path)   # accounts + bank tx + 4 splits + 3 invoices
+
+    e1 = tmp_path / 'e1.txt'
+    assert runner.invoke(cli, ['export', str(gf_a), str(e1),
+                               '--include-business-objects']).exit_code == 0
+    gf_b = tmp_path / 'B.gnucash'
+    assert runner.invoke(cli, ['import', '--new', str(gf_b), str(e1),
+                               '--include-business-objects']).exit_code == 0
+    time.sleep(1)
+    e2 = tmp_path / 'e2.txt'
+    assert runner.invoke(cli, ['export', str(gf_b), str(e2),
+                               '--include-business-objects']).exit_code == 0
+
+    def guid_lines(path):
+        return sorted(line.strip() for line in path.read_text().splitlines()
+                      if re.search(r'guid:', line))
+
+    g1, g2 = guid_lines(e1), guid_lines(e2)
+    assert g1 == g2, 'GUIDs drifted across the roundtrip:\n' + '\n'.join(
+        difflib.unified_diff(g1, g2, 'export1', 'export2', lineterm=''))

--- a/use_cases/export_business_objects.py
+++ b/use_cases/export_business_objects.py
@@ -8,13 +8,18 @@ GnuCash Python SWIG bindings have const-type mismatches for these calls
 See infrastructure/gnucash/engine.py for the platform notes.
 """
 
+from fractions import Fraction
+
 import gnucash.gnucash_business as gb
 import gnucash.gnucash_core_c as gc
 from gnucash import Book, Query, Split
 
 from infrastructure.gnucash.engine import iterate_glist, load_gnc_engine, safe_ctypes_string
 from infrastructure.gnucash.kvp import get_custom_metadata
-from infrastructure.gnucash.utils import get_account_full_name
+from infrastructure.gnucash.utils import (
+    format_amount_for_commodity,
+    get_account_full_name,
+)
 
 
 def _fmt_rate(rate: float) -> str:
@@ -447,7 +452,6 @@ class ExportBusinessObjectsUseCase:
         # and memo. ApplyPayment stores the memo on the splits (not on
         # the transaction description, which is set to the owner name).
         bank_name = ''
-        pay_amt   = 0.0
         pay_memo  = ''
         for i in range(txn.CountSplits()):
             split = txn.GetSplit(i)
@@ -455,9 +459,19 @@ class ExportBusinessObjectsUseCase:
             atype = gc.xaccAccountGetType(acct.instance)
             if atype not in (gc.ACCT_TYPE_RECEIVABLE, gc.ACCT_TYPE_PAYABLE):
                 bank_name = get_account_full_name(acct)
-                pay_amt   = abs(split.GetAmount().to_double())
                 pay_memo  = split.GetMemo() or ''
                 break
+
+        # This record's payment amount is its OWN allocation — the AR/AP split
+        # in this invoice/bill's lot (`in_lot_ar_ap_split`) — NOT the bank-side
+        # total. They differ when one bank tx is split across several
+        # invoices/bills: each lot holds its portion, the bank split holds the
+        # sum. Emitting the bank total would over-report every record (a $400
+        # wire across 3 invoices would otherwise export amount: 400 on each).
+        # Format at the AR/AP commodity's own decimal count, exactly (no float).
+        ar_commodity = in_lot_ar_ap_split.GetAccount().GetCommodity()
+        pay_amt_str = format_amount_for_commodity(
+            in_lot_ar_ap_split.GetAmount().abs(), ar_commodity)
 
         # Q-015 / Q-016: prepayment residual — AR/AP splits on this tx
         # that are NOT in another invoice/bill's lot. In the Q-015
@@ -467,7 +481,7 @@ class ExportBusinessObjectsUseCase:
         # invoice's lot — those must NOT count as prepayment residual,
         # they're portions for other invoices.
         in_lot_guid = in_lot_ar_ap_split.GetGUID().to_string()
-        prepay = 0.0
+        prepay = Fraction(0)
         for i in range(txn.CountSplits()):
             s = txn.GetSplit(i)
             if s.GetGUID().to_string() == in_lot_guid:
@@ -482,7 +496,8 @@ class ExportBusinessObjectsUseCase:
             if raw_lot is not None and gc.gncInvoiceGetInvoiceFromLot(raw_lot):
                 # Belongs to another invoice/bill's lot — not residual.
                 continue
-            prepay += abs(s.GetAmount().to_double())
+            a = s.GetAmount()
+            prepay += abs(Fraction(a.num(), a.denom()))
 
         # Q-016: always emit `txn_guid:` so re-import resolves the payment
         # via the standalone-tx pass rather than via ApplyPayment (which
@@ -502,7 +517,7 @@ class ExportBusinessObjectsUseCase:
         lines = [
             '	payment:',
             f'		date: {pay_date}',
-            f'		amount: {_fmt_quantity(pay_amt)}',
+            f'		amount: {pay_amt_str}',
             f'		bank_account: "{bank_name}"',
             f'		txn_guid: "{txn_guid}"',
             f'		txn_split_guid: "{txn_split_guid}"',
@@ -511,7 +526,8 @@ class ExportBusinessObjectsUseCase:
         if pay_num:
             lines.append(f'		num: "{pay_num}"')
         if prepay > 0:
-            lines.append(f'		prepayment: {_fmt_quantity(prepay)}')
+            lines.append(
+                f'		prepayment: {format_amount_for_commodity(prepay, ar_commodity)}')
         return lines
 
     # ── Bills (vendor invoices) ───────────────────────────────────────────────


### PR DESCRIPTION
Two related export-fidelity bugs found in the multi-invoice (one bank tx → many records) path, fixed together with a double-roundtrip GUID test that pins both.

Q-026 — per-record payment amount allocation. When one bank transaction pays several invoices/bills (the Q-016 shared-bank-tx shape: one bank split plus one AR/AP split per record), the exporter wrote each record's `payment: amount:` as the whole bank-tx total instead of that record's own allocation, so a $400 wire across three invoices exported 400 on every invoice. Both exporters read the bank-side split's amount rather than the AR/AP split in the record's own lot. The fix emits each record's own allocation (the in-lot AR/AP split). It round-tripped invisibly because re-import attaches each portion by `txn_split_guid:`, so the reconstructed book stayed correct and the structural roundtrip tests, which compare state not the amount text, never saw it; single-invoice tests can't expose it because with one AR split the allocation equals the bank total. While here, amounts are now formatted exactly and currency-correctly via a new `format_amount_for_commodity`: read the value via num()/denom() into a Decimal and quantize to the commodity's own decimal count from `get_fraction()`, never via `to_double()`. A 2-decimal currency exports 100.00; a 0-decimal currency such as JPY (fraction 1) exports 1000. The `prepayment:` residual is summed exactly (Fraction) and formatted the same way. GnuCash records KRW with fraction 100 despite real-world KRW being 0-decimal; the exporter follows whatever fraction the book's commodity defines.

Q-027 — account GUID preservation. The exporter emits `guid:` on every `open` account directive, but `create_account` never applied it, so GnuCash minted a fresh GUID for each account on import and account GUIDs drifted on every roundtrip. Transaction, split, posting-tx, and customer/vendor/invoice/bill GUIDs were already preserved; accounts were the lone exception. `create_account` now applies the declared `guid:` to the freshly created account via the existing `_set_object_guid` helper (ctypes `qof_instance_set_guid`, with the book-wide uniqueness guard already used for customers/vendors).

Tests (GnuCash 3.8 and 5.10). New `tests/integration/test_multi_invoice_payment_amount.py`: multi-invoice export emits 100.00/120.00/180.00 not 400; multi-bill emits 90.00/110.00/160.00; the print-invoice render emits the allocation; a JPY invoice exports 1000 (0-decimal); and `test_double_roundtrip_preserves_every_guid` asserts export → fresh import → export keeps every guid-bearing line identical (account, tx, split, posting, owner) — which catches the account-GUID drift. The `business_objects_only.txt` reference is updated to the currency-decimal payment amounts; the business-objects roundtrip, idempotent-reimport, posted-tx-roundtrip, overpayment, and fresh-roundtrip suites still pass.

Documented as issues Q-026 and Q-027.