### PR TITLE
feat(Q-028): round-trip company info and add GST/PST registration numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,6 +837,46 @@ bill "BILL-2026-001"
 > field is omitted in the XML file and defaults to `true` on reload. Exported
 > bills therefore always show `taxable: true` regardless of what was imported.
 
+#### Your own company info: the `company` directive
+
+A single book-level `company` directive round-trips the seller identity that
+`print-invoice` / `print-bill` show in the "From" / "Bill To" block. These are
+GnuCash's own **File → Properties → Business** options — they were rendered
+before but never exported or imported, so a roundtrip into a fresh book used to
+lose them. The directive has no id and no date; it is master data for the whole
+book:
+
+```
+company
+  name: "Maple Leaf Widgets Inc."
+  contact: "Jane Doe"
+  id: "123456789RT0001"
+  gst: "123456789RT0001"
+  pst: "BC PST-1234-5678; SK 9012-3456"
+  addr1: "42 Example Street, Unit 5"
+  addr2: "Springfield ON A1A 1A1"
+  phone: "+1-555-0100"
+  fax: "+1-555-0199"
+  email: "billing@example.com"
+  url: "https://example.com"
+```
+
+`name`, `contact`, `id`, `phone`, `fax`, `email`, `url`, and `addr1..4` map
+directly to GnuCash's native Business fields. The address lines are stored in
+GnuCash's single multi-line `Company Address` slot.
+
+`gst` and `pst` are **registration numbers GnuCash has no field for** — there is
+only one generic `Company ID`. This tool stores them as extra Business slots
+alongside it, so you no longer have to cram a tax number into the company name
+or address. `gst` is a single number; `pst` may hold **several** numbers (e.g.
+for multiple provinces) in one value separated by `;` — each is rendered on its
+own row in the invoice/bill. All of these are additive: `id` is preserved
+unchanged.
+
+Only non-empty fields are emitted on export. On import the directive is the
+source of truth for the fields it names; it reports `created` / `updated` /
+`unchanged` like other business objects.
+
 **Invoice and bill status fields**
 
 The `posted:` and `payment:` fields are always present in exported output.

--- a/cli/import_cmd.py
+++ b/cli/import_cmd.py
@@ -221,6 +221,7 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
                 # possible). Run them now so the standalone tx pass has
                 # full account + owner context.
                 biz_types_early = {
+                    DirectiveType.COMPANY,
                     DirectiveType.CUSTOMER, DirectiveType.VENDOR,
                     DirectiveType.TAXTABLE,
                 }
