### PR TITLE
fix(Q-029): company custom keys merge on partial import, not full replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -977,6 +977,20 @@ instance, are an application preference, not stored in the file, so there is no
 native slot to map them to.) These custom keys are stored together in the book
 and re-emitted on export; they never reach the rendered seller block.
 
+Importing a `company` directive is a **partial update** — for the custom keys as
+well as the known fields. Keys you list are set, keys you omit are **kept**, and
+a key given the null value `#None` is **removed** (JSON Merge Patch semantics):
+
+```
+company
+  province: "Ontario"      # set/update province
+  entity_type: #None       # remove the entity_type key
+  # any custom key not listed here is left untouched
+```
+
+So a small edit never wipes the rest of your book metadata. (`set-book-key`,
+used in migrations, upserts the same way through the same code.)
+
 **Invoice and bill status fields**
 
 The `posted:` and `payment:` fields are always present in exported output.

--- a/docs/issues/Q-029-company-arbitrary-book-keys.md
+++ b/docs/issues/Q-029-company-arbitrary-book-keys.md
@@ -33,7 +33,13 @@ company
 
 All custom (non-Business) keys are serialised together as one JSON blob in a single dedicated book option slot, `options/Plaintext/Custom Metadata`, via the existing `set_book_string_option`. One fixed slot (rather than one slot per key) means the exporter reads it back by a known path — avoiding cross-version KVP key-enumeration, which the bindings make unreliable. The section is private to this tool, so it never collides with GnuCash's own Business options. The object-level `set_custom_metadata` path was tried first and does **not** persist on the book object (verified empirically — it read back empty), which is why the book-option path is used.
 
-The directive replaces the whole custom-metadata blob whenever it carries any custom keys (mirrors `set_custom_metadata` semantics on other objects); a directive with no custom keys leaves the existing blob untouched.
+The directive is a partial **upsert** of custom keys (see the reopened section below): keys it names are set, keys it omits are preserved, and a key given the null value (`#None`) is removed.
+
+## Reopened (2026-06-28): partial import must not delete custom keys
+
+The original implementation **replaced** the whole custom-metadata blob whenever the directive carried any custom key — a deliberate "mirror `set_custom_metadata`" choice that was wrong and was not flagged. It broke the directive's own documented contract ("an absent field is left as-is", honoured by the known-Business-field tier) and was inconsistent with `set-book-key` (Q-031), which merges. The result: a partial, hand-written `company` directive that set one custom key **silently deleted every other custom key** the book held (a user's `schema_version`, `entity_type`, etc.). Known Business fields were unaffected — so the deletion hit exactly the keys users hand-edit.
+
+**Fix:** the custom-key tier now follows **JSON Merge Patch** semantics (RFC 7386) — `key: value` upserts, `key: #None` removes, an omitted key is preserved. It is implemented in one shared helper, `merge_book_custom_metadata` in `infrastructure/gnucash/kvp.py`, used by **both** `import_company` and `set-book-key`, so the `company` directive and `set-book-key` provably behave the same. A full export → import round-trip is unaffected (the export emits every key, so the upsert restores all of them).
 
 ## Files touched
 

--- a/infrastructure/gnucash/kvp.py
+++ b/infrastructure/gnucash/kvp.py
@@ -492,6 +492,47 @@ def get_book_string_option(book, section: str, name: str) -> Optional[str]:
         return None
 
 
+def get_book_custom_metadata(book) -> dict:
+    """Read the book's custom-metadata JSON blob (the keys the `company`
+    directive's non-Business tier and `set-book-key` share) as a dict."""
+    current = get_book_string_option(book, COMPANY_CUSTOM_SECTION, COMPANY_CUSTOM_SLOT)
+    if not current:
+        return {}
+    try:
+        data = json.loads(current)
+        return data if isinstance(data, dict) else {}
+    except (ValueError, TypeError):
+        return {}
+
+
+def merge_book_custom_metadata(book, updates: dict) -> bool:
+    """Upsert keys into the book's custom-metadata blob with **JSON Merge Patch**
+    semantics (RFC 7386): a key with a non-None value is set; a key whose value
+    is None is *removed*; keys not named in `updates` are left untouched. This is
+    the single, shared writer for the `company` directive's custom keys and
+    `set-book-key`, so both behave identically — a partial update never silently
+    drops keys it didn't mention. Returns True if the stored blob changed."""
+    current = get_book_string_option(book, COMPANY_CUSTOM_SECTION, COMPANY_CUSTOM_SLOT) or ''
+    try:
+        data = json.loads(current) if current else {}
+        if not isinstance(data, dict):
+            data = {}
+    except (ValueError, TypeError):
+        data = {}
+
+    for key, value in updates.items():
+        if value is None:
+            data.pop(key, None)
+        else:
+            data[key] = value
+
+    blob = json.dumps(data, ensure_ascii=False, sort_keys=True)
+    if blob != current:
+        set_book_string_option(book, COMPANY_CUSTOM_SECTION, COMPANY_CUSTOM_SLOT, blob)
+        return True
+    return False
+
+
 def get_custom_metadata(obj) -> dict:
     """
     Read custom metadata from a GnuCash Transaction or Split KVP slot.

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -6,7 +6,6 @@ Converts PlaintextDirective objects from the parser into GnuCash objects
 """
 
 import ctypes
