### PR TITLE
feat(Q-029): accept arbitrary keys on the company directive as book metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,6 +877,27 @@ Only non-empty fields are emitted on export. On import the directive is the
 source of truth for the fields it names; it reports `created` / `updated` /
 `unchanged` like other business objects.
 
+Beyond the fields above, the `company` directive accepts **any key** — like
+`customer`, `vendor`, and account `open` directives do. Keys it doesn't
+recognise are kept as book-level data that round-trips but is **never rendered**
+on an invoice or bill (it is private to you, not the recipient):
+
+```
+company
+  name: "Acme Inc."
+  id: "123456789RT0001"
+  fiscal_year_end: "12-31"
+  province: "British Columbia"
+  entity_type: "T2 Corporation"
+  ledger_locale: "en_CA"
+```
+
+This is the place for book-level facts GnuCash itself has no field for — a
+fiscal year end, entity type, locale. (GnuCash's accounting-period dates, for
+instance, are an application preference, not stored in the file, so there is no
+native slot to map them to.) These custom keys are stored together in the book
+and re-emitted on export; they never reach the rendered seller block.
+
 **Invoice and bill status fields**
 
 The `posted:` and `payment:` fields are always present in exported output.

--- a/docs/issues/Q-029-company-arbitrary-book-keys.md
+++ b/docs/issues/Q-029-company-arbitrary-book-keys.md
@@ -1,0 +1,62 @@
+---
+id: Q-029
+title: company directive only round-trips known seller-identity keys; no way to store arbitrary book-level data
+category: quality
+severity: medium
+status: closed
+---
+
+## Problem
+
+The `company` directive (Q-028) round-trips a fixed set of GnuCash Business options — name, contact, Company ID, GST/PST, address, phone, fax, email, url. It is the only book-level directive, and it only understands those known keys. There is no way to record other book-level information through plaintext import — a fiscal year end, a province, an entity type (e.g. "T2 Corporation"), a ledger locale.
+
+The CLI can already set arbitrary book string options internally (`set_book_string_option` / `get_book_string_option`), but that capability is not exposed to `import`. Every other directive — `customer`, `vendor`, `account` — already accepts arbitrary keys beyond its known ones and round-trips them as custom metadata; `company` did not.
+
+Note on accounting period specifically: GnuCash's Start Date / End Date of the accounting period are an **application preference** (GSettings), not stored in the `.gnucash` file. So there is no native book slot to map a fiscal year to — it can only be kept as our own book-level data.
+
+## Fix
+
+The `company` directive now accepts **any** key. Known keys map to GnuCash Business option slots and render in the seller block as before. **Any other key** is kept as book-level custom metadata that round-trips but is never rendered — private book data (a customer has no business seeing the seller's fiscal year).
+
+```
+company
+  name: "Acme Inc."
+  id: "123456789RT0001"
+  gst: "123456789RT0001"
+  fiscal_year_end: "12-31"
+  province: "British Columbia"
+  entity_type: "T2 Corporation"
+  ledger_locale: "en_CA"
+```
+
+### Storage
+
+All custom (non-Business) keys are serialised together as one JSON blob in a single dedicated book option slot, `options/Plaintext/Custom Metadata`, via the existing `set_book_string_option`. One fixed slot (rather than one slot per key) means the exporter reads it back by a known path — avoiding cross-version KVP key-enumeration, which the bindings make unreliable. The section is private to this tool, so it never collides with GnuCash's own Business options. The object-level `set_custom_metadata` path was tried first and does **not** persist on the book object (verified empirically — it read back empty), which is why the book-option path is used.
+
+The directive replaces the whole custom-metadata blob whenever it carries any custom keys (mirrors `set_custom_metadata` semantics on other objects); a directive with no custom keys leaves the existing blob untouched.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `infrastructure/gnucash/kvp.py` | `COMPANY_CUSTOM_SECTION` / `COMPANY_CUSTOM_SLOT` constants for the dedicated custom-metadata slot. |
+| `services/gnucash_importer.py` | `import_company` collects every non-Business, non-address key into a JSON blob and writes it via `set_book_string_option`. |
+| `use_cases/export_business_objects.py` | `_export_company` reads the blob back and emits each custom key as its own `key: value` line (sorted, stable round-trip). |
+| `README.md` | Document arbitrary custom keys on the `company` directive. |
+
+## Tests
+
+`tests/integration/test_company_custom_book_keys.py` (fixture `tests/fixtures/company_custom_keys.txt`):
+
+- Custom keys export with their exact values alongside the known fields.
+- Double-roundtrip (import → export → fresh import → export) keeps the whole `company` block byte-identical, custom keys included.
+- Custom keys and their distinctive values do **not** appear in rendered `print-invoice` / `print-bill` output (plaintext and HTML), while a known field (GST) still renders — proving the seller block runs but private book data stays out of it.
+- Passing on GnuCash 3.8 and 5.10.
+
+## Related issues
+
+- **Q-028** — the `company` directive and the Business string-option round-trip this extends.
+
+---
+
+**Created**: 2026-06-17

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -73,3 +73,4 @@ and in the **Status** column below.
 | [Q-026](Q-026-multi-invoice-payment-amount-allocation.md) | One bank tx paying multiple invoices/bills exports the bank total as each record's payment amount | medium | closed |
 | [Q-027](Q-027-account-guid-not-preserved-on-import.md) | Account GUIDs are not preserved on import, so they drift every roundtrip | medium | closed |
 | [Q-028](Q-028-company-info-gst-pst-roundtrip.md) | Company info (incl. GST/PST registration numbers) is not round-tripped, and there is nowhere to record GST/PST | medium | closed |
+| [Q-029](Q-029-company-arbitrary-book-keys.md) | company directive only round-trips known seller-identity keys; no way to store arbitrary book-level data | medium | closed |

--- a/infrastructure/gnucash/kvp.py
+++ b/infrastructure/gnucash/kvp.py
@@ -27,6 +27,13 @@ from typing import Optional
 
 PT_DATA_SLOT = 'plaintext_metadata'
 
+# Q-029: book option slot that stores the `company` directive's custom
+# (non-Business) keys as one JSON blob — `fiscal_year_end`, `province`, etc.
+# A private section so it never collides with GnuCash's own Business options;
+# one fixed slot so export reads it back by path without KVP key-enumeration.
+COMPANY_CUSTOM_SECTION = 'Plaintext'
+COMPANY_CUSTOM_SLOT = 'Custom Metadata'
+
 # Transaction metadata keys that have dedicated GnuCash setters.
 # Any key NOT in this set is treated as custom metadata → KVP slot.
 KNOWN_TX_METADATA_KEYS = frozenset({

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -6,6 +6,7 @@ Converts PlaintextDirective objects from the parser into GnuCash objects
 """
 
 import ctypes
+import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -31,6 +32,8 @@ from gnucash.gnucash_core_c import (
 )
 
 from infrastructure.gnucash.kvp import (
+    COMPANY_CUSTOM_SECTION,
+    COMPANY_CUSTOM_SLOT,
     KNOWN_ACCOUNT_METADATA_KEYS,
     KNOWN_BILL_METADATA_KEYS,
     KNOWN_CUSTOMER_METADATA_KEYS,
@@ -70,6 +73,15 @@ COMPANY_FIELD_TO_SLOT = {
     'url':     'Company Website URL',
 }
 _COMPANY_ADDR_KEYS = ('addr1', 'addr2', 'addr3', 'addr4')
+
+# Q-029: any `company` key that is not a known Business field (above) or an
+# address line is book-level custom metadata — e.g. `fiscal_year_end`,
+# `province`, `entity_type`, `ledger_locale`. GnuCash has no slot for these
+# (accounting period is an app preference, not stored in the file), so they are
+# kept as our own book metadata under COMPANY_CUSTOM_SECTION/COMPANY_CUSTOM_SLOT
+# (one JSON blob; see kvp.py). These keys round-trip but are never rendered on
+# an invoice/bill — they are private book data (a customer has no business
+# seeing the seller's fiscal year).
 
 
 def string_to_gnc_numeric_quantity(s):
@@ -2492,6 +2504,11 @@ class GnuCashImporter:
         slots; `pst` may carry several numbers in one string (split for
         rendering, stored verbatim).
 
+        Q-029: any key that is not a known Business field or address line is
+        kept as book-level custom metadata (e.g. `fiscal_year_end`, `province`,
+        `entity_type`) — serialised together as one JSON blob in a dedicated
+        book option slot. These round-trip but are not rendered.
+
         Status compares each field to the book's current value so a no-op
         re-import reports 'unchanged'. 'created' when the book had no company
         options before, else 'updated'."""
@@ -2525,6 +2542,23 @@ class GnuCashImporter:
                 had_any = True
             if current != addr_val:
                 set_book_string_option(book, 'Business', 'Company Address', addr_val)
+                changed = True
+
+        # Q-029: collect any remaining keys as book-level custom metadata. The
+        # directive replaces the whole custom-metadata blob when it carries any
+        # custom keys (mirrors `set_custom_metadata` semantics on other
+        # objects); an absent custom key set leaves the existing blob alone.
+        known = set(COMPANY_FIELD_TO_SLOT) | set(_COMPANY_ADDR_KEYS)
+        custom = {k: v for k, v in md.items() if k not in known and v is not None}
+        if custom:
+            blob = json.dumps(custom, ensure_ascii=False, sort_keys=True)
+            current = get_book_string_option(
+                book, COMPANY_CUSTOM_SECTION, COMPANY_CUSTOM_SLOT) or ''
+            if current:
+                had_any = True
+            if current != blob:
+                set_book_string_option(
+                    book, COMPANY_CUSTOM_SECTION, COMPANY_CUSTOM_SLOT, blob)
                 changed = True
 
         if not changed:

--- a/tests/fixtures/company_custom_keys.txt
+++ b/tests/fixtures/company_custom_keys.txt
@@ -1,0 +1,9 @@
+company
+	name: "Acme Plaintext Co."
+	id: "123456789RT0001"
+	gst: "123456789RT0001"
+	pst: "BC PST-1234-5678; SK 9012-3456"
+	fiscal_year_end: "12-31"
+	province: "British Columbia"
+	entity_type: "T2 Corporation"
+	ledger_locale: "en_CA"

--- a/tests/integration/test_company_custom_book_keys.py
+++ b/tests/integration/test_company_custom_book_keys.py
@@ -1,0 +1,152 @@
+"""Q-029: the `company` directive accepts arbitrary keys beyond the known
+Business identity fields. Any unknown key (e.g. `fiscal_year_end`, `province`,
+`entity_type`, `ledger_locale`) is stored as book-level custom metadata and
+round-trips through export/import — but is NEVER rendered on an invoice or bill,
+because it is private book data (a customer has no business seeing the seller's
+fiscal year).
+
+GnuCash has no native slot for these (accounting period is an app preference,
+not stored in the file), so they live in a dedicated book option slot as one
+JSON blob.
+"""
+
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURES = Path('tests/fixtures')
+ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
+COMPANY = str(FIXTURES / 'company_custom_keys.txt')
+
+KNOWN = {
+    'name': 'Acme Plaintext Co.',
+    'id':   '123456789RT0001',
+    'gst':  '123456789RT0001',
+    'pst':  'BC PST-1234-5678; SK 9012-3456',
+}
+CUSTOM = {
+    'fiscal_year_end': '12-31',
+    'province':        'British Columbia',
+    'entity_type':     'T2 Corporation',
+    'ledger_locale':   'en_CA',
+}
+
+
+def _new_book(runner, tmp_path, name='book.gnucash'):
+    gf = tmp_path / name
+    assert runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS]).exit_code == 0
+    time.sleep(1)
+    return gf
+
+
+def _import(runner, gf, content, tmp_path, name):
+    p = tmp_path / name
+    p.write_text(content)
+    r = runner.invoke(cli, ['import', str(gf), str(p), '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+
+
+def _export(runner, gf, tmp_path, name='exp.txt'):
+    out = tmp_path / name
+    r = runner.invoke(cli, ['export', str(gf), str(out), '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    return out.read_text()
+
+
+def _company_block(text):
+    out, capturing = [], False
+    for line in text.splitlines():
+        if not capturing:
+            if line.strip() == 'company' and not line[:1].isspace():
+                capturing = True
+                out.append(line)
+            continue
+        if line[:1].isspace():
+            out.append(line)
+        else:
+            break
+    return '\n'.join(out)
+
+
+def _company_fields(text):
+    fields = {}
+    for line in _company_block(text).splitlines()[1:]:
+        key, _, val = line.strip().partition(':')
+        val = val.strip()
+        if val.startswith('"') and val.endswith('"'):
+            val = val[1:-1]
+        fields[key.strip()] = val
+    return fields
+
+
+def test_custom_keys_round_trip_with_values(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf, Path(COMPANY).read_text(), tmp_path, 'company.txt')
+    fields = _company_fields(_export(runner, gf, tmp_path))
+    for key, want in {**KNOWN, **CUSTOM}.items():
+        assert fields.get(key) == want, (key, fields)
+
+
+def test_custom_keys_survive_double_roundtrip(tmp_path):
+    runner = CliRunner()
+    gf_a = _new_book(runner, tmp_path, 'A.gnucash')
+    _import(runner, gf_a, Path(COMPANY).read_text(), tmp_path, 'company.txt')
+    e1 = _export(runner, gf_a, tmp_path, 'e1.txt')
+    block1 = _company_block(e1)
+    assert block1, e1
+
+    gf_b = tmp_path / 'B.gnucash'
+    (tmp_path / 'e1_in.txt').write_text(e1)
+    assert runner.invoke(cli, ['import', '--new', str(gf_b),
+                               str(tmp_path / 'e1_in.txt'),
+                               '--include-business-objects']).exit_code == 0
+    time.sleep(1)
+    block2 = _company_block(_export(runner, gf_b, tmp_path, 'e2.txt'))
+    assert block1 == block2, f'--- e1 ---\n{block1}\n--- e2 ---\n{block2}'
+
+
+def _book_with_company_and(runner, tmp_path, doc_fixture):
+    gf = _new_book(runner, tmp_path)
+    combined = Path(COMPANY).read_text() + '\n\n' + (FIXTURES / doc_fixture).read_text()
+    _import(runner, gf, combined, tmp_path, 'doc.txt')
+    return gf
+
+
+def _assert_custom_not_rendered(doc):
+    # Sanity: a known identity field IS rendered, proving the seller block ran.
+    assert 'GST: 123456789RT0001' in doc, doc
+    # The private custom keys and their distinctive values must NOT appear.
+    for token in ('fiscal_year_end', '12-31', 'entity_type', 'T2 Corporation',
+                  'ledger_locale', 'en_CA', 'province', 'British Columbia'):
+        assert token not in doc, f'custom data {token!r} leaked into render:\n{doc}'
+
+
+def test_custom_keys_not_rendered_on_invoice(tmp_path):
+    runner = CliRunner()
+    gf = _book_with_company_and(runner, tmp_path, 'q019_unposted_cash_with_tax.txt')
+    for fmt, ext in (('plaintext', 'txt'), ('html', 'html')):
+        out = tmp_path / f'inv.{ext}'
+        r = runner.invoke(cli, ['print-invoice', str(gf), 'INV-Q19-CASH-TAX-200',
+                                '--format', fmt, '-o', str(out)])
+        assert r.exit_code == 0, r.output
+        _assert_custom_not_rendered(out.read_text())
+
+
+def test_custom_keys_not_rendered_on_bill(tmp_path):
+    runner = CliRunner()
+    gf = _book_with_company_and(runner, tmp_path, 'q019_unposted_cash_bill.txt')
+    bill_id = None
+    for line in (FIXTURES / 'q019_unposted_cash_bill.txt').read_text().splitlines():
+        if line.startswith('bill "'):
+            bill_id = line.split('"')[1]
+            break
+    out = tmp_path / 'bill.txt'
+    r = runner.invoke(cli, ['print-bill', str(gf), bill_id, '--format', 'plaintext',
+                            '-o', str(out)])
+    assert r.exit_code == 0, r.output
+    _assert_custom_not_rendered(out.read_text())

--- a/use_cases/export_business_objects.py
+++ b/use_cases/export_business_objects.py
@@ -8,6 +8,7 @@ GnuCash Python SWIG bindings have const-type mismatches for these calls
 See infrastructure/gnucash/engine.py for the platform notes.
 """
 
+import json
 from fractions import Fraction
 
 import gnucash.gnucash_business as gb
@@ -15,7 +16,12 @@ import gnucash.gnucash_core_c as gc
 from gnucash import Book, Query, Split
 
 from infrastructure.gnucash.engine import iterate_glist, load_gnc_engine, safe_ctypes_string
-from infrastructure.gnucash.kvp import get_book_string_option, get_custom_metadata
+from infrastructure.gnucash.kvp import (
+    COMPANY_CUSTOM_SECTION,
+    COMPANY_CUSTOM_SLOT,
+    get_book_string_option,
+    get_custom_metadata,
+)
 from infrastructure.gnucash.utils import (
     encode_value_as_string,
     format_amount_for_commodity,
@@ -200,6 +206,18 @@ class ExportBusinessObjectsUseCase:
             val = opt(slot)
             if val:
                 lines.append(f'\t{key}: {encode_value_as_string(val)}')
+                has_value = True
+
+        # Q-029: custom (non-Business) keys stored as one JSON blob — emit each
+        # back as its own `key: value` line (sorted for a stable round-trip).
+        blob = get_book_string_option(self.book, COMPANY_CUSTOM_SECTION, COMPANY_CUSTOM_SLOT)
+        if blob:
+            try:
+                custom = json.loads(blob)
+            except (ValueError, TypeError):
+                custom = {}
+            for key in sorted(custom):
+                lines.append(f'\t{key}: {encode_value_as_string(custom[key])}')
                 has_value = True
 
         return '\n'.join(lines) if has_value else ''


### PR DESCRIPTION
The `company` directive — the only book-level directive — round-tripped just a fixed set of GnuCash Business options (name, contact, ID, GST/PST, address, phone, fax, email, url). There was no way to record any other book-level fact through plaintext import: a fiscal year end, a province, an entity type, a ledger locale. Yet `customer`, `vendor`, and account `open` directives have always accepted arbitrary keys and round-tripped them as custom metadata; `company` was the exception.

The `company` directive now accepts any key. Known keys map to GnuCash Business slots and render in the seller block as before. Any other key is kept as book-level data that round-trips but is never rendered on an invoice or bill — it is private to the seller, not something a customer should see (a recipient has no business seeing your fiscal year end).

```
company
  name: "Acme Inc."
  id: "123456789RT0001"
  fiscal_year_end: "12-31"
  province: "British Columbia"
  entity_type: "T2 Corporation"
  ledger_locale: "en_CA"
```

- Custom keys are serialised together as one JSON blob in a dedicated book option slot, `options/Plaintext/Custom Metadata`, written and read via the existing `set_book_string_option` / `get_book_string_option`. One fixed slot means the exporter reads it back by a known path, avoiding cross-version KVP key-enumeration, which the bindings make unreliable. The section is private to this tool, so it never collides with GnuCash's own Business options.
- The object-level `set_custom_metadata` path does not persist on the book object (verified empirically — it reads back empty), which is why the book-option path is used.
- This is the home for book-level facts GnuCash has no field for. GnuCash's accounting-period dates, for example, are an application preference, not stored in the file, so there is no native slot to map a fiscal year to.

Tests in `tests/integration/test_company_custom_book_keys.py` (fixture `tests/fixtures/company_custom_keys.txt`): custom keys export with their exact values alongside the known fields; a double-roundtrip keeps the whole company block byte-identical; the custom keys and their distinctive values never appear in rendered print-invoice / print-bill output (plaintext and HTML) while a known field still renders. Passing on GnuCash 3.8 and 5.10.