### PR TITLE
feat(Q-031): migrate — batch operations and versioned migrations in one save

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,55 @@ Renaming an account under itself or a descendant, a name collision under the
 target parent, or an unknown GUID/parent are all refused with an explicit message
 and leave the book untouched.
 
+### Migrations: batch operations with `migrate`
+
+Surgical commands (`rename-account`, …) each open the book, do one change, and
+save. Because a GnuCash save writes a backup whose filename has a *second*
+timestamp, two saves in the same second collide — so back-to-back operations
+must be ≥1s apart, and renaming 200 accounts takes 200+ seconds. `migrate`
+applies many operations to one open book and saves **once**.
+
+A migration is a versioned file of **operation** lines. Each line uses CLI
+syntax — an operation command and its arguments, minus the book (the book is
+`migrate`'s target) — but a migration line is *not* "any CLI command": only the
+mutating operations (`rename-account`, `set-book-key`) are allowed. Read/meta
+commands (`export`, `import`, `print-invoice`, and `migrate` itself) are refused,
+so a migration only changes the target book and **migrations cannot nest**.
+
+```
+# migrations/0002_restructure.txt
+rename-account --guid 51359958977a4ca88ec927c2958b3d8b --to "Assets:Current:Chequing"
+rename-account --guid 0409000f1f9c4374aa1651b6c42ed919 --to "Assets:Current:Savings"
+set-book-key --key schema_version --value 2
+```
+
+```bash
+gnucash-plaintext migrate mybook.gnucash migrations/
+# applied 1 migration(s) in 1 save; head: 0002_restructure
+
+gnucash-plaintext migrate mybook.gnucash migrations/ --status   # applied vs pending
+gnucash-plaintext migrate mybook.gnucash migrations/ --dry-run  # show, change nothing
+```
+
+Files apply in filename order (the zero-padded prefix is the version). Each is
+applied **atomically**: if any operation fails, `migrate` aborts before saving —
+nothing persists and nothing is recorded — and the message names the migration,
+the failing line, and that command's own error.
+
+**History is tracked in two places.** The book itself records which migrations
+were applied (in `options/Plaintext/Migrations`, the source of truth that travels
+with the file). A cheap, readable sidecar — `mybook.gnucash.migrate-state.json` —
+mirrors it and is stamped with the book's size+mtime, so a re-run with nothing
+pending answers `up to date … book not opened` **without opening the (expensive)
+GnuCash file** — safe to run on every deploy. Applied migrations are immutable:
+editing one after it ran is rejected (write a new migration instead). `--verify`
+ignores the sidecar and checks the book directly.
+
+A migration can also stamp your **own** version marker with `set-book-key`
+(e.g. `--key schema_version --value 2`), stored as book metadata that round-trips
+via the `company` directive — separate from the tool's automatic
+applied-migrations log.
+
 ### Export transactions by GUID
 
 Export one or more transactions to plaintext (useful for AI-assisted editing or review):

--- a/cli/_batch.py
+++ b/cli/_batch.py
@@ -1,0 +1,38 @@
+"""Session ownership for batched operations (Q-031: `migrate`).
+
+Each surgical CLI command (`rename-account`, …) used to open the book, do one
+mutation, and save — so applying N of them meant N saves, and because a GnuCash
+save writes a backup whose filename has a *second*-resolution timestamp, two
+saves in the same second collide; back-to-back ops must be ≥1s apart. 200
+renames ⇒ 200+ seconds.
+
+To batch many operations into a single save, session ownership moves out of the
+individual commands and up to a parent (the `migrate` runner). A command checks
+the Click context: if a `BatchSession` is present it mutates that shared book and
+records the change, leaving the single save to the owner; otherwise it runs
+standalone — opens the book, mutates, saves once, closes — exactly as before.
+"""
+
+
+class BatchSession:
+    """A book held open across a batch of operation commands, plus the running
+    record of what they did. Operation commands mutate `book` and call
+    `mark_dirty()` / `note()`; the owner performs the one save at the end."""
+
+    def __init__(self, book):
+        self.book = book
+        self.dirty = False
+        self.log = []  # one human-readable line per applied operation
+
+    def mark_dirty(self):
+        self.dirty = True
+
+    def note(self, message):
+        self.log.append(message)
+
+
+def current_batch(ctx):
+    """Return the active `BatchSession` from the Click context, or None when the
+    command is being run standalone (no parent owns the session)."""
+    obj = getattr(ctx, 'obj', None)
+    return obj if isinstance(obj, BatchSession) else None

--- a/cli/main.py
+++ b/cli/main.py
@@ -29,7 +29,9 @@ from cli.import_beancount_cmd import import_beancount
 from cli.import_cmd import import_transactions
 from cli.income_statement_cmd import income_statement
 from cli.invoice_print_cmd import print_invoice
+from cli.migrate_cmd import migrate
 from cli.rename_account_cmd import rename_account
+from cli.set_book_key_cmd import set_book_key
 from cli.unapply_cmd import unapply_payment
 from cli.unpost_cmd import unpost_bills, unpost_invoices
 from cli.validate_cmd import validate_ledger
@@ -81,6 +83,8 @@ cli.add_command(unpost_invoices, name='unpost-invoices')
 cli.add_command(unpost_bills, name='unpost-bills')
 cli.add_command(unapply_payment, name='unapply-payment')
 cli.add_command(rename_account, name='rename-account')
+cli.add_command(set_book_key, name='set-book-key')
+cli.add_command(migrate, name='migrate')
 cli.add_command(find_orphan_payments, name='find-orphan-payments')
 cli.add_command(find_prepayments, name='find-prepayments')
 

--- a/cli/migrate_cmd.py
+++ b/cli/migrate_cmd.py
@@ -1,0 +1,195 @@
+"""CLI command: apply versioned migrations to a book in a single save.
+
+`migrate <book> <migrations-dir> [--dry-run] [--status] [--verify]`
+
+Each migration file (`migrations/0002_rename_chequing.txt`) is an ordered list
+of operation lines — every line is a CLI invocation minus the book (the book is
+this command's target), parsed by Click itself. All pending migrations apply to
+one open book and are persisted with ONE save, so 200 renames cost ~1 save, not
+200 (each save writes a second-stamped backup, forcing ≥1s between saves).
+
+History lives in two layers: the in-book `options/Plaintext/Migrations` slot is
+the source of truth (travels with the file); a cheap `<book>.migrate-state.json`
+sidecar, stamped with the book's size+mtime, lets a no-op run conclude there is
+nothing to do WITHOUT opening the (expensive) GnuCash file.
+"""
+
+import shlex
+import sys
+from datetime import datetime, timezone
+
+import click
+
+from cli._batch import BatchSession
+from cli.rename_account_cmd import rename_account
+from cli.set_book_key_cmd import set_book_key
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from use_cases.migrate import (
+    compute_pending,
+    discover_migrations,
+    read_applied_from_book,
+    read_sidecar,
+    sidecar_is_fresh,
+    write_applied_to_book,
+    write_sidecar,
+)
+
+# The ALLOWLIST of operations a migration line may invoke: name → batch-aware
+# Click command. A migration line uses CLI syntax, but it is NOT "any CLI
+# command" — only these mutating operations are valid. Read/meta commands
+# (export, import, print-invoice, and `migrate` itself) are intentionally absent,
+# so a migration can only apply changes to the target book, and migrations cannot
+# nest. Adding a batch-aware command here makes it a valid migration operation.
+_OPERATIONS = {
+    'rename-account': rename_account,
+    'set-book-key': set_book_key,
+}
+
+
+def _now():
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _apply_op(batch, line):
+    """Parse one migration line as a CLI invocation and run it against the shared
+    batch session. Raises click.ClickException / UsageError on failure."""
+    tokens = shlex.split(line)
+    if not tokens:
+        return
+    name, rest = tokens[0], tokens[1:]
+    if name == 'migrate':
+        raise click.ClickException(
+            "'migrate' cannot appear inside a migration — migrations do not nest. "
+            "A migration file lists operations (e.g. rename-account), not migrate "
+            "itself.")
+    cmd = _OPERATIONS.get(name)
+    if cmd is None:
+        raise click.ClickException(
+            f"{name!r} is not a migration operation. A migration file may use only "
+            f"these operations: {', '.join(sorted(_OPERATIONS))}. Read/meta commands "
+            f"(export, import, print-invoice, migrate, …) are not operations — a "
+            f"migration only applies changes to the target book.")
+    cmd.main(args=rest, obj=batch, standalone_mode=False)
+
+
+def _immutability_error(errors):
+    ids = ', '.join(eid for eid, _old, _new in errors)
+    return click.ClickException(
+        f'migration(s) already applied have been edited since: {ids}. Applied '
+        f'migrations are immutable — revert the file(s), or write a new migration '
+        f'for further changes.')
+
+
+def _print_status(applied, pending, opened):
+    head = applied[-1]['id'] if applied else '(none)'
+    src = 'book' if opened else 'sidecar cache'
+    click.echo(f'head: {head}  ({len(applied)} applied, {len(pending)} pending) '
+               f'[from {src}]')
+    for a in applied:
+        click.echo(f'  applied  {a["id"]}  @ {a.get("applied_at", "?")}')
+    for f in pending:
+        click.echo(f'  pending  {f.id}  ({len(f.ops)} op(s))')
+
+
+@click.command('migrate')
+@click.argument('gnucash_file', type=click.Path(exists=True))
+@click.argument('migrations_dir', type=click.Path(exists=True, file_okay=False))
+@click.option('--dry-run', is_flag=True, help='Show what would apply; change nothing.')
+@click.option('--status', 'show_status', is_flag=True,
+              help='Report applied vs pending migrations (uses the sidecar when fresh).')
+@click.option('--verify', is_flag=True,
+              help='Ignore the sidecar cache and check the book directly.')
+def migrate(gnucash_file, migrations_dir, dry_run, show_status, verify):
+    """Apply pending migrations to the book in a single save."""
+    files = discover_migrations(migrations_dir)
+
+    # ── Fast path: trust the sidecar when it still matches the book on disk ──
+    if not verify:
+        sc = read_sidecar(gnucash_file)
+        if sidecar_is_fresh(gnucash_file, sc):
+            applied = sc.get('applied', [])
+            pending, errors = compute_pending(files, applied)
+            if show_status:
+                _print_status(applied, pending, opened=False)
+                return
+            if errors:
+                raise _immutability_error(errors)
+            if not pending:
+                head = sc.get('head')
+                click.echo(f'up to date (head: {head}); book not opened')
+                return
+            # pending work exists → fall through and open the book
+
+    # ── Authoritative path: open the book ──────────────────────────────────
+    repo = GnuCashRepository(gnucash_file)
+    repo.open(mode=SessionMode.NORMAL)
+    saved = False
+    try:
+        applied = read_applied_from_book(repo.book)
+        pending, errors = compute_pending(files, applied)
+        if errors:
+            raise _immutability_error(errors)
+
+        if show_status:
+            _print_status(applied, pending, opened=True)
+            return
+        if dry_run:
+            if not pending:
+                click.echo('up to date; nothing to apply')
+            else:
+                click.echo(f'would apply {len(pending)} migration(s):')
+                for f in pending:
+                    click.echo(f'  {f.id}')
+                    for line in f.ops:
+                        click.echo(f'      {line}')
+            return
+
+        if pending:
+            batch = BatchSession(repo.book)
+            for mf in pending:
+                for line in mf.ops:
+                    try:
+                        _apply_op(batch, line)
+                    except Exception as e:
+                        # Surface the operation command's own message (Click
+                        # errors via format_message, anything else via str), name
+                        # the migration + line, and abort BEFORE saving — migrate
+                        # is atomic, so a failure in the middle of the batch
+                        # persists nothing and records nothing.
+                        detail = (e.format_message()
+                                  if isinstance(e, click.ClickException) else str(e))
+                        done = len(batch.log)
+                        raise click.ClickException(
+                            f'migration {mf.id!r} failed at operation:\n'
+                            f'    {line}\n'
+                            f'  → {detail}\n'
+                            f'  No changes were saved. migrate is atomic: the whole '
+                            f'batch applies in one save or nothing does '
+                            f'({done} operation(s) had run in memory and were '
+                            f'discarded). Fix the migration and re-run.') from e
+                applied.append({'id': mf.id, 'applied_at': _now(),
+                                'checksum': mf.checksum})
+            write_applied_to_book(repo.book, applied)
+            repo.save()
+            saved = True
+            report = batch.log
+        else:
+            report = []
+    finally:
+        repo.close()
+
+    # Refresh the sidecar from the now-authoritative applied list (also stamps a
+    # fresh book size/mtime so the next run can fast-path).
+    write_sidecar(gnucash_file, applied)
+
+    if not pending:
+        click.echo('up to date; nothing to apply')
+        return
+    for line in report:
+        click.echo(f'  {line}')
+    click.echo(f'applied {len(pending)} migration(s) in {"1 save" if saved else "0 saves"}; '
+               f'head: {applied[-1]["id"]}')
+
+
+if __name__ == '__main__':
+    sys.exit(migrate())

--- a/cli/rename_account_cmd.py
+++ b/cli/rename_account_cmd.py
@@ -13,46 +13,24 @@ Because GnuCash keeps splits attached to accounts by reference, every
 transaction that touched the account follows it automatically — nothing in the
 ledger text needs editing. On the next export the account's new path is printed
 wherever it appears.
+
+Runs standalone (opens the book, renames, saves) or — when invoked by `migrate`
+with a shared `BatchSession` in the Click context — against that already-open
+book, leaving the single save to the batch owner.
 """
 
 import sys
 
 import click
 
+from cli._batch import current_batch
 from repositories.gnucash_repository import GnuCashRepository, SessionMode
 from use_cases.rename_account import execute_rename
 
 
-@click.command('rename-account')
-@click.argument('gnucash_file', type=click.Path(exists=True))
-@click.option('--guid', 'account_guid', required=True,
-              help='GUID of the account to rename (stable identity, not the old name).')
-@click.option('--to', 'new_name', required=True,
-              help='New full name. Bare leaf ("Chequing") keeps the parent; full '
-                   'path ("Assets:Cash:Petty") sets a new parent and/or leaf.')
-def rename_account(gnucash_file, account_guid, new_name):
-    """Rename an account by GUID, keeping all its splits."""
-    repo = GnuCashRepository(gnucash_file)
-    repo.open(mode=SessionMode.NORMAL)
-    try:
-        result = execute_rename(repo.book, account_guid, new_name)
-        if result.status == 'renamed':
-            repo.save()
-    finally:
-        repo.close()
-
-    if result.status == 'renamed':
-        click.echo(f'renamed account {result.old_name!r} → {result.new_name!r} '
-                   f'(guid {result.guid})')
-        return
-    if result.status == 'unchanged':
-        click.echo(f'account {result.old_name!r} (guid {result.guid}) is already '
-                   f'named {new_name!r} — nothing to change')
-        return
-
-    # Failure: every message names the account, what was attempted, why it was
-    # refused, and how to fix it — and the book is left untouched.
-    msgs = {
+def _failure_message(result, account_guid, new_name):
+    """Explicit, detailed message for a non-applied rename, or None on success."""
+    return {
         'bad_guid':
             f'--guid {account_guid!r} is not a valid account GUID: {result.detail}. '
             f'Pass the 32-character hex GUID; run `export-accounts` to list each '
@@ -78,9 +56,52 @@ def rename_account(gnucash_file, account_guid, new_name):
             f'cannot rename account {result.old_name!r} to {new_name!r}: an account '
             f'named {result.detail!r} already exists under that parent. Pick a '
             f'different leaf name, or rename/remove the existing account first.',
-    }
-    raise click.ClickException(
-        msgs.get(result.status, f'rename failed ({result.status})'))
+    }.get(result.status)
+
+
+def _success_message(result, new_name):
+    if result.status == 'renamed':
+        return (f'renamed account {result.old_name!r} → {result.new_name!r} '
+                f'(guid {result.guid})')
+    return (f'account {result.old_name!r} (guid {result.guid}) is already named '
+            f'{new_name!r} — nothing to change')
+
+
+@click.command('rename-account')
+@click.argument('gnucash_file', required=False, type=click.Path(exists=True))
+@click.option('--guid', 'account_guid', required=True,
+              help='GUID of the account to rename (stable identity, not the old name).')
+@click.option('--to', 'new_name', required=True,
+              help='New full name. Bare leaf ("Chequing") keeps the parent; full '
+                   'path ("Assets:Cash:Petty") sets a new parent and/or leaf.')
+@click.pass_context
+def rename_account(ctx, gnucash_file, account_guid, new_name):
+    """Rename an account by GUID, keeping all its splits."""
+    batch = current_batch(ctx)
+
+    if batch is not None:
+        # Batch mode: operate on the shared, already-open book; the owner saves.
+        result = execute_rename(batch.book, account_guid, new_name)
+        if result.status == 'renamed':
+            batch.mark_dirty()
+        emit = batch.note
+    else:
+        if not gnucash_file:
+            raise click.UsageError("missing book: rename-account <book> --guid … --to …")
+        repo = GnuCashRepository(gnucash_file)
+        repo.open(mode=SessionMode.NORMAL)
+        try:
+            result = execute_rename(repo.book, account_guid, new_name)
+            if result.status == 'renamed':
+                repo.save()
+        finally:
+            repo.close()
+        emit = click.echo
+
+    failure = _failure_message(result, account_guid, new_name)
+    if failure is not None:
+        raise click.ClickException(failure)
+    emit(_success_message(result, new_name))
 
 
 if __name__ == '__main__':

--- a/cli/set_book_key_cmd.py
+++ b/cli/set_book_key_cmd.py
@@ -1,0 +1,57 @@
+"""CLI command: set a custom book-level key.
+
+`set-book-key <book> --key <name> --value <value>`
+
+Stores an arbitrary key (e.g. your own `schema_version`) in the book's custom
+metadata — the same store the `company` directive round-trips (Q-029). Runs
+standalone or, under `migrate`, against the shared batch session (one save).
+"""
+
+import sys
+
+import click
+
+from cli._batch import current_batch
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from use_cases.set_book_key import execute_set_book_key
+
+
+@click.command('set-book-key')
+@click.argument('gnucash_file', required=False, type=click.Path(exists=True))
+@click.option('--key', required=True, help='Book key to set (e.g. schema_version).')
+@click.option('--value', required=True, help='Value to store.')
+@click.pass_context
+def set_book_key(ctx, gnucash_file, key, value):
+    """Set a custom book-level key (book metadata, round-trips via `company`)."""
+    batch = current_batch(ctx)
+
+    try:
+        if batch is not None:
+            status = execute_set_book_key(batch.book, key, value)
+            if status != 'unchanged':
+                batch.mark_dirty()
+            emit = batch.note
+        else:
+            if not gnucash_file:
+                raise click.UsageError(
+                    "missing book: set-book-key <book> --key … --value …")
+            repo = GnuCashRepository(gnucash_file)
+            repo.open(mode=SessionMode.NORMAL)
+            try:
+                status = execute_set_book_key(repo.book, key, value)
+                if status != 'unchanged':
+                    repo.save()
+            finally:
+                repo.close()
+            emit = click.echo
+    except ValueError as e:
+        raise click.ClickException(str(e)) from e
+
+    if status == 'unchanged':
+        emit(f'book key {key!r} already = {value!r} — nothing to change')
+    else:
+        emit(f'{status} book key {key!r} = {value!r}')
+
+
+if __name__ == '__main__':
+    sys.exit(set_book_key())

--- a/docs/issues/Q-031-migrate-batch-operations.md
+++ b/docs/issues/Q-031-migrate-batch-operations.md
@@ -1,0 +1,76 @@
+---
+id: Q-031
+title: No batch operations or migrations — every surgical command is one-op-per-save
+category: feature
+severity: enhancement
+status: closed
+---
+
+## Problem
+
+Every surgical CLI command (`rename-account`, `unapply-payment`, `delete-*`) opens the book, does **one** mutation, saves, and closes. Each save writes a GnuCash backup whose filename carries a **second-resolution** timestamp, so two saves in the same second collide (`ERR_FILEIO_BACKUP_ERROR`) — back-to-back operations must be ≥1s apart. Renaming 200 accounts therefore costs **200+ seconds**.
+
+There was also no migration concept: no way to express an ordered set of operations, apply them as a unit, and **track which have been applied** — the database-migration model. Users want to version their chart-of-accounts evolution and replay it reproducibly, and to know "what version is this book on?" cheaply.
+
+Plaintext `import` doesn't cover this: it is **declarative** state-sync, and can't express an imperative "rename X → Y" (renaming an account in a declarative file would mean rewriting every transaction that references it by path — the reason `rename-account` is a command, not a directive). Migrations are imperative and ordered — a different paradigm.
+
+## Fix
+
+A `migrate` command that applies versioned migrations to a book in a **single save**.
+
+```
+gnucash-plaintext migrate <book> <migrations-dir> [--dry-run] [--status] [--verify]
+```
+
+### Migration files are operation lines (CLI syntax)
+
+A migration file (`migrations/0002_rename_chequing.txt`) is an ordered list of operation lines — each uses CLI syntax (an operation command + args, minus the book), parsed by Click itself via `shlex.split` + `command.main(args=…, standalone_mode=False)`. One vocabulary for interactive use and migrations; the file doubles as runnable documentation.
+
+A migration line is **not** "any CLI command", though. Operations come from a strict allowlist (`_OPERATIONS`) of mutating, batch-aware commands. Read/meta commands — `export`, `import`, `print-invoice`, and `migrate` itself — are intentionally excluded, so a migration only changes the target book and **migrations cannot nest**. Each refusal is explicit: a `migrate` line says migrations don't nest; any other non-operation says it is not a migration operation and lists the ones that are.
+
+```
+# 0002_rename_chequing
+rename-account --guid 51359958977a4ca88ec927c2958b3d8b --to "Assets:Current:Chequing"
+set-book-key --key schema_version --value 2
+```
+
+### Session ownership moves up → one save
+
+Each operation command now checks the Click context for a `BatchSession` (`cli/_batch.py`): present (under `migrate`) → it mutates that shared, already-open book and records the change, leaving the single save to the owner; absent → it runs standalone exactly as before (open, mutate, save, close). The book argument became optional on these commands. The use cases were already book-in / no-save, so this is a CLI-layer change only. 200 renames ⇒ **1 save**.
+
+### Two-layer history → cheap no-op
+
+- **In-book, source of truth:** `options/Plaintext/Migrations` — a JSON list of `{id, applied_at, checksum}`, the "schema_migrations table" that travels with the `.gnucash` file. Written during the apply (the book is already open + saving).
+- **Sidecar cache:** `<book>.migrate-state.json` — readable JSON stamped with the book's size+mtime. A no-op `migrate` reads the sidecar + `stat`s the book (cheap) and, if the stamp still matches and nothing is pending, prints `up to date … book not opened` and **never opens the GnuCash file**. The sidecar is a regenerable cache; the in-book history wins whenever the stamp is stale (book moved/reverted), and `--verify` bypasses the cache.
+
+### Semantics
+
+- **Atomic:** all pending migrations apply to one book; if any operation fails, `migrate` aborts **before** saving — nothing persists, nothing is recorded (`… no changes were saved`).
+- **Immutable history:** editing an already-applied migration changes its checksum and is rejected (Flyway-style), pointing the user to write a new migration.
+- **Two version layers:** the tool tracks *which files ran*; a migration can also `set-book-key --key schema_version --value N` to stamp the user's **own** semantic version (Q-029 custom-key store, round-trips via the `company` directive). The user-facing "what version am I on?" is answerable from the sidecar with zero book reads.
+- **Extensible vocabulary:** any batch-aware command registered in `_OPERATIONS` is a valid migration operation. v1 ships `rename-account` and `set-book-key`.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `cli/_batch.py` | `BatchSession` + `current_batch(ctx)` — shared open book + change log for batched ops. |
+| `cli/rename_account_cmd.py` | Batch-aware: optional book, operates on `ctx.obj.book` under a batch, else standalone. |
+| `cli/set_book_key_cmd.py`, `use_cases/set_book_key.py` | New `set-book-key` op (custom book key / version marker). |
+| `use_cases/migrate.py` | Discovery, checksums, in-book history, sidecar read/write + freshness. |
+| `cli/migrate_cmd.py` | The `migrate` command — fast path, authoritative apply with one save, atomicity, immutability, dry-run/status. |
+| `infrastructure/gnucash/kvp.py` | `MIGRATIONS_SECTION` / `MIGRATIONS_SLOT` for the in-book history. |
+| `cli/main.py`, `README.md` | Register + document `migrate` and `set-book-key`. |
+
+## Tests
+
+`tests/integration/test_migrate.py`: a batch of renames + a version stamp applied in one run (`1 save`); a re-run is a no-op that doesn't open the book (sidecar fast path); an operation failure aborts atomically with the book unchanged and nothing recorded; an edited applied migration is rejected as immutable; `--dry-run` changes nothing; an unknown operation is rejected; the `schema_version` marker round-trips through export. Passing on GnuCash 3.8 and 5.10; the Q-030 `rename-account` standalone tests still pass (the refactor is backward-compatible).
+
+## Related issues
+
+- **Q-030** — `rename-account`, the first batch-aware operation.
+- **Q-029** — the custom book-key store reused for `set-book-key` and the migration history slot.
+
+---
+
+**Created**: 2026-06-26

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -75,3 +75,4 @@ and in the **Status** column below.
 | [Q-028](Q-028-company-info-gst-pst-roundtrip.md) | Company info (incl. GST/PST registration numbers) is not round-tripped, and there is nowhere to record GST/PST | medium | closed |
 | [Q-029](Q-029-company-arbitrary-book-keys.md) | company directive only round-trips known seller-identity keys; no way to store arbitrary book-level data | medium | closed |
 | [Q-030](Q-030-rename-account.md) | No way to rename an account; the full round-trip can't express it | enhancement | closed |
+| [Q-031](Q-031-migrate-batch-operations.md) | No batch operations or migrations — every surgical command is one-op-per-save | enhancement | closed |

--- a/infrastructure/gnucash/kvp.py
+++ b/infrastructure/gnucash/kvp.py
@@ -34,6 +34,12 @@ PT_DATA_SLOT = 'plaintext_metadata'
 COMPANY_CUSTOM_SECTION = 'Plaintext'
 COMPANY_CUSTOM_SLOT = 'Custom Metadata'
 
+# Q-031: book option slot holding the applied-migrations history (a JSON list of
+# {id, applied_at, checksum}) — the in-book source of truth for `migrate`, the
+# "schema_migrations table" equivalent that travels with the .gnucash file.
+MIGRATIONS_SECTION = 'Plaintext'
+MIGRATIONS_SLOT = 'Migrations'
+
 # Transaction metadata keys that have dedicated GnuCash setters.
 # Any key NOT in this set is treated as custom metadata → KVP slot.
 KNOWN_TX_METADATA_KEYS = frozenset({

--- a/tests/integration/test_migrate.py
+++ b/tests/integration/test_migrate.py
@@ -1,0 +1,193 @@
+"""Q-031: `migrate` applies versioned migrations in a single save, tracks applied
+history in the book + a cheap sidecar, is atomic, and treats applied migrations
+as immutable.
+
+A migration file is an ordered list of operation lines — each line is a CLI
+invocation minus the book (the book is `migrate`'s target), parsed by Click.
+"""
+
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+BOOK = str(Path('tests/fixtures/rename_account_book.txt'))
+
+
+def _new_book(runner, tmp_path):
+    gf = tmp_path / 'book.gnucash'
+    assert runner.invoke(cli, ['import', '--new', str(gf), BOOK]).exit_code == 0
+    time.sleep(1)
+    return gf
+
+
+def _colon_name(acc):
+    parts, node = [], acc
+    while node is not None and node.get_parent() is not None:
+        parts.append(node.GetName())
+        node = node.get_parent()
+    return ':'.join(reversed(parts))
+
+
+def _accounts(gf):
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        return {_colon_name(a): a.GetGUID().to_string()
+                for a in repo.book.get_root_account().get_descendants()}
+    finally:
+        repo.close()
+
+
+def _migrations(tmp_path, files):
+    d = tmp_path / 'migrations'
+    d.mkdir(exist_ok=True)
+    for name, content in files.items():
+        (d / name).write_text(content)
+    return d
+
+
+def test_applies_a_batch_of_renames_in_one_run(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    a = _accounts(gf)
+    chk, groc = a['Assets:Bank:Checking'], a['Expenses:Groceries']
+    d = _migrations(tmp_path, {
+        '0001_restructure.txt':
+            f'# rename two accounts and stamp a version in one save\n'
+            f'rename-account --guid {chk} --to "Assets:Bank:Chequing"\n'
+            f'rename-account --guid {groc} --to "Food"\n'
+            f'set-book-key --key schema_version --value 1\n',
+    })
+    r = runner.invoke(cli, ['migrate', str(gf), str(d)])
+    assert r.exit_code == 0, r.output
+    assert '1 save' in r.output
+    time.sleep(1)
+
+    after = _accounts(gf)
+    assert 'Assets:Bank:Chequing' in after and 'Expenses:Food' in after
+    assert 'Assets:Bank:Checking' not in after and 'Expenses:Groceries' not in after
+    assert after['Assets:Bank:Chequing'] == chk      # same accounts, renamed
+    assert after['Expenses:Food'] == groc
+
+
+def test_rerun_is_a_noop_without_opening_the_book(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    chk = _accounts(gf)['Assets:Bank:Checking']
+    d = _migrations(tmp_path, {'0001.txt': f'rename-account --guid {chk} --to "Chequing"\n'})
+    assert runner.invoke(cli, ['migrate', str(gf), str(d)]).exit_code == 0
+
+    r = runner.invoke(cli, ['migrate', str(gf), str(d)])
+    assert r.exit_code == 0, r.output
+    assert 'book not opened' in r.output           # fast path via the sidecar
+    assert (Path(str(gf) + '.migrate-state.json')).exists()
+
+
+def test_atomic_abort_leaves_the_book_unchanged(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    before = _accounts(gf)
+    chk = before['Assets:Bank:Checking']
+    d = _migrations(tmp_path, {
+        '0001.txt':
+            f'rename-account --guid {chk} --to "Chequing"\n'
+            f'rename-account --guid 00000000000000000000000000000000 --to "Nope"\n',
+    })
+    r = runner.invoke(cli, ['migrate', str(gf), str(d)])
+    assert r.exit_code != 0
+    # The failing operation's OWN detailed message is surfaced, with context.
+    assert 'no account in this book has guid' in r.output
+    assert "migration '0001' failed at operation" in r.output
+    assert 'No changes were saved' in r.output
+    assert 'discarded' in r.output            # the earlier op ran in memory, then was discarded
+    # The earlier good rename in the same migration must NOT have persisted.
+    assert _accounts(gf) == before
+    # Nothing recorded → still fully pending.
+    s = runner.invoke(cli, ['migrate', str(gf), str(d), '--status'])
+    assert '1 pending' in s.output and '0 applied' in s.output
+
+
+def test_operation_with_bad_arguments_aborts_with_its_message(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    chk = _accounts(gf)['Assets:Bank:Checking']
+    # rename-account line missing the required --to → Click MissingParameter.
+    d = _migrations(tmp_path, {'0001.txt': f'rename-account --guid {chk}\n'})
+    r = runner.invoke(cli, ['migrate', str(gf), str(d)])
+    assert r.exit_code != 0
+    assert "'--to'" in r.output                # Click's own parameter error
+    assert 'failed at operation' in r.output and 'No changes were saved' in r.output
+
+
+def test_applied_migration_is_immutable(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    chk = _accounts(gf)['Assets:Bank:Checking']
+    d = _migrations(tmp_path, {'0001.txt': f'rename-account --guid {chk} --to "Chequing"\n'})
+    assert runner.invoke(cli, ['migrate', str(gf), str(d)]).exit_code == 0
+
+    # Edit a migration that was already applied → checksum no longer matches.
+    (d / '0001.txt').write_text(f'rename-account --guid {chk} --to "Savings"\n')
+    r = runner.invoke(cli, ['migrate', str(gf), str(d)])
+    assert r.exit_code != 0
+    assert 'immutable' in r.output and '0001' in r.output
+
+
+def test_dry_run_changes_nothing(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    before = _accounts(gf)
+    chk = before['Assets:Bank:Checking']
+    d = _migrations(tmp_path, {'0001.txt': f'rename-account --guid {chk} --to "Chequing"\n'})
+    r = runner.invoke(cli, ['migrate', str(gf), str(d), '--dry-run'])
+    assert r.exit_code == 0, r.output
+    assert '0001' in r.output and 'rename-account' in r.output
+    assert _accounts(gf) == before                 # untouched
+
+
+def test_unknown_operation_is_rejected(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    d = _migrations(tmp_path, {'0001.txt': 'frobnicate --foo bar\n'})
+    r = runner.invoke(cli, ['migrate', str(gf), str(d)])
+    assert r.exit_code != 0
+    assert 'not a migration operation' in r.output
+
+
+def test_migrate_cannot_be_nested(tmp_path):
+    """A migration file may not contain `migrate` — migrations don't nest."""
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    d = _migrations(tmp_path, {'0001.txt': 'migrate other.gnucash more-migrations/\n'})
+    r = runner.invoke(cli, ['migrate', str(gf), str(d)])
+    assert r.exit_code != 0
+    assert 'do not nest' in r.output
+    assert 'No changes were saved' in r.output
+
+
+def test_read_meta_command_is_not_an_operation(tmp_path):
+    """A real CLI command that isn't a mutating operation (export) is refused —
+    migration lines are operations, not arbitrary CLI commands."""
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    d = _migrations(tmp_path, {'0001.txt': 'export book.gnucash out.txt\n'})
+    r = runner.invoke(cli, ['migrate', str(gf), str(d)])
+    assert r.exit_code != 0
+    assert 'not a migration operation' in r.output
+
+
+def test_version_marker_is_set_and_round_trips(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    d = _migrations(tmp_path, {'0001.txt': 'set-book-key --key schema_version --value 3\n'})
+    assert runner.invoke(cli, ['migrate', str(gf), str(d)]).exit_code == 0
+    time.sleep(1)
+    out = tmp_path / 'exp.txt'
+    assert runner.invoke(cli, ['export', str(gf), str(out),
+                               '--include-business-objects']).exit_code == 0
+    text = out.read_text()
+    assert 'schema_version' in text and '"3"' in text

--- a/use_cases/migrate.py
+++ b/use_cases/migrate.py
@@ -1,0 +1,139 @@
+"""Q-031: migration discovery, history, and the cheap sidecar cache.
+
+Pure logic only — no Click, no session lifecycle (the CLI layer owns those).
+
+A migration is a versioned file of imperative operation lines (each line is a
+CLI invocation minus the book), applied in filename order. History is tracked in
+two layers:
+
+  - **in-book** (`options/Plaintext/Migrations`): the source of truth, a JSON
+    list of `{id, applied_at, checksum}` that travels with the .gnucash file;
+  - **sidecar** (`<book>.migrate-state.json`): a cheap, readable cache stamped
+    with the book's size+mtime, so a no-op `migrate` can decide there is nothing
+    to do WITHOUT opening the (expensive to read) GnuCash file.
+"""
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+
+from infrastructure.gnucash.kvp import (
+    MIGRATIONS_SECTION,
+    MIGRATIONS_SLOT,
+    get_book_string_option,
+    set_book_string_option,
+)
+
+
+@dataclass
+class MigrationFile:
+    id: str        # filename stem, e.g. '0002_rename_chequing'
+    path: str
+    ops: list      # operation lines (comments / blank lines stripped)
+    checksum: str  # 'sha256:…' over the raw file bytes
+
+
+def _checksum(raw: bytes) -> str:
+    return 'sha256:' + hashlib.sha256(raw).hexdigest()
+
+
+def _parse_ops(text: str) -> list:
+    ops = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith('#'):
+            ops.append(stripped)
+    return ops
+
+
+def discover_migrations(migrations_dir: str) -> list:
+    """All `*.txt` migration files in `migrations_dir`, sorted by filename
+    (the zero-padded numeric prefix is the version order)."""
+    out = []
+    for name in sorted(os.listdir(migrations_dir)):
+        path = os.path.join(migrations_dir, name)
+        if not name.endswith('.txt') or not os.path.isfile(path):
+            continue
+        with open(path, 'rb') as f:
+            raw = f.read()
+        out.append(MigrationFile(id=name[:-4], path=path,
+                                 ops=_parse_ops(raw.decode('utf-8')),
+                                 checksum=_checksum(raw)))
+    return out
+
+
+def compute_pending(files, applied):
+    """Split discovered `files` against the `applied` records (list of dicts with
+    `id` + `checksum`). Returns (pending_files, checksum_errors) where a checksum
+    error means an already-applied migration's file was edited (immutable)."""
+    by_id = {a['id']: a for a in applied}
+    pending, errors = [], []
+    for f in files:
+        prev = by_id.get(f.id)
+        if prev is None:
+            pending.append(f)
+        elif prev.get('checksum') != f.checksum:
+            errors.append((f.id, prev.get('checksum'), f.checksum))
+    return pending, errors
+
+
+# ── in-book history (source of truth) ──────────────────────────────────────
+
+def read_applied_from_book(book) -> list:
+    blob = get_book_string_option(book, MIGRATIONS_SECTION, MIGRATIONS_SLOT)
+    if not blob:
+        return []
+    try:
+        data = json.loads(blob)
+        return data if isinstance(data, list) else []
+    except (ValueError, TypeError):
+        return []
+
+
+def write_applied_to_book(book, applied: list):
+    set_book_string_option(book, MIGRATIONS_SECTION, MIGRATIONS_SLOT,
+                           json.dumps(applied, ensure_ascii=False, sort_keys=True))
+
+
+# ── sidecar cache (cheap fast-path) ────────────────────────────────────────
+
+def sidecar_path(book_path: str) -> str:
+    return book_path + '.migrate-state.json'
+
+
+def book_stamp(book_path: str) -> dict:
+    st = os.stat(book_path)
+    return {'book_size': st.st_size, 'book_mtime': st.st_mtime}
+
+
+def read_sidecar(book_path: str):
+    path = sidecar_path(book_path)
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as f:
+            return json.loads(f.read())
+    except (ValueError, OSError):
+        return None
+
+
+def write_sidecar(book_path: str, applied: list):
+    data = book_stamp(book_path)
+    data['applied'] = applied
+    data['head'] = applied[-1]['id'] if applied else None
+    with open(sidecar_path(book_path), 'w') as f:
+        f.write(json.dumps(data, indent=2, sort_keys=True))
+
+
+def sidecar_is_fresh(book_path: str, sidecar: dict) -> bool:
+    """True if the sidecar's stamp still matches the book file — i.e. the book
+    has not changed since the sidecar was written, so its cached `applied` list
+    can be trusted without opening the book."""
+    if not sidecar:
+        return False
+    try:
+        current = book_stamp(book_path)
+    except OSError:
+        return False
+    return (sidecar.get('book_size') == current['book_size']
+            and sidecar.get('book_mtime') == current['book_mtime'])

--- a/use_cases/set_book_key.py
+++ b/use_cases/set_book_key.py
@@ -1,0 +1,45 @@
+"""Q-031: set a custom book-level key (e.g. a user's own `schema_version`).
+
+Writes into the same book custom-metadata store the `company` directive uses for
+arbitrary keys (Q-029), so the value round-trips through export/import. This is
+how a migration stamps the user's *own* semantic version into the book —
+separate from `migrate`'s automatic applied-migrations history.
+"""
+import json
+import re
+
+from infrastructure.gnucash.kvp import (
+    COMPANY_CUSTOM_SECTION,
+    COMPANY_CUSTOM_SLOT,
+    get_book_string_option,
+    set_book_string_option,
+)
+
+# Same key grammar as plaintext metadata keys, so the value round-trips through
+# the `company` directive (`key: value`) — lowercase-ish identifier, no colon.
+_KEY_RE = re.compile(r'^[a-z_][a-zA-Z0-9_\-.]*$')
+
+
+def execute_set_book_key(book, key, value):
+    """Set `key` to `value` in the book's custom metadata. Returns
+    'created' / 'updated' / 'unchanged', or raises ValueError for a bad key."""
+    if not _KEY_RE.match(key or ''):
+        raise ValueError(
+            f'invalid book key {key!r}: use a lowercase identifier with no ":" '
+            f'(letters, digits, "_", "-", "."), e.g. "schema_version"')
+
+    blob = get_book_string_option(book, COMPANY_CUSTOM_SECTION, COMPANY_CUSTOM_SLOT) or ''
+    try:
+        data = json.loads(blob) if blob else {}
+        if not isinstance(data, dict):
+            data = {}
+    except (ValueError, TypeError):
+        data = {}
+
+    old = data.get(key)
+    if old == value:
+        return 'unchanged'
+    data[key] = value
+    set_book_string_option(book, COMPANY_CUSTOM_SECTION, COMPANY_CUSTOM_SLOT,
+                           json.dumps(data, ensure_ascii=False, sort_keys=True))
+    return 'updated' if old is not None else 'created'


### PR DESCRIPTION
Every surgical command (rename-account, …) opened the book, did one mutation, and saved. Because a GnuCash save writes a backup whose filename carries a second-resolution timestamp, two saves in the same second collide, so back-to-back operations must be ≥1s apart — renaming 200 accounts cost 200+ seconds. There was also no migration concept: no ordered, replayable set of operations with tracked history, the way databases do schema migrations. Plaintext import can't fill this gap — it is declarative state-sync and can't express an imperative "rename X → Y".

A new `migrate` command applies versioned migrations to a book in a single save.

    gnucash-plaintext migrate <book> <migrations-dir> [--dry-run] [--status] [--verify]

- Migration files are operation lines in CLI syntax. A migration (`migrations/0002_rename.txt`) is an ordered list of operation lines, each an operation command + args minus the book — parsed by Click itself (shlex.split + command.main(standalone_mode=False)). One vocabulary for interactive use and migrations; the file is runnable documentation. A migration line is NOT "any CLI command": operations come from a strict allowlist of mutating, batch-aware commands. Read/meta commands (export, import, print-invoice, and migrate itself) are excluded, so a migration only changes the target book and migrations cannot nest — a `migrate` line is refused with "migrations do not nest", any other non-operation with "not a migration operation".
- Session ownership moved up so a batch is one save. Operation commands now check the Click context for a shared BatchSession (cli/_batch.py): under `migrate` they mutate the already-open book and record the change, leaving the single save to the owner; standalone they open/mutate/save/close as before. The book argument became optional on these commands; the use cases were already book-in / no-save, so this is a CLI-layer change. 200 renames now cost one save.
- Two-layer history. The book itself holds the source of truth in `options/Plaintext/Migrations` (a JSON list of {id, applied_at, checksum} that travels with the file). A cheap `<book>.migrate-state.json` sidecar, stamped with the book's size+mtime, lets a no-op run conclude there is nothing to do and print "up to date … book not opened" WITHOUT opening the expensive GnuCash file — safe to run on every deploy. The sidecar is a regenerable cache; the in-book history wins when the stamp is stale (book moved or reverted), and --verify bypasses the cache.
- Atomic, and immutable. All pending migrations apply to one in-memory book; if any operation fails, migrate aborts before saving, so nothing persists and nothing is recorded — and the error names the migration, the failing line, and that command's own message. Editing an already-applied migration changes its checksum and is rejected (write a new migration instead).
- Version markers. A migration can `set-book-key --key schema_version --value N` to stamp the user's own semantic version into the book (the Q-029 custom-key store, round-trips via the `company` directive) — separate from the tool's automatic applied-migrations log. The operation vocabulary is extensible: any batch-aware command is a valid migration op; v1 ships rename-account and set-book-key.

Tests in tests/integration/test_migrate.py: a batch of renames plus a version stamp applied in one run; a re-run is a no-op that never opens the book; an operation failure aborts atomically with the book unchanged, nothing recorded, and the failing command's own message surfaced (both a domain error and a Click bad-argument error); an edited applied migration is rejected as immutable; --dry-run changes nothing; an unknown operation is rejected; the schema_version marker round-trips through export. Passing on GnuCash 3.8 and 5.10; the Q-030 rename-account standalone tests still pass (the refactor is backward-compatible).