-import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -32,8 +31,6 @@ from gnucash.gnucash_core_c import (
 )
 
 from infrastructure.gnucash.kvp import (
-    COMPANY_CUSTOM_SECTION,
-    COMPANY_CUSTOM_SLOT,
     KNOWN_ACCOUNT_METADATA_KEYS,
     KNOWN_BILL_METADATA_KEYS,
     KNOWN_CUSTOMER_METADATA_KEYS,
@@ -41,8 +38,10 @@ from infrastructure.gnucash.kvp import (
     KNOWN_SPLIT_METADATA_KEYS,
     KNOWN_TX_METADATA_KEYS,
     KNOWN_VENDOR_METADATA_KEYS,
+    get_book_custom_metadata,
     get_book_string_option,
     get_custom_metadata,
+    merge_book_custom_metadata,
     set_book_string_option,
     set_custom_metadata,
 )
@@ -2544,21 +2543,20 @@ class GnuCashImporter:
                 set_book_string_option(book, 'Business', 'Company Address', addr_val)
                 changed = True
 
-        # Q-029: collect any remaining keys as book-level custom metadata. The
-        # directive replaces the whole custom-metadata blob when it carries any
-        # custom keys (mirrors `set_custom_metadata` semantics on other
-        # objects); an absent custom key set leaves the existing blob alone.
+        # Q-029 (fixed): any key that is not a known Business field or an address
+        # line is book-level custom metadata. The directive is a partial UPSERT,
+        # consistent with the known-field tier above and with the documented
+        # contract that an absent field is left as-is — keys named here are set,
+        # keys NOT named are preserved, and a key given the null value (`#None`)
+        # is removed (JSON Merge Patch). It used to replace the whole blob, so a
+        # partial company directive silently deleted any custom key it didn't
+        # repeat; merge is shared with `set-book-key` so both behave the same.
         known = set(COMPANY_FIELD_TO_SLOT) | set(_COMPANY_ADDR_KEYS)
-        custom = {k: v for k, v in md.items() if k not in known and v is not None}
+        custom = {k: v for k, v in md.items() if k not in known}
         if custom:
-            blob = json.dumps(custom, ensure_ascii=False, sort_keys=True)
-            current = get_book_string_option(
-                book, COMPANY_CUSTOM_SECTION, COMPANY_CUSTOM_SLOT) or ''
-            if current:
+            if get_book_custom_metadata(book):
                 had_any = True
-            if current != blob:
-                set_book_string_option(
-                    book, COMPANY_CUSTOM_SECTION, COMPANY_CUSTOM_SLOT, blob)
+            if merge_book_custom_metadata(book, custom):
                 changed = True
 
         if not changed:

--- a/tests/integration/test_company_custom_book_keys.py
+++ b/tests/integration/test_company_custom_book_keys.py
@@ -150,3 +150,53 @@ def test_custom_keys_not_rendered_on_bill(tmp_path):
                             '-o', str(out)])
     assert r.exit_code == 0, r.output
     _assert_custom_not_rendered(out.read_text())
+
+
+# ── Reopened Q-029: a partial company import is an UPSERT, not a full replace ──
+
+def test_partial_import_preserves_unmentioned_custom_keys(tmp_path):
+    """A later company directive that names only some keys must NOT delete the
+    custom keys it omits — the bug that reopened Q-029. (It used to replace the
+    whole custom blob, silently dropping absent custom keys.)"""
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf,
+            'company\n\tgst: "GST-111"\n\tprovince: "BC"\n\tentity_type: "T2 Corporation"\n',
+            tmp_path, 'c1.txt')
+    # Second import touches only province.
+    _import(runner, gf, 'company\n\tprovince: "Ontario"\n', tmp_path, 'c2.txt')
+
+    fields = _company_fields(_export(runner, gf, tmp_path))
+    assert fields.get('entity_type') == 'T2 Corporation'   # custom key preserved
+    assert fields.get('gst') == 'GST-111'                  # known field preserved
+    assert fields.get('province') == 'Ontario'             # the named key updated
+
+
+def test_null_value_removes_a_custom_key(tmp_path):
+    """`key: #None` (the format's null) removes that custom key — JSON Merge
+    Patch semantics — while leaving the others intact."""
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf,
+            'company\n\tprovince: "BC"\n\tentity_type: "T2 Corporation"\n',
+            tmp_path, 'c1.txt')
+    _import(runner, gf, 'company\n\tentity_type: #None\n', tmp_path, 'c2.txt')
+
+    fields = _company_fields(_export(runner, gf, tmp_path))
+    assert 'entity_type' not in fields                     # removed via null
+    assert fields.get('province') == 'BC'                  # the other key survives
+
+
+def test_set_book_key_does_not_disturb_other_custom_keys(tmp_path):
+    """`set-book-key` shares the merge helper, so it upserts one key without
+    dropping the others — same behaviour as the company directive."""
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    _import(runner, gf, 'company\n\tprovince: "BC"\n', tmp_path, 'c1.txt')
+    r = runner.invoke(cli, ['set-book-key', str(gf), '--key', 'schema_version',
+                            '--value', '5'])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+    fields = _company_fields(_export(runner, gf, tmp_path))
+    assert fields.get('schema_version') == '5'
+    assert fields.get('province') == 'BC'                  # not disturbed

