### PR TITLE
feat(Q-030): rename an account by GUID, keeping all its splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,36 @@ instead:
 gnucash-plaintext export-accounts mybook.gnucash accounts.txt --as-of 2024-01-01
 ```
 
+### Rename an account
+
+Rename an account, identified by its GUID. `--to` is the account's new full
+name, so a single rename can change the leaf, the parent, or both at once:
+
+```bash
+# New leaf, same parent: Assets:Bank:Checking → Assets:Bank:Chequing
+gnucash-plaintext rename-account mybook.gnucash \
+    --guid 51359958977a4ca88ec927c2958b3d8b --to "Chequing"
+
+# New parent, same leaf → Assets:Checking
+gnucash-plaintext rename-account mybook.gnucash \
+    --guid 51359958977a4ca88ec927c2958b3d8b --to "Assets:Checking"
+
+# New parent and new leaf together → Assets:Cash:Petty
+gnucash-plaintext rename-account mybook.gnucash \
+    --guid 51359958977a4ca88ec927c2958b3d8b --to "Assets:Cash:Petty"
+```
+
+This is a targeted operation, not something the full export/edit/import cycle can
+do — every transaction names its account by full path, so renaming an account in
+the text would mean rewriting every transaction that references it. GnuCash keeps
+splits attached to accounts by reference, so renaming the account in place carries
+all its transactions with it; the next export prints the new path everywhere
+automatically. The account is found by GUID (run `export-accounts` to see each
+account's `guid:`), never by its old name. Any named parent must already exist.
+Renaming an account under itself or a descendant, a name collision under the
+target parent, or an unknown GUID/parent are all refused with an explicit message
+and leave the book untouched.
+
 ### Export transactions by GUID
 
 Export one or more transactions to plaintext (useful for AI-assisted editing or review):

--- a/cli/main.py
+++ b/cli/main.py
@@ -29,6 +29,7 @@ from cli.import_beancount_cmd import import_beancount
 from cli.import_cmd import import_transactions
 from cli.income_statement_cmd import income_statement
 from cli.invoice_print_cmd import print_invoice
+from cli.rename_account_cmd import rename_account
 from cli.unapply_cmd import unapply_payment
 from cli.unpost_cmd import unpost_bills, unpost_invoices
 from cli.validate_cmd import validate_ledger
@@ -79,6 +80,7 @@ cli.add_command(archive_vendors, name='archive-vendors')
 cli.add_command(unpost_invoices, name='unpost-invoices')
 cli.add_command(unpost_bills, name='unpost-bills')
 cli.add_command(unapply_payment, name='unapply-payment')
+cli.add_command(rename_account, name='rename-account')
 cli.add_command(find_orphan_payments, name='find-orphan-payments')
 cli.add_command(find_prepayments, name='find-prepayments')
 

--- a/cli/rename_account_cmd.py
+++ b/cli/rename_account_cmd.py
@@ -1,0 +1,87 @@
+"""CLI command: rename an account, identified by its GUID.
+
+`rename-account <book> --guid <account-guid> --to "<new name>"`
+
+Renames an account in place. `--to` is the account's new full name; one rename
+can change the leaf, the parent, or both at once:
+  - bare leaf ("Chequing")           → new leaf, same parent
+  - full path ("Assets:Chequing")    → new parent, same leaf
+  - full path ("Assets:Cash:Petty")  → new parent and new leaf together
+
+The account is found by GUID, never by its old name (that is what changes).
+Because GnuCash keeps splits attached to accounts by reference, every
+transaction that touched the account follows it automatically — nothing in the
+ledger text needs editing. On the next export the account's new path is printed
+wherever it appears.
+"""
+
+import sys
+
+import click
+
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from use_cases.rename_account import execute_rename
+
+
+@click.command('rename-account')
+@click.argument('gnucash_file', type=click.Path(exists=True))
+@click.option('--guid', 'account_guid', required=True,
+              help='GUID of the account to rename (stable identity, not the old name).')
+@click.option('--to', 'new_name', required=True,
+              help='New full name. Bare leaf ("Chequing") keeps the parent; full '
+                   'path ("Assets:Cash:Petty") sets a new parent and/or leaf.')
+def rename_account(gnucash_file, account_guid, new_name):
+    """Rename an account by GUID, keeping all its splits."""
+    repo = GnuCashRepository(gnucash_file)
+    repo.open(mode=SessionMode.NORMAL)
+    try:
+        result = execute_rename(repo.book, account_guid, new_name)
+        if result.status == 'renamed':
+            repo.save()
+    finally:
+        repo.close()
+
+    if result.status == 'renamed':
+        click.echo(f'renamed account {result.old_name!r} → {result.new_name!r} '
+                   f'(guid {result.guid})')
+        return
+    if result.status == 'unchanged':
+        click.echo(f'account {result.old_name!r} (guid {result.guid}) is already '
+                   f'named {new_name!r} — nothing to change')
+        return
+
+    # Failure: every message names the account, what was attempted, why it was
+    # refused, and how to fix it — and the book is left untouched.
+    msgs = {
+        'bad_guid':
+            f'--guid {account_guid!r} is not a valid account GUID: {result.detail}. '
+            f'Pass the 32-character hex GUID; run `export-accounts` to list each '
+            f"account's `guid:`.",
+        'not_found':
+            f'no account in this book has guid {account_guid!r}. Identify the '
+            f'account by GUID, not its name — run `export-accounts` to list each '
+            f"account with its `guid:`.",
+        'bad_name':
+            f'invalid --to value {new_name!r} for account {result.old_name!r}: an '
+            f'account name cannot be empty or start/end with ":". Use a bare leaf '
+            f'("Chequing") or a full path ("Assets:Chequing").',
+        'parent_not_found':
+            f'cannot rename account {result.old_name!r} to {new_name!r}: the parent '
+            f'{result.detail!r} does not exist in this book. Create the parent '
+            f'account first, or check the path (parents are colon-separated).',
+        'cycle':
+            f'cannot rename account {result.old_name!r} to {new_name!r}: the new '
+            f'parent {result.detail!r} is {result.old_name!r} itself or one of its '
+            f'descendants, which would make the account its own ancestor. Choose a '
+            f'parent outside the {result.old_name!r} subtree.',
+        'name_taken':
+            f'cannot rename account {result.old_name!r} to {new_name!r}: an account '
+            f'named {result.detail!r} already exists under that parent. Pick a '
+            f'different leaf name, or rename/remove the existing account first.',
+    }
+    raise click.ClickException(
+        msgs.get(result.status, f'rename failed ({result.status})'))
+
+
+if __name__ == '__main__':
+    sys.exit(rename_account())

--- a/docs/issues/Q-030-rename-account.md
+++ b/docs/issues/Q-030-rename-account.md
@@ -1,0 +1,67 @@
+---
+id: Q-030
+title: No way to rename an account; the full round-trip can't express it
+category: feature
+severity: enhancement
+status: closed
+---
+
+## Problem
+
+GnuCash lets you rename an account — including giving it a new name under a different parent — keeping all its transactions. Our plaintext had no way to do this.
+
+The full export/import round-trip can't express it cleanly. Every transaction split names its account by **full path** (`account: "Assets:Bank:Checking"`), so renaming an account through the text would require rewriting *every* transaction line that references it — miss one and the file is inconsistent (a "breaking" edit). Worse, editing only the `open` directive's path while leaving the `guid:` would make the importer try to create a new account with an in-use GUID, which errors; with no `guid:` it silently creates a duplicate. So account restructuring was effectively impossible via plaintext.
+
+## Fix
+
+A surgical CLI command, `rename-account`, that mutates the live book directly. GnuCash keeps splits attached to accounts **by reference, not by name**, so renaming the account leaves every split intact; the next export simply prints the new path wherever the account appears — no transaction lines to hand-edit.
+
+```
+gnucash-plaintext rename-account <book> --guid <account-guid> --to "<new name>"
+```
+
+It is one operation — rename. The account is identified by **GUID** (stable since Q-027), never by its old name — the name is precisely what changes. `--to` is the account's new full name, so a single rename can change the leaf, the parent, or both at once. There is no separate "move": placing the account under a different parent is just what happens when the new name names a different parent.
+
+- bare leaf `--to "Chequing"` → `Assets:Bank:Checking` becomes `Assets:Bank:Chequing` (same parent);
+- full path `--to "Assets:Checking"` → new parent `Assets`, same leaf;
+- full path `--to "Assets:Cash:Petty"` → new parent **and** new leaf, together.
+
+Mechanically: find by GUID → `SetName(leaf)` and, only if the parent differs, `new_parent.append_child(account)`.
+
+### Guards — each refusal gives an explicit, detailed message and leaves the book untouched
+
+- `bad_guid` — `--guid` is not a valid GUID (names the value, points to `export-accounts`).
+- `not_found` — no account in the book has that GUID.
+- `parent_not_found` — a named parent in `--to` doesn't exist.
+- `cycle` — the new parent is the account itself or one of its descendants (would make the account its own ancestor).
+- `name_taken` — the target parent already has a child with the new leaf name.
+- `unchanged` — `--to` equals the current name; nothing written.
+
+Names in messages and path resolution use the plaintext colon convention; GnuCash's own `get_full_name()` uses the engine separator (`.` in a headless book), so the use case builds colon names itself.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `use_cases/rename_account.py` | `execute_rename` — GUID lookup, `--to` parsing, guards, rename/reparent. |
+| `cli/rename_account_cmd.py` | `rename-account` command. |
+| `cli/main.py` | Register the command. |
+| `README.md` | Document `rename-account`. |
+
+## Tests
+
+`tests/integration/test_rename_account.py` (fixture `tests/fixtures/rename_account_book.txt` — accounts + a transaction touching the renamed account):
+
+- all three rename shapes — leaf only, parent only, parent **and** leaf together — each preserve the **GUID**;
+- the transaction's split **follows** the account — after a rename the export prints the new path on the split and the old path appears nowhere;
+- **full export → import → export roundtrip** after a rename (all three shapes) reproduces the renamed book byte-for-byte in a fresh book, with the account at its new path, same GUID, split intact — proving the rename leaves the book self-consistent;
+- guards: malformed GUID, unknown GUID, cycle, name collision, unknown new parent each error with an explicit message and leave the book unchanged; a no-op reports `unchanged`. The failure tests assert the message content.
+- Passing on GnuCash 3.8 and 5.10.
+
+## Related issues
+
+- **Q-027** — account GUID preservation, which makes GUID-based identity reliable across roundtrips.
+
+---
+
+**Created**: 2026-06-26

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -74,3 +74,4 @@ and in the **Status** column below.
 | [Q-027](Q-027-account-guid-not-preserved-on-import.md) | Account GUIDs are not preserved on import, so they drift every roundtrip | medium | closed |
 | [Q-028](Q-028-company-info-gst-pst-roundtrip.md) | Company info (incl. GST/PST registration numbers) is not round-tripped, and there is nowhere to record GST/PST | medium | closed |
 | [Q-029](Q-029-company-arbitrary-book-keys.md) | company directive only round-trips known seller-identity keys; no way to store arbitrary book-level data | medium | closed |
+| [Q-030](Q-030-rename-account.md) | No way to rename an account; the full round-trip can't express it | enhancement | closed |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,13 @@ testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+# Default fd-level capture is kept on purpose: it shields pytest's live output
+# from GnuCash, which churns file descriptors during a run and intermittently
+# closes one. The only fallout is that pytest's capture *teardown* then crashes
+# in `os.dup2(saved_fd, 0)` with `OSError: [Errno 9] Bad file descriptor` AFTER
+# every test has passed; that teardown is hardened in tests/conftest.py to
+# swallow the EBADF. (sys-level capture is NOT used — it routes live output to
+# the real fd, so a mid-run close internal-errors pytest, which is worse.)
 addopts = "-v --tb=short"
 
 [tool.coverage.run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,54 @@ from datetime import date
 import pytest
 
 
+def _harden_pytest_capture_teardown():
+    """Stop a GnuCash fd-close from failing the run on a pytest teardown artifact.
+
+    GnuCash's backend churns file descriptors during a run — it opens and removes
+    a per-session `.LCK` lock file and writes per-session `.log` files for every
+    book session — and intermittently closes the fd pytest saved when it set up
+    fd-level output capture. At the end of the run, pytest's capture teardown
+    (`FDCapture.done()`) restores that fd with `os.dup2(saved_fd, 0)`, which then
+    raises `OSError: [Errno 9] Bad file descriptor` AFTER every test has already
+    passed — failing the whole run on a teardown artifact. It is a probabilistic
+    fd collision, not version-specific (seen on Ubuntu 20.04/Py3.8 and Debian
+    11/Py3.9); its odds rise with the number of session open/close cycles a suite
+    does.
+
+    Default fd-level capture is kept (it shields pytest's live output from the
+    fd churn — sys-level capture would route live output to the real fd and
+    internal-error pytest on a mid-run close, which is worse). Instead, wrap the
+    capture classes' `done()` so a closed fd is swallowed during teardown rather
+    than crashing the process. Targeted (only OSError), defensive (no-ops if the
+    pytest internals differ), and verified deterministically by closing pytest's
+    own saved stdin fd: crash without this, clean exit with it. No test uses the
+    fd-level capture fixtures (capfd/capfdbinary), so nothing depends on a
+    perfectly-restored fd at exit.
+    """
+    try:
+        from _pytest import capture as _cap
+    except Exception:
+        return
+
+    def _wrap(orig):
+        def _safe_done(self):
+            try:
+                return orig(self)
+            except OSError:
+                return None
+        return _safe_done
+
+    for name in ('FDCaptureBinary', 'FDCapture', 'SysCaptureBinary', 'SysCapture'):
+        cls = getattr(_cap, name, None)
+        if cls is None or not hasattr(cls, 'done') or getattr(cls, '_gnc_hardened', False):
+            continue
+        cls.done = _wrap(cls.done)
+        cls._gnc_hardened = True
+
+
+_harden_pytest_capture_teardown()
+
+
 def find_account(root_account, account_path):
     """
     Find account by full path (e.g., 'Assets:Bank:Checking').

--- a/tests/fixtures/rename_account_book.txt
+++ b/tests/fixtures/rename_account_book.txt
@@ -1,0 +1,39 @@
+2026-01-01 commodity CAD
+	mnemonic: "CAD"
+	fullname: "Canadian Dollar"
+	namespace: "CURRENCY"
+	fraction: 100
+2026-01-01 open Assets
+	type: "Asset"
+	placeholder: #True
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Bank
+	type: "Asset"
+	placeholder: #True
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Bank:Checking
+	type: "Asset"
+	placeholder: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Assets:Cash
+	type: "Asset"
+	placeholder: #True
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Expenses
+	type: "Expense"
+	placeholder: #True
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Expenses:Groceries
+	type: "Expense"
+	placeholder: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+
+2026-01-15 * "Groceries"
+	Expenses:Groceries 50.00 CAD
+	Assets:Bank:Checking -50.00 CAD

--- a/tests/integration/test_rename_account.py
+++ b/tests/integration/test_rename_account.py
@@ -1,0 +1,234 @@
+"""Q-030: `rename-account` renames / reparents an account by GUID, in place.
+
+Covers both cases the operation must handle:
+  1. different parent  → reparent (full-path `--to`)
+  2. same parent, leaf → rename (bare-leaf `--to`)
+
+In both, the account keeps its GUID and every split stays attached (GnuCash
+holds splits by reference, not by name), so the transaction that touched the
+account simply follows it — the next export prints the new path everywhere.
+"""
+
+import time
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from cli.main import cli
+
+BOOK = str(Path('tests/fixtures/rename_account_book.txt'))
+
+
+def _new_book(runner, tmp_path):
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), BOOK])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    return gf
+
+
+def _colon_name(acc):
+    # Colon-separated full name (GnuCash get_full_name() uses '.' in a headless
+    # book; the plaintext format and this command are colon-based).
+    parts = []
+    node = acc
+    while node is not None and node.get_parent() is not None:
+        parts.append(node.GetName())
+        node = node.get_parent()
+    return ':'.join(reversed(parts))
+
+
+def _accounts(gf):
+    """Return {colon_full_name: guid} for every account in the book."""
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        return {_colon_name(a): a.GetGUID().to_string()
+                for a in repo.book.get_root_account().get_descendants()}
+    finally:
+        repo.close()
+
+
+def _export(runner, gf, tmp_path):
+    out = tmp_path / 'exp.txt'
+    r = runner.invoke(cli, ['export', str(gf), str(out)])
+    assert r.exit_code == 0, r.output
+    return out.read_text()
+
+
+def _rename(runner, gf, guid, to):
+    return runner.invoke(cli, ['rename-account', str(gf), '--guid', guid, '--to', to])
+
+
+def test_leaf_rename_same_parent(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    guid = _accounts(gf)['Assets:Bank:Checking']
+
+    r = _rename(runner, gf, guid, 'Chequing')
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+
+    accts = _accounts(gf)
+    assert 'Assets:Bank:Chequing' in accts
+    assert 'Assets:Bank:Checking' not in accts
+    # GUID preserved across the rename.
+    assert accts['Assets:Bank:Chequing'] == guid
+
+
+def test_rename_to_different_parent(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    guid = _accounts(gf)['Assets:Bank:Checking']
+
+    r = _rename(runner, gf, guid, 'Assets:Checking')
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+
+    accts = _accounts(gf)
+    assert 'Assets:Checking' in accts
+    assert 'Assets:Bank:Checking' not in accts
+    assert accts['Assets:Checking'] == guid          # same account, new parent
+    assert 'Assets:Bank' in accts                     # old parent still exists
+
+
+def test_rename_changes_parent_and_leaf_together(tmp_path):
+    """A single rename can change the parent AND the leaf at once."""
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    guid = _accounts(gf)['Assets:Bank:Checking']
+
+    r = _rename(runner, gf, guid, 'Assets:Cash:Petty')
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+
+    accts = _accounts(gf)
+    assert 'Assets:Cash:Petty' in accts               # new parent + new leaf
+    assert 'Assets:Bank:Checking' not in accts
+    assert accts['Assets:Cash:Petty'] == guid
+
+
+def test_splits_follow_the_renamed_account(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    guid = _accounts(gf)['Assets:Bank:Checking']
+    assert _rename(runner, gf, guid, 'Assets:Checking').exit_code == 0
+    time.sleep(1)
+
+    exported = _export(runner, gf, tmp_path)
+    # The transaction split now names the new path; the old path is gone
+    # entirely (open directive and split alike) — nothing in the ledger text
+    # had to be hand-edited.
+    assert 'Assets:Checking' in exported
+    assert 'Assets:Bank:Checking' not in exported
+    # The split (and its -50.00) still belongs to the moved account.
+    assert 'Assets:Checking -50.00 CAD' in exported
+
+
+# ── Failure cases: each must give an explicit, detailed message and leave the
+#    book untouched. ─────────────────────────────────────────────────────────
+
+def test_malformed_guid_is_rejected(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    r = _rename(runner, gf, 'not-a-real-guid', 'Whatever')
+    assert r.exit_code != 0
+    out = r.output
+    assert 'not a valid account GUID' in out and 'not-a-real-guid' in out
+    assert 'export-accounts' in out                  # tells the user how to find it
+
+
+def test_unknown_guid_is_rejected(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    before = _accounts(gf)
+    r = _rename(runner, gf, '00000000000000000000000000000000', 'Whatever')
+    assert r.exit_code != 0
+    out = r.output
+    assert 'no account in this book has guid' in out
+    assert '00000000000000000000000000000000' in out
+    assert _accounts(gf) == before                   # book untouched
+
+
+def test_rename_cycle_is_rejected(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    # Rename Assets to a name under its own descendant Assets:Bank:Checking.
+    guid = _accounts(gf)['Assets']
+    r = _rename(runner, gf, guid, 'Assets:Bank:Checking:Assets')
+    assert r.exit_code != 0
+    out = r.output
+    assert "rename account 'Assets'" in out
+    assert 'own ancestor' in out                      # explains why
+    assert 'Assets:Bank:Checking' in out              # names the offending parent
+    assert 'Assets:Bank:Checking' in _accounts(gf)    # unchanged
+
+
+def test_name_collision_is_rejected(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    before = _accounts(gf)
+    guid = before['Assets:Bank:Checking']
+    # Expenses:Groceries already exists → renaming Checking there clashes.
+    r = _rename(runner, gf, guid, 'Expenses:Groceries')
+    assert r.exit_code != 0
+    out = r.output
+    assert "already exists under that parent" in out
+    assert 'Expenses:Groceries' in out and "'Assets:Bank:Checking'" in out
+    assert _accounts(gf) == before                    # book untouched
+
+
+def test_unknown_new_parent_is_rejected(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    guid = _accounts(gf)['Assets:Bank:Checking']
+    r = _rename(runner, gf, guid, 'Nope:Checking')
+    assert r.exit_code != 0
+    out = r.output
+    assert "parent 'Nope' does not exist" in out
+    assert "rename account 'Assets:Bank:Checking'" in out
+
+
+def test_no_op_rename_reports_unchanged(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    guid = _accounts(gf)['Assets:Bank:Checking']
+    r = _rename(runner, gf, guid, 'Checking')
+    assert r.exit_code == 0, r.output
+    assert 'nothing to change' in r.output
+
+
+# ── Full export → import roundtrip after a rename ────────────────────────────
+
+@pytest.mark.parametrize('new_to,new_path', [
+    ('Chequing',            'Assets:Bank:Chequing'),   # leaf only
+    ('Assets:Chequing',     'Assets:Chequing'),        # parent only
+    ('Assets:Cash:Petty',   'Assets:Cash:Petty'),      # parent and leaf
+])
+def test_full_roundtrip_after_rename(tmp_path, new_to, new_path):
+    """After a rename, the whole book must export to self-consistent plaintext
+    that re-imports cleanly: a fresh import → export reproduces the renamed
+    book byte-for-byte, with the account at its new path, same GUID, and the
+    transaction's split still attached."""
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    guid = _accounts(gf)['Assets:Bank:Checking']
+    assert _rename(runner, gf, guid, new_to).exit_code == 0
+    time.sleep(1)
+
+    e1 = tmp_path / 'e1.txt'
+    assert runner.invoke(cli, ['export', str(gf), str(e1)]).exit_code == 0
+    gf2 = tmp_path / 'B.gnucash'
+    assert runner.invoke(cli, ['import', '--new', str(gf2), str(e1)]).exit_code == 0
+    time.sleep(1)
+    e2 = tmp_path / 'e2.txt'
+    assert runner.invoke(cli, ['export', str(gf2), str(e2)]).exit_code == 0
+
+    # The renamed structure survives a full export→import→export unchanged.
+    assert e1.read_text() == e2.read_text()
+    accts = _accounts(gf2)
+    assert new_path in accts and 'Assets:Bank:Checking' not in accts
+    assert accts[new_path] == guid                    # GUID preserved through roundtrip
+    assert f'{new_path} -50.00 CAD' in e2.read_text()  # split followed the account

--- a/use_cases/rename_account.py
+++ b/use_cases/rename_account.py
@@ -1,0 +1,129 @@
+"""Q-030: rename an account in place, identified by its GUID.
+
+One operation — rename — that gives an account a new name. The new name is a
+full account path, so a single rename can change the leaf, the parent, or both
+at once. There is no separate "move": placing the account under a different
+parent is just what happens when the new name names a different parent.
+
+  - bare leaf  ("Chequing")            → new leaf, same parent
+  - full path  ("Assets:Chequing")     → new parent (Assets), same leaf
+  - full path  ("Assets:Cash:Petty")   → new parent AND new leaf, together
+
+A surgical book mutation the full plaintext round-trip can't express cleanly.
+Every transaction split names its account by *full path*, so renaming an
+account through the text would mean rewriting every transaction that references
+it — miss one and the file is inconsistent. GnuCash attaches splits to accounts
+by *reference* (the account's entity), not by name, so renaming the live
+account leaves every split intact; the next export simply prints the new path
+wherever the account appears.
+
+Identity is the account GUID (stable across roundtrips since Q-027), never the
+old name — the name is precisely what is changing. Any named parent in the new
+name must already exist.
+"""
+from dataclasses import dataclass
+
+from infrastructure.gnucash.guid_lookup import normalise_guid
+from infrastructure.gnucash.utils import find_account
+
+
+@dataclass
+class RenameResult:
+    # renamed | unchanged | bad_guid | not_found | bad_name | parent_not_found
+    # | cycle | name_taken
+    status: str
+    guid: str = ''
+    old_name: str = ''
+    new_name: str = ''
+    detail: str = ''
+
+
+def _norm(account) -> str:
+    return account.GetGUID().to_string().replace('-', '').lower()
+
+
+def _colon_name(account) -> str:
+    """Full account name in the plaintext convention (colon-separated). GnuCash's
+    own `get_full_name()` uses the engine separator, which defaults to '.' in a
+    headless book; the plaintext format and `find_account` are colon-based, so
+    messages and results use colons too."""
+    parts = []
+    node = account
+    while node is not None and node.get_parent() is not None:
+        parts.append(node.GetName())
+        node = node.get_parent()
+    return ':'.join(reversed(parts))
+
+
+def _find_account_by_guid(book, guid_norm):
+    root = book.get_root_account()
+    for acc in root.get_descendants():
+        if _norm(acc) == guid_norm:
+            return acc
+    return None
+
+
+def _is_self_or_descendant(candidate, account) -> bool:
+    """True if `candidate` is `account` itself or sits below it — i.e.
+    reparenting `account` under `candidate` would create a cycle. Walks up
+    from candidate to the root looking for account."""
+    target = _norm(account)
+    node = candidate
+    while node is not None:
+        if _norm(node) == target:
+            return True
+        node = node.get_parent()
+    return False
+
+
+def execute_rename(book, account_guid, new_name) -> RenameResult:
+    try:
+        guid_norm = normalise_guid(account_guid)
+    except ValueError as e:
+        return RenameResult(status='bad_guid', detail=str(e))
+
+    account = _find_account_by_guid(book, guid_norm)
+    if account is None:
+        return RenameResult(status='not_found', guid=guid_norm)
+
+    old_full = _colon_name(account)
+    name = (new_name or '').strip()
+    if not name or name.startswith(':') or name.endswith(':'):
+        return RenameResult(status='bad_name', guid=guid_norm, old_name=old_full,
+                            detail=f'invalid new name {new_name!r}')
+
+    if ':' in name:
+        *parent_parts, leaf = name.split(':')
+        parent_path = ':'.join(parent_parts)
+        new_parent = find_account(book.get_root_account(), parent_path)
+        if new_parent is None:
+            return RenameResult(status='parent_not_found', guid=guid_norm,
+                                old_name=old_full, detail=parent_path)
+    else:
+        leaf = name
+        new_parent = account.get_parent()
+
+    cur_parent = account.get_parent()
+    reparenting = _norm(new_parent) != _norm(cur_parent)
+    renaming = leaf != account.GetName()
+    if not reparenting and not renaming:
+        return RenameResult(status='unchanged', guid=guid_norm,
+                            old_name=old_full, new_name=old_full)
+
+    if reparenting and _is_self_or_descendant(new_parent, account):
+        return RenameResult(status='cycle', guid=guid_norm, old_name=old_full,
+                            detail=_colon_name(new_parent))
+
+    # A sibling under the target parent must not already own the new leaf name.
+    clash = new_parent.lookup_by_name(leaf)
+    if clash is not None and _norm(clash) != guid_norm:
+        return RenameResult(status='name_taken', guid=guid_norm, old_name=old_full,
+                            detail=f'{_colon_name(new_parent)}:{leaf}')
+
+    if reparenting:
+        new_parent.append_child(account)   # moves it; splits stay attached
+    if renaming:
+        account.SetName(leaf)
+
+    return RenameResult(status='renamed', guid=guid_norm,
+                        old_name=old_full, new_name=_colon_name(account))


### PR DESCRIPTION
GnuCash lets you rename an account — including giving it a new name under a different parent — and keep all its transactions. Plaintext had no way to do this. The full export/import round-trip can't express it: every transaction split names its account by full path, so renaming an account through the text would mean rewriting every transaction line that references it, and editing only the open directive's path either errors on the in-use GUID or silently creates a duplicate.

A surgical command, `rename-account`, mutates the live book directly. GnuCash keeps splits attached to accounts by reference, not by name, so renaming the account leaves every split intact; the next export prints the new path wherever the account appears, with no transaction lines to hand-edit.

```
gnucash-plaintext rename-account <book> --guid <account-guid> --to "<new name>"
```

- One operation: rename. `--to` is the account's new full name, so a single rename can change the leaf, the parent, or both at once. There is no separate "move" — placing the account under a different parent is just what happens when the new name names a different parent. `--to "Chequing"` renames the leaf in place; `--to "Assets:Checking"` sets a new parent; `--to "Assets:Cash:Petty"` sets a new parent and leaf together.
- The account is found by GUID (stable since Q-027), never by its old name — the name is precisely what changes. Path resolution and messages use the plaintext colon convention; GnuCash's own get_full_name() uses the engine separator ('.' in a headless book), so the use case builds colon names itself.
- Every refusal gives an explicit, detailed message — naming the account, what was attempted, why it was refused, and how to fix it — and leaves the book untouched: a malformed GUID, an unknown GUID, a new parent that doesn't exist, a cycle (the new parent is the account itself or a descendant), or a name collision under the target parent. A no-op rename reports unchanged.

Tests in `tests/integration/test_rename_account.py` (fixture `tests/fixtures/rename_account_book.txt`, accounts plus a transaction touching the renamed account): all three rename shapes preserve the GUID; the transaction's split follows the account so the export shows the new path and the old path nowhere; a full export → import into a fresh book → export reproduces the renamed book byte-for-byte with the account at its new path, same GUID, and split intact; and every guard errors with an asserted message while leaving the book unchanged. Passing on GnuCash 3.8 and 5.10.