### PR TITLE
test(Q-028): assert the full company block renders in invoice/bill HTML

### DIFF
--- a/tests/integration/test_company_info_roundtrip.py
+++ b/tests/integration/test_company_info_roundtrip.py
@@ -162,7 +162,20 @@ def test_print_invoice_plaintext_renders_gst_and_each_pst(tmp_path):
     assert 'PST: SK 9012-3456' in text, text
 
 
-def test_print_invoice_html_renders_gst_and_each_pst(tmp_path):
+def _assert_full_company_rendered(doc):
+    """Every populated company field must appear in the rendered output.
+    Requirement: if the book carries company info, the invoice/bill prints
+    all of it — name, contact, Company ID, GST, every PST number, address,
+    phone, fax, email, url."""
+    for key, want in EXPECTED.items():
+        if key == 'pst':
+            continue  # rendered as one row per number, asserted below
+        assert want in doc, f'company field {key!r} ({want!r}) missing from render:\n{doc}'
+    for pst in ('BC PST-1234-5678', 'SK 9012-3456'):
+        assert pst in doc, f'PST {pst!r} missing from render:\n{doc}'
+
+
+def test_print_invoice_html_renders_full_company_block(tmp_path):
     runner = CliRunner()
     gf = _book_with_company_and(runner, tmp_path, 'q019_unposted_cash_with_tax.txt')
     out = tmp_path / 'inv.html'
@@ -170,20 +183,33 @@ def test_print_invoice_html_renders_gst_and_each_pst(tmp_path):
                             '--format', 'html', '-o', str(out)])
     assert r.exit_code == 0, r.output
     html = out.read_text()
-    assert 'GST: 123456789RT0001' in html, html
-    assert 'BC PST-1234-5678' in html and 'SK 9012-3456' in html, html
+    assert '>From<' in html, f'missing "From" company block:\n{html}'
+    _assert_full_company_rendered(html)
+
+
+def test_print_bill_html_renders_full_company_block(tmp_path):
+    runner = CliRunner()
+    gf = _book_with_company_and(runner, tmp_path, 'q019_unposted_cash_bill.txt')
+    bill_id = _bill_id('q019_unposted_cash_bill.txt')
+    out = tmp_path / 'bill.html'
+    r = runner.invoke(cli, ['print-bill', str(gf), bill_id,
+                            '--format', 'html', '-o', str(out)])
+    assert r.exit_code == 0, r.output
+    _assert_full_company_rendered(out.read_text())
+
+
+def _bill_id(fixture_name):
+    """Discover the bill id from a fixture's `bill "..."` header."""
+    for line in (FIXTURES / fixture_name).read_text().splitlines():
+        if line.startswith('bill "'):
+            return line.split('"')[1]
+    raise AssertionError(f'no bill header in {fixture_name}')
 
 
 def test_print_bill_plaintext_renders_gst_and_each_pst(tmp_path):
     runner = CliRunner()
     gf = _book_with_company_and(runner, tmp_path, 'q019_unposted_cash_bill.txt')
-    # Discover the bill id from the fixture header.
-    bill_id = None
-    for line in (FIXTURES / 'q019_unposted_cash_bill.txt').read_text().splitlines():
-        if line.startswith('bill "'):
-            bill_id = line.split('"')[1]
-            break
-    assert bill_id, 'could not find bill id in fixture'
+    bill_id = _bill_id('q019_unposted_cash_bill.txt')
     out = tmp_path / 'bill.txt'
     r = runner.invoke(cli, ['print-bill', str(gf), bill_id,
                             '--format', 'plaintext', '-o', str(out)])


### PR DESCRIPTION
The Q-028 render tests only checked that GST and the PST numbers reached the seller block, so the other company fields — notably the `contact` and `fax` lines added with the feature — were rendered but never asserted. The requirement is stronger: when the book carries company info, the rendered invoice and bill must print all of it.

- `_assert_full_company_rendered` checks every populated field from the `company_full.txt` fixture (name, contact, Company ID, GST, each PST number, all address lines, phone, fax, email, url) appears in the rendered document.
- `test_print_invoice_html_renders_full_company_block` and `test_print_bill_html_renders_full_company_block` apply it to the HTML output of both commands, also confirming HTML is a usable output format end to end. PDF carries the same XSLT-rendered HTML verbatim, so this covers the PDF content too.
- `_bill_id` helper factors out discovering the bill id from a fixture header, shared by the bill plaintext and HTML tests.

Passing on GnuCash 3.8 and 5.10.