--- a/use_cases/set_book_key.py
+++ b/use_cases/set_book_key.py
@@ -1,18 +1,16 @@
 """Q-031: set a custom book-level key (e.g. a user's own `schema_version`).
 
 Writes into the same book custom-metadata store the `company` directive uses for
-arbitrary keys (Q-029), so the value round-trips through export/import. This is
-how a migration stamps the user's *own* semantic version into the book —
-separate from `migrate`'s automatic applied-migrations history.
+arbitrary keys (Q-029), through the shared merge helper, so the value round-trips
+and a write upserts one key without disturbing the others. This is how a
+migration stamps the user's *own* semantic version into the book — separate from
+`migrate`'s automatic applied-migrations history.
 """
-import json
 import re
 
 from infrastructure.gnucash.kvp import (
-    COMPANY_CUSTOM_SECTION,
-    COMPANY_CUSTOM_SLOT,
-    get_book_string_option,
-    set_book_string_option,
+    get_book_custom_metadata,
+    merge_book_custom_metadata,
 )
 
 # Same key grammar as plaintext metadata keys, so the value round-trips through
@@ -21,25 +19,16 @@ _KEY_RE = re.compile(r'^[a-z_][a-zA-Z0-9_\-.]*$')
 
 
 def execute_set_book_key(book, key, value):
-    """Set `key` to `value` in the book's custom metadata. Returns
-    'created' / 'updated' / 'unchanged', or raises ValueError for a bad key."""
+    """Upsert `key` = `value` in the book's custom metadata (preserving the other
+    keys). Returns 'created' / 'updated' / 'unchanged', or raises ValueError for a
+    bad key."""
     if not _KEY_RE.match(key or ''):
         raise ValueError(
             f'invalid book key {key!r}: use a lowercase identifier with no ":" '
             f'(letters, digits, "_", "-", "."), e.g. "schema_version"')
 
-    blob = get_book_string_option(book, COMPANY_CUSTOM_SECTION, COMPANY_CUSTOM_SLOT) or ''
-    try:
-        data = json.loads(blob) if blob else {}
-        if not isinstance(data, dict):
-            data = {}
-    except (ValueError, TypeError):
-        data = {}
-
-    old = data.get(key)
+    old = get_book_custom_metadata(book).get(key)
     if old == value:
         return 'unchanged'
-    data[key] = value
-    set_book_string_option(book, COMPANY_CUSTOM_SECTION, COMPANY_CUSTOM_SLOT,
-                           json.dumps(data, ensure_ascii=False, sort_keys=True))
+    merge_book_custom_metadata(book, {key: value})
     return 'updated' if old is not None else 'created'


### PR DESCRIPTION
A partial `company` directive silently deleted book custom keys it didn't mention. The custom-key tier (Q-029 — fiscal_year_end, province, entity_type, schema_version, …) replaced the whole custom-metadata blob whenever the directive carried any custom key, so importing a directive that set one custom key dropped every other custom key in the book. Known Business fields were unaffected (they were already a partial update), so the deletion hit exactly the keys users hand-edit, and it contradicted the directive's own documented "an absent field is left as-is" contract and the merging behaviour of `set-book-key`.

The custom-key tier now follows JSON Merge Patch semantics (RFC 7386): a key with a value is upserted, a key with the null value `#None` is removed, and an omitted key is preserved.

- `merge_book_custom_metadata` (and `get_book_custom_metadata`) in infrastructure/gnucash/kvp.py is the single shared writer for the book custom-metadata blob. `import_company` and `set-book-key` both go through it, so the `company` directive and the migration `set-book-key` operation provably behave identically — neither drops keys it didn't name.
- A full export → import round-trip is unaffected: the export emits every key, so the upsert restores all of them. Only partial, hand-written directives change behaviour — and now non-destructively.

Tests in tests/integration/test_company_custom_book_keys.py: a second company import that names only one custom key preserves the others (and the known fields); `key: #None` removes just that key; `set-book-key` upserts one key without disturbing the rest. Passing on GnuCash 3.8 and 5.10; the existing Q-029 round-trip/render tests and the Q-031 migrate suite still pass.

Reopened Q-029 — the full-replace was a wrong design decision in the original feature, not a new gap.