@@ -324,6 +325,7 @@ def import_transactions(gnucash_file, input_file, gnucash_path, plaintext_file, 
                 click.echo("")
                 click.echo("Business Objects:")
                 labels = [
+                    ('company',  'Company'),
                     ('customer', 'Customers'),
                     ('vendor',   'Vendors'),
                     ('taxtable', 'Tax tables'),

--- a/docs/issues/Q-028-company-info-gst-pst-roundtrip.md
+++ b/docs/issues/Q-028-company-info-gst-pst-roundtrip.md
@@ -1,0 +1,99 @@
+---
+id: Q-028
+title: Company info (incl. GST/PST registration numbers) is not round-tripped, and there is nowhere to record GST/PST
+category: quality
+severity: medium
+status: closed
+---
+
+## Problem
+
+Two related gaps in how seller/company identity is handled.
+
+**1. Company info is read for rendering but never round-tripped.**
+`read_book_company_info` (`services/invoice_renderer.py`) reads the GnuCash book-option Business slots — `Company Name`, `Company ID`, `Company Phone Number`, `Company Email Address`, `Company Website URL`, `Company Address` — and `print-invoice` / `print-bill` render them in the seller block (HTML/PDF `<company>` element and the plaintext `# Issued by:` / `# Bill received by:` header). But **nothing exports or imports these fields**: the only writer of Business options, `set_book_string_option` (`infrastructure/gnucash/kvp.py`), is called only from tests; the plaintext exporter emits no company directive and the importer parses none. So an `export → import` into a fresh book silently **loses all company identity** (Company Name, Company ID, address, contact). Company ID in particular is well covered on the read/render side (`test_set_book_string_option.py`, `test_invoice_renderer.py`, `test_q019_two_sided_render.py`) but **has no round-trip test** because there is no round-trip.
+
+**2. GnuCash has no GST/PST field.**
+GnuCash's Business options expose exactly one generic identifier, `Company ID` — there is no GST, PST, QST, or VAT registration field. A Canadian filer who must print *both* a GST/HST number and a provincial PST/QST number on the same invoice has only one slot, and ends up cramming the second number into the Company Name or Address string. There is no first-class place to record additional tax-registration numbers, and therefore no way to render them cleanly.
+
+## Fix
+
+Introduce a book-level `company` directive that round-trips the Business → Company options through plaintext, **and** add dedicated GST/PST registration keys stored alongside `Company ID`.
+
+### New company keys (stored as Business option slots)
+
+GnuCash preserves arbitrary string slots under `options → Business`, so the new numbers are stored there next to the native `Company ID`, written via `set_book_string_option(book, 'Business', <key>, <value>)`:
+
+| Plaintext key | Business slot key | Notes |
+|---|---|---|
+| `gst` | `Company GST Number` | GST/HST registration number — a single value |
+| `pst` | `Company PST Number` | Provincial PST/QST — **one slot may hold several** numbers separated by `;` |
+
+`read_book_company_info` gains `gst` and `pst` in its returned dict. The native `Company ID` is preserved unchanged; GST/PST are **additive**, not a replacement.
+
+**Multiple PST numbers.** A filer can be registered for PST/QST in more than one province. GnuCash storage is fundamentally one string slot, so rather than inventing repeated-key parsing (which would flatten to one slot anyway), `pst` carries several numbers in one value separated by `;` — e.g. `pst: "BC PST-1234-5678; SK 9012-3456"`. The renderer splits on `;` and emits one PST row per number; storage and round-trip stay a single verbatim string. `gst` is always one value.
+
+### `company` directive (export + import)
+
+Beyond GST/PST, the directive round-trips **every** native GnuCash Business field — the ones in File → Properties → Business (`name`, `contact`, `id`, `phone`, `fax`, `email`, `url`, and the multi-line address) — because none of them were exported or imported before. The exporter emits a single book-level block as the first section of the business-objects export:
+
+```
+company
+	name: "Acme Inc."
+	contact: "Jane Doe"
+	id: "123456789RT0001"
+	gst: "123456789RT0001"
+	pst: "BC PST-1234-5678; SK 9012-3456"
+	addr1: "100 King St W"
+	addr2: "Toronto, ON M5X 1A1"
+	phone: "+1-416-555-0100"
+	fax: "+1-416-555-0199"
+	email: "billing@acme.example"
+	url: "https://acme.example"
+```
+
+Only non-empty fields are emitted (same convention as customer/vendor blocks). On import, each present field is written to its Business slot via `set_book_string_option`; absent fields are left untouched (the directive is the source of truth for the fields it names, like other blocks). The address lines are joined into the single multi-line `Company Address` slot on import and split back into `addr1..4` on export. This block is part of the `--include-business-objects` export/import path.
+
+Import status follows the standard per-record model: `created` when the book had no company option before, `updated` when at least one field changed, `unchanged` on an idempotent re-run (compared field-by-field against the live book via `get_book_string_option`).
+
+### Rendering
+
+The seller/company block renders `gst` and `pst` directly under `Company ID`:
+
+- **HTML/PDF**: new `<gst>` / `<pst>` elements in the `<company>` block (`invoice_to_xml` / `bill_to_xml`) plus the seller-block XSLT.
+- **Plaintext**: extra labeled segments in `_render_seller_header`, e.g. `... | Company ID: 123… | GST: 123… | PST: PST-… | ...`.
+
+When `gst`/`pst` are empty the output is unchanged from today.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `infrastructure/gnucash/kvp.py` | `get_book_string_option` — read a Business option from the live book via `qof_book_get_string_option` (the inverse of `set_book_string_option`; works on 3.8–5.x). |
+| `services/plaintext_parser.py` | `DirectiveType.COMPANY` + `parse_company_head`; the `company` header block whose `key: value` children accumulate as metadata. |
+| `services/gnucash_importer.py` | `import_company` writes each field to its Business slot via `set_book_string_option`; dispatched first in `import_business_objects`; `company` added to the per-type counts. |
+| `cli/import_cmd.py` | `COMPANY` joins the early import pass; `Company` row in the business-objects summary. |
+| `use_cases/export_business_objects.py` | `_export_company` emits the `company` directive (first section) from the book's Business options. |
+| `services/invoice_renderer.py` | `read_book_company_info` returns `contact`/`gst`/`pst`/`fax`; shared `build_company_xml` emits `<contact>`/`<gst>`/`<pst>`/`<fax>` (one `<pst>` per number); `_render_seller_header` renders the GST/PST/contact/fax segments; `split_pst_numbers` helper. |
+| `services/bill_renderer.py` | Reuses `build_company_xml` for the seller block. |
+| `services/invoice.xslt`, `services/bill.xslt` | Render Contact / GST / each PST / Fax rows in the company block. |
+| `README.md` | Document the `company` directive and the `gst`/`pst` keys. |
+
+## Tests
+
+`tests/integration/test_company_info_roundtrip.py` (fixture `tests/fixtures/company_full.txt`):
+
+- **Round-trip** (the missing coverage): import the `company` directive → export → import into a fresh book → export again; the `company` block (every native field plus GST and both PST numbers) is byte-for-byte identical. This is the Company ID round-trip test that did not previously exist.
+- **Field fidelity**: every field exports with its exact value after import.
+- **Render**: `print-invoice` / `print-bill` in plaintext and HTML show the GST value and *each* PST number in the seller block.
+- **Baseline**: a book with no company options exports no `company` block.
+- All passing on GnuCash 3.8 and 5.10.
+
+## Related issues
+
+- **Q-019** — two-sided rendering + the original `read_book_company_info` / seller-header mechanism this extends.
+- **Q-002** — `read_book_company_info` bypasses the repository layer (pre-existing; unchanged here).
+
+---
+
+**Created**: 2026-06-08

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -72,3 +72,4 @@ and in the **Status** column below.
 | [Q-025](Q-025-edited-guid-match-skipped-silently.md) | Editing a transaction by re-import is silently skipped as a "duplicate" | low | closed |
 | [Q-026](Q-026-multi-invoice-payment-amount-allocation.md) | One bank tx paying multiple invoices/bills exports the bank total as each record's payment amount | medium | closed |
 | [Q-027](Q-027-account-guid-not-preserved-on-import.md) | Account GUIDs are not preserved on import, so they drift every roundtrip | medium | closed |
+| [Q-028](Q-028-company-info-gst-pst-roundtrip.md) | Company info (incl. GST/PST registration numbers) is not round-tripped, and there is nowhere to record GST/PST | medium | closed |

--- a/infrastructure/gnucash/kvp.py
+++ b/infrastructure/gnucash/kvp.py
@@ -448,6 +448,37 @@ def set_book_string_option(book, section: str, name: str, value: str) -> bool:
         return False
 
 
+def get_book_string_option(book, section: str, name: str) -> Optional[str]:
+    """Read a string-valued book option from the nested slot path
+    `options → <section> → <name>` — the inverse of
+    `set_book_string_option`, and the same layout `read_book_company_info`
+    walks in the saved XML. Reads straight from the live in-memory book
+    via `qof_book_get_string_option(book, opt_name)` (ctypes), so it sees
+    unsaved writes and needs no file path.
+
+    Returns the option value, or None when the slot is absent. Verified
+    on GnuCash 3.8 (Ubuntu 20) through 5.x (Debian 13): the C getter
+    resolves the slash-separated path internally, including custom slots
+    such as `Company GST Number` that GnuCash itself never writes.
+    """
+    try:
+        obj_ptr = int(book.instance)
+        lib = _load_gnc_engine()
+        lib.qof_book_get_string_option.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+        lib.qof_book_get_string_option.restype = ctypes.c_char_p
+
+        opt_path = f'options/{section}/{name}'.encode()
+        raw = lib.qof_book_get_string_option(ctypes.c_void_p(obj_ptr), opt_path)
+        if raw is None:
+            return None
+        return raw.decode('utf-8')
+    except Exception as e:
+        logging.debug(
+            f"Failed to read book option options/{section}/{name}: {e}"
+        )
+        return None
+
+
 def get_custom_metadata(obj) -> dict:
     """
     Read custom metadata from a GnuCash Transaction or Split KVP slot.

--- a/services/bill.xslt
+++ b/services/bill.xslt
@@ -163,9 +163,18 @@
       <div class="addr addr-to">
         <h3>Bill To</h3>
         <p><strong><xsl:value-of select="company/name"/></strong></p>
+        <xsl:if test="string-length(company/contact) > 0">
+          <p>Attn: <xsl:value-of select="company/contact"/></p>
+        </xsl:if>
         <xsl:if test="string-length(company/id) > 0">
           <p class="co-reg">Company ID: <xsl:value-of select="company/id"/></p>
         </xsl:if>
+        <xsl:if test="string-length(company/gst) > 0">
+          <p class="co-reg">GST: <xsl:value-of select="company/gst"/></p>
+        </xsl:if>
+        <xsl:for-each select="company/pst">
+          <p class="co-reg">PST: <xsl:value-of select="."/></p>
+        </xsl:for-each>
         <xsl:if test="string-length(company/addr1) > 0">
           <p><xsl:value-of select="company/addr1"/></p>
         </xsl:if>
@@ -180,6 +189,9 @@
         </xsl:if>
         <xsl:if test="string-length(company/phone) > 0">
           <p><xsl:value-of select="company/phone"/></p>
+        </xsl:if>
+        <xsl:if test="string-length(company/fax) > 0">
+          <p>Fax: <xsl:value-of select="company/fax"/></p>
         </xsl:if>
         <xsl:if test="string-length(company/email) > 0">
           <p><xsl:value-of select="company/email"/></p>

--- a/services/bill_renderer.py
+++ b/services/bill_renderer.py
@@ -30,6 +30,7 @@ from services.invoice_renderer import (
     _fmt_rate,
     _render_seller_header,
     _render_taxtable_block,
+    build_company_xml,
 )
 
 
@@ -178,17 +179,7 @@ def bill_to_xml(bill, book, company_info=None):
     ET.SubElement(v_el, 'addr4').text = addr4 or ''
     ET.SubElement(v_el, 'email').text = email or ''
 
-    co = company_info or {}
-    co_el = ET.SubElement(root, 'company')
-    ET.SubElement(co_el, 'name').text = co.get('name', '')
-    ET.SubElement(co_el, 'id').text = co.get('id', '')
-    ET.SubElement(co_el, 'addr1').text = co.get('addr1', '')
-    ET.SubElement(co_el, 'addr2').text = co.get('addr2', '')
-    ET.SubElement(co_el, 'addr3').text = co.get('addr3', '')
-    ET.SubElement(co_el, 'addr4').text = co.get('addr4', '')
-    ET.SubElement(co_el, 'phone').text = co.get('phone', '')
-    ET.SubElement(co_el, 'email').text = co.get('email', '')
-    ET.SubElement(co_el, 'url').text = co.get('url', '')
+    build_company_xml(root, company_info)
 
     entries_el = ET.SubElement(root, 'entries')
     entries_subtotal = 0.0

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -38,11 +38,38 @@ from infrastructure.gnucash.kvp import (
     KNOWN_SPLIT_METADATA_KEYS,
     KNOWN_TX_METADATA_KEYS,
     KNOWN_VENDOR_METADATA_KEYS,
+    get_book_string_option,
     get_custom_metadata,
+    set_book_string_option,
     set_custom_metadata,
 )
 from infrastructure.gnucash.utils import find_account, get_account_full_name, string_to_gnc_numeric
 from services.plaintext_parser import DirectiveType, PlaintextDirective
+
+# Q-028: book-level `company` directive — plaintext key ↔ Business option slot.
+# These land at `options → Business → <slot>`, the exact slots GnuCash's own
+# File → Properties → Business dialog reads and writes (Company Name, Company
+# Contact Person, Company Phone/Fax Number, Company Email Address, Company
+# Website URL, Company ID) and that `read_book_company_info` reads for the
+# seller block. The directive routes each plaintext key to GnuCash's native
+# slot so the whole block round-trips — it does not invent storage for fields
+# GnuCash already owns. The ONLY custom additions are `Company GST Number` /
+# `Company PST Number`: GnuCash has no GST/PST field, so this tool stores them
+# as extra string slots in the same Business frame, alongside `Company ID`.
+# Address lines map to the single multi-line `Company Address` slot (joined on
+# import, split on export).
+COMPANY_FIELD_TO_SLOT = {
+    'name':    'Company Name',
+    'contact': 'Company Contact Person',
+    'id':      'Company ID',
+    'gst':     'Company GST Number',
+    'pst':     'Company PST Number',
+    'phone':   'Company Phone Number',
+    'fax':     'Company Fax Number',
+    'email':   'Company Email Address',
+    'url':     'Company Website URL',
+}
+_COMPANY_ADDR_KEYS = ('addr1', 'addr2', 'addr3', 'addr4')
 
 
 def string_to_gnc_numeric_quantity(s):
@@ -81,6 +108,7 @@ class BusinessObjectImportResult:
     model.
     """
     counts: Dict[str, Dict[str, int]] = field(default_factory=lambda: {
+        'company':  {'created': 0, 'updated': 0, 'unchanged': 0, 'skipped': 0},
         'customer': {'created': 0, 'updated': 0, 'unchanged': 0, 'skipped': 0},
         'vendor':   {'created': 0, 'updated': 0, 'unchanged': 0, 'skipped': 0},
         'taxtable': {'created': 0, 'updated': 0, 'unchanged': 0, 'skipped': 0},
@@ -2456,6 +2484,54 @@ class GnuCashImporter:
             raise
 
     @staticmethod
+    def import_company(directive: PlaintextDirective, book: Book):
+        """Q-028: write the book-level `company` directive to the Business
+        options. The directive is the source of truth for the fields it
+        names; only those slots are touched (an absent field is left as-is).
+        GST/PST land in the custom `Company GST Number` / `Company PST Number`
+        slots; `pst` may carry several numbers in one string (split for
+        rendering, stored verbatim).
+
+        Status compares each field to the book's current value so a no-op
+        re-import reports 'unchanged'. 'created' when the book had no company
+        options before, else 'updated'."""
+        if directive.type != DirectiveType.COMPANY:
+            raise ValueError(f"Expected COMPANY but got {directive.type}")
+        md = directive.metadata
+        changed = False
+        had_any = False
+
+        for key, slot in COMPANY_FIELD_TO_SLOT.items():
+            if key not in md:
+                continue
+            val = '' if md[key] is None else str(md[key])
+            current = get_book_string_option(book, 'Business', slot) or ''
+            if current:
+                had_any = True
+            if current != val:
+                set_book_string_option(book, 'Business', slot, val)
+                changed = True
+
+        # Address lines → single multi-line `Company Address` slot, the inverse
+        # of the `read_book_company_info` split-on-newline. Only rewritten when
+        # the directive names at least one address line.
+        if any(k in md for k in _COMPANY_ADDR_KEYS):
+            addr_val = '\n'.join(
+                ('' if md.get(k) is None else str(md.get(k, '')))
+                for k in _COMPANY_ADDR_KEYS
+            ).rstrip('\n')
+            current = get_book_string_option(book, 'Business', 'Company Address') or ''
+            if current:
+                had_any = True
+            if current != addr_val:
+                set_book_string_option(book, 'Business', 'Company Address', addr_val)
+                changed = True
+
+        if not changed:
+            return 'unchanged'
+        return 'updated' if had_any else 'created'
+
+    @staticmethod
     def import_customer(directive: PlaintextDirective, book: Book):
         if directive.type != DirectiveType.CUSTOMER:
             raise ValueError(f"Expected CUSTOMER but got {directive.type}")
@@ -3059,6 +3135,17 @@ class GnuCashImporter:
         """
         cb = on_directive_status or (lambda *_: None)
         result = BusinessObjectImportResult()
+
+        # Book-level company identity first — independent of everything else.
+        for directive in directives:
+            if directive.type == DirectiveType.COMPANY:
+                cname = directive.metadata.get('name', '?')
+                try:
+                    status = self.import_company(directive, book)
+                except Exception as e:
+                    raise ValueError(f'company "{cname}": {e}') from e
+                result.tally('company', status)
+                cb('company', cname, status)
 
         # Customers and vendors first (invoices/bills depend on them)
         for directive in directives:

--- a/services/invoice.xslt
+++ b/services/invoice.xslt
@@ -186,9 +186,18 @@
       <div class="addr addr-from">
         <h3>From</h3>
         <p><strong><xsl:value-of select="company/name"/></strong></p>
+        <xsl:if test="string-length(company/contact) > 0">
+          <p>Attn: <xsl:value-of select="company/contact"/></p>
+        </xsl:if>
         <xsl:if test="string-length(company/id) > 0">
           <p class="co-reg">Company ID: <xsl:value-of select="company/id"/></p>
         </xsl:if>
+        <xsl:if test="string-length(company/gst) > 0">
+          <p class="co-reg">GST: <xsl:value-of select="company/gst"/></p>
+        </xsl:if>
+        <xsl:for-each select="company/pst">
+          <p class="co-reg">PST: <xsl:value-of select="."/></p>
+        </xsl:for-each>
         <xsl:if test="string-length(company/addr1) > 0">
           <p><xsl:value-of select="company/addr1"/></p>
         </xsl:if>
@@ -203,6 +212,9 @@
         </xsl:if>
         <xsl:if test="string-length(company/phone) > 0">
           <p><xsl:value-of select="company/phone"/></p>
+        </xsl:if>
+        <xsl:if test="string-length(company/fax) > 0">
+          <p>Fax: <xsl:value-of select="company/fax"/></p>
         </xsl:if>
         <xsl:if test="string-length(company/email) > 0">
           <p><xsl:value-of select="company/email"/></p>

--- a/services/invoice_renderer.py
+++ b/services/invoice_renderer.py
@@ -50,8 +50,14 @@ def read_book_company_info(file_path):
 
     result = {
         'name': _str_val(biz_el, 'Company Name'),
+        'contact': _str_val(biz_el, 'Company Contact Person'),
         'id': _str_val(biz_el, 'Company ID'),
+        # Q-028: GnuCash has no GST/PST field — these are custom Business slots
+        # this tool adds. `pst` may carry several numbers separated by ';'.
+        'gst': _str_val(biz_el, 'Company GST Number'),
+        'pst': _str_val(biz_el, 'Company PST Number'),
         'phone': _str_val(biz_el, 'Company Phone Number'),
+        'fax': _str_val(biz_el, 'Company Fax Number'),
         'email': _str_val(biz_el, 'Company Email Address'),
         'url': _str_val(biz_el, 'Company Website URL'),
     }
@@ -61,6 +67,42 @@ def read_book_company_info(file_path):
         result[k] = addr_lines[i].strip() if i < len(addr_lines) else ''
 
     return result
+
+
+def split_pst_numbers(value) -> list:
+    """Q-028: split a `pst` company value into individual registration
+    numbers. A filer may hold more than one provincial PST/QST number, so
+    several are stored in the single `Company PST Number` slot separated by
+    ';' and rendered as separate rows. `gst` is always a single value."""
+    if not value:
+        return []
+    return [p.strip() for p in str(value).split(';') if p.strip()]
+
+
+def build_company_xml(root, company_info):
+    """Build the `<company>` seller block shared by invoice and bill XML.
+
+    Emits GnuCash's native Business fields plus the custom GST/PST
+    registration numbers (Q-028). GST is one `<gst>`; PST is one `<pst>`
+    element per number so the stylesheet can render multiple provincial
+    registrations as separate rows."""
+    co = company_info or {}
+    co_el = ET.SubElement(root, 'company')
+    ET.SubElement(co_el, 'name').text = co.get('name', '')
+    ET.SubElement(co_el, 'contact').text = co.get('contact', '')
+    ET.SubElement(co_el, 'id').text = co.get('id', '')
+    ET.SubElement(co_el, 'gst').text = co.get('gst', '')
+    for pst in split_pst_numbers(co.get('pst', '')):
+        ET.SubElement(co_el, 'pst').text = pst
+    ET.SubElement(co_el, 'addr1').text = co.get('addr1', '')
+    ET.SubElement(co_el, 'addr2').text = co.get('addr2', '')
+    ET.SubElement(co_el, 'addr3').text = co.get('addr3', '')
+    ET.SubElement(co_el, 'addr4').text = co.get('addr4', '')
+    ET.SubElement(co_el, 'phone').text = co.get('phone', '')
+    ET.SubElement(co_el, 'fax').text = co.get('fax', '')
+    ET.SubElement(co_el, 'email').text = co.get('email', '')
+    ET.SubElement(co_el, 'url').text = co.get('url', '')
+    return co_el
 
 
 def _read_tax_label(lib, ptr):
@@ -169,17 +211,7 @@ def invoice_to_xml(inv, book, company_info=None):
     ET.SubElement(c_el, 'addr4').text = addr4 or ''
     ET.SubElement(c_el, 'email').text = email or ''
 
-    co = company_info or {}
-    co_el = ET.SubElement(root, 'company')
-    ET.SubElement(co_el, 'name').text = co.get('name', '')
-    ET.SubElement(co_el, 'id').text = co.get('id', '')
-    ET.SubElement(co_el, 'addr1').text = co.get('addr1', '')
-    ET.SubElement(co_el, 'addr2').text = co.get('addr2', '')
-    ET.SubElement(co_el, 'addr3').text = co.get('addr3', '')
-    ET.SubElement(co_el, 'addr4').text = co.get('addr4', '')
-    ET.SubElement(co_el, 'phone').text = co.get('phone', '')
-    ET.SubElement(co_el, 'email').text = co.get('email', '')
-    ET.SubElement(co_el, 'url').text = co.get('url', '')
+    build_company_xml(root, company_info)
 
     entries_el = ET.SubElement(root, 'entries')
     # Q-019: drafts (cash-basis or accrual) now compute tax from each
@@ -585,6 +617,9 @@ def _render_seller_header(company_info) -> str:
     if not name:
         return ''
     parts = [f'Issued by: {name}']
+    contact = (company_info.get('contact') or '').strip()
+    if contact:
+        parts.append(f'Attn: {contact}')
     company_id = (company_info.get('id') or '').strip()
     if company_id:
         # Label matches GnuCash's own slot name ("Company ID") rather
@@ -593,6 +628,14 @@ def _render_seller_header(company_info) -> str:
         # corporate number, etc. here; the rendered output stays
         # neutral so the slot value reads correctly regardless.
         parts.append(f'Company ID: {company_id}')
+    # Q-028: dedicated GST/PST registration numbers, labelled so the
+    # recipient can tell them apart from the generic Company ID. GST is a
+    # single value; PST may hold several (one rendered segment each).
+    gst = (company_info.get('gst') or '').strip()
+    if gst:
+        parts.append(f'GST: {gst}')
+    for pst in split_pst_numbers(company_info.get('pst')):
+        parts.append(f'PST: {pst}')
     addr_lines = [
         (company_info.get(k) or '').strip()
         for k in ('addr1', 'addr2', 'addr3', 'addr4')
@@ -600,10 +643,11 @@ def _render_seller_header(company_info) -> str:
     addr_joined = ', '.join(line for line in addr_lines if line)
     if addr_joined:
         parts.append(addr_joined)
-    for key in ('phone', 'email', 'url'):
+    for key in ('phone', 'fax', 'email', 'url'):
         val = (company_info.get(key) or '').strip()
         if val:
-            parts.append(val)
+            label = {'fax': 'Fax: '}.get(key, '')
+            parts.append(f'{label}{val}')
     return '# ' + ' | '.join(parts)
 
 

--- a/services/plaintext_parser.py
+++ b/services/plaintext_parser.py
@@ -150,6 +150,13 @@ class DirectiveType(Enum):
     # per-split lot_owner markers, which rebuild the lots).
     OPEN_PREPAYMENT = 17
 
+    # Q-028: book-level seller/company identity (Company Name, Company ID,
+    # GST/PST registration numbers, address, contact). A singleton header
+    # block `company` whose indented `key: value` children populate the
+    # book's Business → Company options. Round-trips the company info that
+    # `print-invoice` / `print-bill` render in the seller block.
+    COMPANY = 18
+
 
 
 class PlaintextDirective:
@@ -290,6 +297,7 @@ class PlaintextParser:
             (tx_date, tx_num, tx_desc) = parse_transaction_head(line)
             (split_account_name, split_amount, split_symbol) = parse_split(line)
             (key, value) = parse_metadata(line)
+            company_head = parse_company_head(line.strip())
             customer_id = parse_customer(line.strip())
             taxtable_name = parse_taxtable(line.strip())
             invoice_id = parse_invoice(line.strip())
@@ -323,6 +331,10 @@ class PlaintextParser:
                 obj.props['amount'] = split_amount
                 obj.props['symbol'] = split_symbol
                 obj.props['account'] = split_account_name
+                parent_directive.children.append(obj)
+                self.current_directive = obj
+            elif company_head:
+                obj = PlaintextDirective(DirectiveType.COMPANY, line_level, line, parent_directive)
                 parent_directive.children.append(obj)
                 self.current_directive = obj
             elif customer_id is not None:
@@ -404,7 +416,15 @@ taxtable_pattern = r'^taxtable\s+"(.*?)"\s*$'
 invoice_pattern = r'^invoice\s+"(.*?)"\s*$'
 vendor_pattern = r'^vendor\s+"(.*?)"\s*$'
 bill_pattern = r'^bill\s+"(.*?)"\s*$'
+company_pattern = r'^company\s*$'
 block_pattern = r'^\s*(entry|posted|payment|breakdown|open_prepayment):\s*$'
+
+
+def parse_company_head(line: str) -> bool:
+    """Match the book-level `company` header line (Q-028). The block's
+    indented `key: value` children are accumulated as metadata by the
+    generic metadata path, so this only has to recognise the header."""
+    return re.match(company_pattern, line) is not None
 
 
 def parse_customer(line: str) -> Optional[str]:

--- a/tests/fixtures/company_full.txt
+++ b/tests/fixtures/company_full.txt
@@ -1,0 +1,13 @@
+company
+	name: "Acme Plaintext Co."
+	contact: "Jane Doe"
+	id: "123456789RT0001"
+	gst: "123456789RT0001"
+	pst: "BC PST-1234-5678; SK 9012-3456"
+	addr1: "100 Main St"
+	addr2: "Suite 200"
+	addr3: "Toronto ON M5H 1A1"
+	phone: "+1-555-0142"
+	fax: "+1-555-0199"
+	email: "billing@acmeplain.test"
+	url: "https://acmeplain.test"

--- a/tests/integration/test_company_info_roundtrip.py
+++ b/tests/integration/test_company_info_roundtrip.py
@@ -1,0 +1,194 @@
+"""Q-028: the book-level `company` directive round-trips GnuCash's Business →
+Company options (Company Name/Contact/Phone/Fax/Email/URL/ID + the custom
+GST/PST registration numbers), and `print-invoice` / `print-bill` render the
+GST/PST in the seller block.
+
+Before this feature the company block was read for rendering but never
+exported/imported, so a roundtrip into a fresh book silently dropped every
+field — Company ID included. These tests pin that the whole block survives a
+double roundtrip, and that GST and each PST number reach the rendered output.
+"""
+
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURES = Path('tests/fixtures')
+ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
+COMPANY = str(FIXTURES / 'company_full.txt')
+
+# Field values as written in tests/fixtures/company_full.txt.
+EXPECTED = {
+    'name':    'Acme Plaintext Co.',
+    'contact': 'Jane Doe',
+    'id':      '123456789RT0001',
+    'gst':     '123456789RT0001',
+    'pst':     'BC PST-1234-5678; SK 9012-3456',
+    'addr1':   '100 Main St',
+    'addr2':   'Suite 200',
+    'addr3':   'Toronto ON M5H 1A1',
+    'phone':   '+1-555-0142',
+    'fax':     '+1-555-0199',
+    'email':   'billing@acmeplain.test',
+    'url':     'https://acmeplain.test',
+}
+
+
+def _new_book(runner, tmp_path, name='book.gnucash'):
+    gf = tmp_path / name
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    return gf
+
+
+def _import(runner, gf, content, tmp_path, name):
+    p = tmp_path / name
+    p.write_text(content)
+    r = runner.invoke(cli, ['import', str(gf), str(p), '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+
+
+def _export(runner, gf, tmp_path, name='exp.txt'):
+    out = tmp_path / name
+    r = runner.invoke(cli, ['export', str(gf), str(out), '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    return out.read_text()
+
+
+def _company_block(text):
+    """Extract the `company` directive block (header + its indented children)
+    from an export."""
+    out = []
+    capturing = False
+    for line in text.splitlines():
+        if not capturing:
+            if line.strip() == 'company' and not line[:1].isspace():
+                capturing = True
+                out.append(line)
+            continue
+        if line[:1].isspace():
+            out.append(line)
+        else:
+            break
+    return '\n'.join(out)
+
+
+def _company_fields(text):
+    """Parse the exported company block into {key: value}."""
+    fields = {}
+    for line in _company_block(text).splitlines()[1:]:
+        key, _, val = line.strip().partition(':')
+        val = val.strip()
+        if val.startswith('"') and val.endswith('"'):
+            val = val[1:-1]
+        fields[key.strip()] = val
+    return fields
+
+
+def test_company_directive_imports_and_exports_every_field(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf, Path(COMPANY).read_text(), tmp_path, 'company.txt')
+    fields = _company_fields(_export(runner, gf, tmp_path))
+    for key, want in EXPECTED.items():
+        assert fields.get(key) == want, (key, fields)
+
+
+def test_company_block_survives_double_roundtrip(tmp_path):
+    """export → import (fresh book) → export must keep the company block
+    byte-for-byte identical. This is the Company-ID roundtrip coverage that
+    did not exist before: every native field plus GST/PST is preserved."""
+    runner = CliRunner()
+    gf_a = _new_book(runner, tmp_path, 'A.gnucash')
+    _import(runner, gf_a, Path(COMPANY).read_text(), tmp_path, 'company.txt')
+
+    e1 = _export(runner, gf_a, tmp_path, 'e1.txt')
+    block1 = _company_block(e1)
+    assert block1, f'no company block in first export:\n{e1}'
+
+    gf_b = tmp_path / 'B.gnucash'
+    (tmp_path / 'e1_in.txt').write_text(e1)
+    assert runner.invoke(cli, ['import', '--new', str(gf_b),
+                               str(tmp_path / 'e1_in.txt'),
+                               '--include-business-objects']).exit_code == 0
+    time.sleep(1)
+    e2 = _export(runner, gf_b, tmp_path, 'e2.txt')
+    block2 = _company_block(e2)
+
+    assert block1 == block2, (
+        f'company block drifted across roundtrip:\n--- e1 ---\n{block1}\n'
+        f'--- e2 ---\n{block2}'
+    )
+    # Explicit: Company ID and both PST numbers really are there after the
+    # fresh-book roundtrip (not just equal-but-empty).
+    f2 = _company_fields(e2)
+    assert f2['id'] == EXPECTED['id']
+    assert f2['gst'] == EXPECTED['gst']
+    assert f2['pst'] == EXPECTED['pst']
+
+
+def test_book_without_company_options_exports_no_company_block(tmp_path):
+    """A book with no Business→Company options must export no `company`
+    directive — the baseline export is unchanged for books that never set
+    company info."""
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    assert _company_block(_export(runner, gf, tmp_path)) == ''
+
+
+def _book_with_company_and(runner, tmp_path, doc_fixture):
+    gf = _new_book(runner, tmp_path)
+    combined = (Path(COMPANY).read_text() + '\n\n'
+                + (FIXTURES / doc_fixture).read_text())
+    _import(runner, gf, combined, tmp_path, 'doc.txt')
+    return gf
+
+
+def test_print_invoice_plaintext_renders_gst_and_each_pst(tmp_path):
+    runner = CliRunner()
+    gf = _book_with_company_and(runner, tmp_path, 'q019_unposted_cash_with_tax.txt')
+    out = tmp_path / 'inv.txt'
+    r = runner.invoke(cli, ['print-invoice', str(gf), 'INV-Q19-CASH-TAX-200',
+                            '--format', 'plaintext', '-o', str(out)])
+    assert r.exit_code == 0, r.output
+    text = out.read_text()
+    assert 'GST: 123456789RT0001' in text, text
+    assert 'PST: BC PST-1234-5678' in text, text
+    assert 'PST: SK 9012-3456' in text, text
+
+
+def test_print_invoice_html_renders_gst_and_each_pst(tmp_path):
+    runner = CliRunner()
+    gf = _book_with_company_and(runner, tmp_path, 'q019_unposted_cash_with_tax.txt')
+    out = tmp_path / 'inv.html'
+    r = runner.invoke(cli, ['print-invoice', str(gf), 'INV-Q19-CASH-TAX-200',
+                            '--format', 'html', '-o', str(out)])
+    assert r.exit_code == 0, r.output
+    html = out.read_text()
+    assert 'GST: 123456789RT0001' in html, html
+    assert 'BC PST-1234-5678' in html and 'SK 9012-3456' in html, html
+
+
+def test_print_bill_plaintext_renders_gst_and_each_pst(tmp_path):
+    runner = CliRunner()
+    gf = _book_with_company_and(runner, tmp_path, 'q019_unposted_cash_bill.txt')
+    # Discover the bill id from the fixture header.
+    bill_id = None
+    for line in (FIXTURES / 'q019_unposted_cash_bill.txt').read_text().splitlines():
+        if line.startswith('bill "'):
+            bill_id = line.split('"')[1]
+            break
+    assert bill_id, 'could not find bill id in fixture'
+    out = tmp_path / 'bill.txt'
+    r = runner.invoke(cli, ['print-bill', str(gf), bill_id,
+                            '--format', 'plaintext', '-o', str(out)])
+    assert r.exit_code == 0, r.output
+    text = out.read_text()
+    assert 'GST: 123456789RT0001' in text, text
+    assert 'PST: BC PST-1234-5678' in text, text
+    assert 'PST: SK 9012-3456' in text, text

--- a/use_cases/export_business_objects.py
+++ b/use_cases/export_business_objects.py
@@ -15,8 +15,9 @@ import gnucash.gnucash_core_c as gc
 from gnucash import Book, Query, Split
 
 from infrastructure.gnucash.engine import iterate_glist, load_gnc_engine, safe_ctypes_string
-from infrastructure.gnucash.kvp import get_custom_metadata
+from infrastructure.gnucash.kvp import get_book_string_option, get_custom_metadata
 from infrastructure.gnucash.utils import (
+    encode_value_as_string,
     format_amount_for_commodity,
     get_account_full_name,
 )
@@ -142,15 +143,66 @@ class ExportBusinessObjectsUseCase:
     def execute(self) -> str:
         """Return the complete business-objects plaintext block."""
         parts = []
+        company   = self._export_company()
         customers = self._export_customers()
         vendors   = self._export_vendors()
         tables    = self._export_tax_tables()
         invoices  = self._export_invoices()
         bills     = self._export_bills()
-        for section in (customers, vendors, tables, invoices, bills):
+        for section in (company, customers, vendors, tables, invoices, bills):
             if section:
                 parts.append(section)
         return '\n\n'.join(parts)
+
+    # ── Company ───────────────────────────────────────────────────────────────
+
+    def _export_company(self) -> str:
+        """Q-028: emit the book-level `company` directive from the Business
+        options — GnuCash's own Company Name/Contact/Phone/Fax/Email/URL/ID
+        plus the custom GST/PST registration numbers. Returns '' when the
+        book has no company option set, so books without company info export
+        unchanged. Address is split back from the single multi-line `Company
+        Address` slot into addr1..4, the inverse of the importer's join."""
+        ordered = [
+            ('name',    'Company Name'),
+            ('contact', 'Company Contact Person'),
+            ('id',      'Company ID'),
+            ('gst',     'Company GST Number'),
+            ('pst',     'Company PST Number'),
+        ]
+        trailing = [
+            ('phone', 'Company Phone Number'),
+            ('fax',   'Company Fax Number'),
+            ('email', 'Company Email Address'),
+            ('url',   'Company Website URL'),
+        ]
+
+        def opt(slot):
+            return (get_book_string_option(self.book, 'Business', slot) or '').strip()
+
+        lines = ['company']
+        has_value = False
+        for key, slot in ordered:
+            val = opt(slot)
+            if val:
+                lines.append(f'\t{key}: {encode_value_as_string(val)}')
+                has_value = True
+
+        addr_raw = get_book_string_option(self.book, 'Business', 'Company Address') or ''
+        addr_lines = addr_raw.split('\n') if addr_raw else []
+        for i, key in enumerate(('addr1', 'addr2', 'addr3', 'addr4')):
+            val = addr_lines[i].strip() if i < len(addr_lines) else ''
+            if val:
+                lines.append(f'\t{key}: {encode_value_as_string(val)}')
+                has_value = True
+
+        for key, slot in trailing:
+            val = opt(slot)
+            if val:
+                lines.append(f'\t{key}: {encode_value_as_string(val)}')
+                has_value = True
+
+        return '\n'.join(lines) if has_value else ''
 
     # ── Customers ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
The seller identity in File → Properties → Business (Company Name, Contact Person, Phone, Fax, Email, Website URL, ID, and the multi-line Address) was rendered in the invoice/bill "From" block but never exported or imported, so a roundtrip into a fresh book silently dropped every field — Company ID included. GnuCash also has only one generic Company ID and no GST/PST field, forcing tax-registration numbers to be crammed into the company name or address.

A new book-level `company` directive now round-trips the whole company block and adds first-class GST/PST registration numbers.

- `company` directive: a singleton, id-less, date-less master-data block whose `key: value` children map to the book's Business → Company option slots. Exported as the first business-objects section; imported in the early pass before customers/vendors. Reports created/updated/unchanged per the standard model.
- Native fields (`name`, `contact`, `id`, `phone`, `fax`, `email`, `url`, `addr1..4`) route to GnuCash's own slots — the address lines join into the single multi-line `Company Address` slot on import and split back on export. This closes the gap where Company ID and the rest were never roundtrip-tested.
- `gst` and `pst` are stored as custom `Company GST Number` / `Company PST Number` slots in the same Business frame, additive to `Company ID`. `gst` is a single value; `pst` holds one or more provincial numbers in one value separated by `;`, each rendered on its own row. Storage stays a single verbatim string, so the roundtrip is exact without inventing repeated-key parsing.
- Rendering: the seller block of plaintext, HTML, and PDF now shows Contact, GST, each PST, and Fax. Empty fields leave the output unchanged from before.
- `get_book_string_option` reads a Business option from the live in-memory book via `qof_book_get_string_option`, the inverse of `set_book_string_option`; verified on GnuCash 3.8 through 5.x. The exporter and importer use it directly, so no file path is needed.

Tests in `tests/integration/test_company_info_roundtrip.py` (fixture `tests/fixtures/company_full.txt`) cover field-exact export after import, a double-roundtrip byte-identity check (every native field plus GST and both PST numbers survive a fresh-book roundtrip), GST/multi-PST rendering in plaintext and HTML for both invoices and bills, and an unchanged baseline when no company options are set. Passing on GnuCash 3.8 and 5.10.