### PR TITLE
feat(Q-032): closing entries first-class, balance sheet, and a report runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1759,6 +1759,53 @@ HKD: 0.17
 CNY: 0.19
 ```
 
+The income statement **excludes closing entries**, so it reports the true period
+result whether or not the books have been closed for the year (see "Closing the
+books" below). Close the books and re-run it — the statement is unchanged.
+
+### Generate a balance sheet
+
+Assets / Liabilities / Equity as of a date, with a **Current Year Earnings** line
+so it balances whether or not the books are closed (before closing, net income
+shows as Current Year Earnings; after closing, it sits in Equity: Retained
+Earnings):
+
+```bash
+gnucash-plaintext balance-sheet mybook.gnucash --as-of 2024-12-31
+gnucash-plaintext balance-sheet mybook.gnucash --as-of 2024-03-31 --fx-rates rates.yaml
+```
+
+### Both statements at once: `report`
+
+T2/GIFI prep needs the income statement and the balance sheet for the same
+period. `report` runs the statements you **name** against a single (expensive)
+book open, output combined — `report` being GnuCash's own term for these:
+
+```bash
+gnucash-plaintext report mybook.gnucash income-statement balance-sheet \
+    --fiscal-year-end 2024-12-31
+```
+
+You list the statements explicitly (`income-statement`, `balance-sheet`) — no
+hidden bundle. The income statement covers the fiscal period; the balance sheet
+is as of the period end (override with `--as-of`). `--fx-rates` and `--output`
+apply across both. It is read-only.
+
+### Closing the books
+
+`close-books` zeroes Income/Expense at year end into `Equity: Retained Earnings:
+{currency}`, marking each closing transaction with GnuCash's closing-transaction
+flag (so GnuCash's reports, the income statement above, and `--force` re-close
+all recognise it — not a fragile description match). The flag round-trips through
+plaintext export/import (`closing: #True`), so a roundtrip never silently
+un-closes the books.
+
+```bash
+gnucash-plaintext close-books mybook.gnucash --closing-date 2024-12-31
+gnucash-plaintext close-books mybook.gnucash --closing-date 2024-12-31 --status
+gnucash-plaintext close-books mybook.gnucash --closing-date 2024-12-31 --force   # re-close
+```
+
 ### Export account balances
 
 Output account balances as of a given date in balance directive format.

--- a/cli/balance_sheet_cmd.py
+++ b/cli/balance_sheet_cmd.py
@@ -1,0 +1,63 @@
+"""CLI command: balance sheet as of a date (F-002).
+
+`balance-sheet <book> --as-of YYYY-MM-DD [--fx-rates rates.yaml] [--output file]`
+
+Assets / Liabilities / Equity as of the date, with a Current Year Earnings line
+so it balances whether or not the books are closed.
+"""
+import sys
+from datetime import datetime
+from typing import Optional
+
+import click
+
+from repositories.gnucash_repository import GnuCashRepository
+from services.balance_sheet import BalanceSheet
+from services.balance_sheet_renderer import render_text
+from services.fx_rates import FxRates
+
+
+def _parse_date(ctx, param, value):
+    if value is None:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as e:
+        raise click.BadParameter(f"Date must be YYYY-MM-DD, got: {value}") from e
+
+
+@click.command("balance-sheet")
+@click.argument("gnucash_file", type=click.Path(exists=True))
+@click.option("--as-of", "as_of", required=True, callback=_parse_date,
+              help="Balance-sheet date (YYYY-MM-DD).")
+@click.option("--fx-rates", "fx_rates_file", default=None, type=click.Path(exists=True),
+              help="YAML FX rates → CAD (for multi-currency T2 consolidation).")
+@click.option("--output", "output_file", default=None, type=click.Path(),
+              help="Output file. Defaults to stdout.")
+def balance_sheet(gnucash_file, as_of, fx_rates_file, output_file):
+    """Generate a balance sheet as of a date."""
+    fx: Optional[FxRates] = None
+    if fx_rates_file:
+        try:
+            fx = FxRates.load(fx_rates_file)
+        except (FileNotFoundError, ValueError) as e:
+            raise click.ClickException(str(e)) from e
+
+    repo = GnuCashRepository(gnucash_file)
+    repo.open()
+    try:
+        result = BalanceSheet().compute(repo.book.get_root_account(), as_of, fx)
+    finally:
+        repo.close()
+
+    text = render_text(result)
+    if output_file:
+        with open(output_file, "w") as f:
+            f.write(text)
+        click.echo(f"Written to {output_file}")
+    else:
+        click.echo(text)
+
+
+if __name__ == "__main__":
+    sys.exit(balance_sheet())

--- a/cli/main.py
+++ b/cli/main.py
@@ -8,6 +8,7 @@ plaintext format.
 import click
 
 from cli.account_balance_cmd import account_balance
+from cli.balance_sheet_cmd import balance_sheet
 from cli.bill_print_cmd import print_bill
 from cli.close_books_cmd import close_books
 from cli.delete_cmd import (
@@ -31,6 +32,7 @@ from cli.income_statement_cmd import income_statement
 from cli.invoice_print_cmd import print_invoice
 from cli.migrate_cmd import migrate
 from cli.rename_account_cmd import rename_account
+from cli.report_cmd import report
 from cli.set_book_key_cmd import set_book_key
 from cli.unapply_cmd import unapply_payment
 from cli.unpost_cmd import unpost_bills, unpost_invoices
@@ -69,6 +71,8 @@ cli.add_command(import_beancount, name='import-beancount')
 cli.add_command(close_books, name='close-books')
 cli.add_command(export_transaction, name='export-transaction')
 cli.add_command(income_statement, name='income-statement')
+cli.add_command(balance_sheet, name='balance-sheet')
+cli.add_command(report, name='report')
 cli.add_command(print_invoice, name='print-invoice')
 cli.add_command(print_bill, name='print-bill')
 cli.add_command(account_balance, name='account-balance')

--- a/cli/report_cmd.py
+++ b/cli/report_cmd.py
@@ -1,0 +1,109 @@
+"""CLI command: run one or more named statements against a single open book.
+
+`report <book> <statement>... [--fiscal-year-end | --start --end] [--as-of] [--fx-rates] [--output]`
+
+You name the statements explicitly — `income-statement`, `balance-sheet` — so a
+T2 package is one invocation and one (expensive) book open, instead of N command
+runs. `report` is GnuCash's own term for these. Read-only; emits the statements
+concatenated.
+
+  gnucash-plaintext report book.gnucash income-statement balance-sheet \
+      --fiscal-year-end 2026-12-31
+"""
+import sys
+from datetime import datetime
+from typing import Optional
+
+import click
+
+from repositories.gnucash_repository import GnuCashRepository, SessionMode
+from services.balance_sheet import BalanceSheet
+from services.balance_sheet_renderer import render_text as bs_render_text
+from services.fx_rates import FxRates
+from services.income_statement_renderer import render_text as is_render_text
+from use_cases.generate_income_statement import (
+    GenerateIncomeStatementUseCase,
+    fiscal_year_start,
+)
+
+_STATEMENTS = ("income-statement", "balance-sheet")
+
+
+def _parse_date(ctx, param, value):
+    if value is None:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as e:
+        raise click.BadParameter(f"Date must be YYYY-MM-DD, got: {value}") from e
+
+
+@click.command("report")
+@click.argument("gnucash_file", type=click.Path(exists=True))
+@click.argument("statements", nargs=-1, required=True)
+@click.option("--fiscal-year-end", callback=_parse_date,
+              help="Fiscal year end (YYYY-MM-DD); start auto-computed as end − 1 year + 1 day.")
+@click.option("--start", callback=_parse_date, help="Explicit period start (with --end).")
+@click.option("--end", callback=_parse_date, help="Explicit period end (with --start).")
+@click.option("--as-of", "as_of", callback=_parse_date,
+              help="Balance-sheet date. Defaults to the period end.")
+@click.option("--fx-rates", "fx_rates_file", default=None, type=click.Path(exists=True),
+              help="YAML FX rates → CAD (for multi-currency T2 consolidation).")
+@click.option("--output", "output_file", default=None, type=click.Path(),
+              help="Output file. Defaults to stdout.")
+def report(gnucash_file, statements, fiscal_year_end, start, end, as_of,
+           fx_rates_file, output_file):
+    """Run the named statements against one open book, output combined."""
+    unknown = [s for s in statements if s not in _STATEMENTS]
+    if unknown:
+        raise click.UsageError(
+            f"unknown statement(s): {', '.join(unknown)}. "
+            f"Choose from: {', '.join(_STATEMENTS)}.")
+
+    # Resolve the period (income statement) and the as-of date (balance sheet).
+    if fiscal_year_end is not None and (start is not None or end is not None):
+        raise click.UsageError("--fiscal-year-end cannot be combined with --start/--end.")
+    if fiscal_year_end is not None:
+        period_start, period_end = fiscal_year_start(fiscal_year_end), fiscal_year_end
+    elif start is not None and end is not None:
+        period_start, period_end = start, end
+    else:
+        raise click.UsageError(
+            "Provide a period: --fiscal-year-end YYYY-MM-DD or --start … --end …")
+    as_of_date = as_of or period_end
+
+    fx: Optional[FxRates] = None
+    if fx_rates_file:
+        try:
+            fx = FxRates.load(fx_rates_file)
+        except (FileNotFoundError, ValueError) as e:
+            raise click.ClickException(str(e)) from e
+
+    repo = GnuCashRepository(gnucash_file)
+    repo.open(mode=SessionMode.READ_ONLY)
+    parts = []
+    try:
+        root = repo.book.get_root_account()
+        for stmt in statements:
+            if stmt == "income-statement":
+                result = GenerateIncomeStatementUseCase(repo).execute(
+                    start_date=period_start, end_date=period_end, fx_rates=fx)
+                parts.append(is_render_text(result))
+            elif stmt == "balance-sheet":
+                parts.append(bs_render_text(BalanceSheet().compute(root, as_of_date, fx)))
+    except ValueError as e:
+        raise click.ClickException(str(e)) from e
+    finally:
+        repo.close()
+
+    combined = "\n\n".join(parts)
+    if output_file:
+        with open(output_file, "w") as f:
+            f.write(combined)
+        click.echo(f"Written to {output_file}")
+    else:
+        click.echo(combined)
+
+
+if __name__ == "__main__":
+    sys.exit(report())

--- a/docs/issues/Q-032-closing-entries-and-report.md
+++ b/docs/issues/Q-032-closing-entries-and-report.md
@@ -1,0 +1,58 @@
+---
+id: Q-032
+title: Income statement breaks once books are closed; no balance sheet; no combined report
+category: feature
+severity: high
+status: closed
+---
+
+## Problem
+
+Three interlocking gaps around financial statements, surfaced together:
+
+1. **The income statement breaks the moment you close the books.** `close-books` created a closing transaction with only a `"Closing entry (…)"` description — it never set GnuCash's `xaccTransSetIsClosingTxn` flag. And `income-statement` summed *every* split in the period. So after closing (the closing entry zeroes Income/Expense on the fiscal-year-end date, inside the period), the income statement included those closing entries and reported ~0. The statement was only correct *before* closing.
+
+2. **The closing flag didn't round-trip plaintext.** Even once set, the flag persisted to the native `.gnucash` XML but the plaintext exporter/importer ignored it — so an `export → import` silently un-closed the books, re-breaking the income statement.
+
+3. **No balance sheet (F-002), and no way to get both statements at once.** T2/GIFI prep needs the income statement *and* the balance sheet as of the same period, but there was no balance-sheet command and no combined run — meaning N command runs and N (expensive) book opens.
+
+## Fix
+
+Closing entries are now first-class, the income statement excludes them, the flag round-trips, and there's a `balance-sheet` command plus a `report` runner.
+
+### Closing entries are first-class
+- `close-books` sets `xaccTransSetIsClosingTxn(tx, True)` on each closing transaction (persists to XML). `is_closing_txn(tx)` recognises a closing entry by the **flag** (authoritative) or the legacy description, so `--force`/`--status` also find GUI-created closings.
+- `income-statement` excludes splits whose transaction `is_closing_txn` — so it reports the true period result whether the books are closed, not closed, or stale-closed.
+- The closing flag round-trips plaintext: the exporter emits `closing: #True` on closing transactions, the importer re-applies it via `xaccTransSetIsClosingTxn` (`closing` is now a known tx key). A roundtrip no longer un-closes the books.
+
+### Balance sheet (F-002)
+- `balance-sheet <book> --as-of DATE [--fx-rates] [--output]` — Assets / Liabilities / Equity as of the date, with a computed **Current Year Earnings** line so it balances whether or not the books are closed. It always balances by the fundamental identity (every split nets to zero ⇒ Assets = Liabilities + Equity + net income); closing just moves the net income from the earnings line into Equity (Retained Earnings).
+- It reuses the income statement's section renderer, so the two statements look identical (indented account tree, subtotals).
+
+### Combined report
+- `report <book> income-statement balance-sheet [--fiscal-year-end | --start --end] [--as-of] [--fx-rates] [--output]` — you **name** the statements explicitly (no opaque bundle; `report` is GnuCash's own term), and they run against **one** read-only book open, output combined. The income statement covers the period; the balance sheet is as of the period end. Read-only — no save/history/versioning (unlike `migrate`).
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `services/book_closer.py` | Set the closing flag on creation; `is_closing_txn`; find closings by flag. |
+| `services/income_statement.py` | Exclude closing splits from period balances. |
+| `infrastructure/gnucash/kvp.py` | `closing` is a known tx metadata key. |
+| `use_cases/export_transactions.py` | Emit `closing: #True` on closing transactions. |
+| `services/gnucash_importer.py` | Re-apply the closing flag on import. |
+| `services/balance_sheet.py`, `services/balance_sheet_renderer.py`, `cli/balance_sheet_cmd.py` | New balance-sheet (F-002), reusing the income statement section renderer. |
+| `cli/report_cmd.py`, `cli/main.py` | New `report` runner; register `balance-sheet` + `report`. |
+| `README.md` | Document closing-entry handling, `balance-sheet`, `report`. |
+
+## Tests
+
+`tests/integration/test_closing_entries.py`: income statement is **byte-identical before and after close**; `close-books` sets the flag (real activity isn't flagged); the flag **survives a plaintext roundtrip** (asserted via `xaccTransGetIsClosingTxn`, not just the description); `--force` re-close finds the prior closing by flag. `tests/integration/test_reports.py`: the balance sheet **balances before and after close** (Current Year Earnings pre-close, Retained Earnings post-close); `report` runs both statements in one invocation; an unknown statement is rejected. Existing income-statement (21) and close-books (70) suites still pass. Passing on GnuCash 3.8 and 5.10.
+
+## Related issues
+
+- **F-002** — "No balance-sheet command" — closed by the `balance-sheet` command here.
+
+---
+
+**Created**: 2026-06-28

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -30,7 +30,7 @@ and in the **Status** column below.
 | ID | Title | Severity | Status |
 |----|-------|----------|--------|
 | [F-001](F-001-qfx-dependency-declared-but-not-implemented.md) | QFX/OFX dependency declared but feature not implemented | medium | open |
-| [F-002](F-002-balance-sheet-command-missing.md) | No balance-sheet command | enhancement | open |
+| [F-002](F-002-balance-sheet-command-missing.md) | No balance-sheet command | enhancement | closed |
 | [F-003](F-003-export-date-range-filter-missing.md) | export command has no date-range filter | enhancement | closed |
 | [F-004](F-004-no-search-find-transaction-command.md) | No search / find-transaction command | enhancement | closed |
 | [F-005](F-005-data-models-and-provider-protocol.md) | Statement import: data models and StatementProvider protocol | feature | closed |
@@ -76,3 +76,4 @@ and in the **Status** column below.
 | [Q-029](Q-029-company-arbitrary-book-keys.md) | company directive only round-trips known seller-identity keys; no way to store arbitrary book-level data | medium | closed |
 | [Q-030](Q-030-rename-account.md) | No way to rename an account; the full round-trip can't express it | enhancement | closed |
 | [Q-031](Q-031-migrate-batch-operations.md) | No batch operations or migrations — every surgical command is one-op-per-save | enhancement | closed |
+| [Q-032](Q-032-closing-entries-and-report.md) | Income statement breaks once books are closed; no balance sheet; no combined report | high | closed |

--- a/infrastructure/gnucash/kvp.py
+++ b/infrastructure/gnucash/kvp.py
@@ -48,6 +48,12 @@ KNOWN_TX_METADATA_KEYS = frozenset({
     'currency.mnemonic',
     'doc_link',
     'notes',
+    # Q-032: the book-closing flag (xaccTransGetIsClosingTxn). Emitted as
+    # `closing: #True` only on closing transactions and re-applied on import via
+    # xaccTransSetIsClosingTxn, so a plaintext roundtrip doesn't un-close the
+    # books (which would re-break the income statement). Handled by the importer
+    # directly, not as a custom KVP slot.
+    'closing',
     # NOTE: `txn_type` and `owner` are deliberately NOT in this set even
     # though the exporter emits them on payment-class transactions. The
     # in-memory mutators (`xaccTransSetTxnType`, `gncOwnerCopyOnTxn`) are

--- a/services/balance_sheet.py
+++ b/services/balance_sheet.py
@@ -1,0 +1,148 @@
+"""Balance sheet service (F-002).
+
+Assets / Liabilities / Equity as of a date, with a computed **Current Year
+Earnings** line so the sheet balances whether or not the books are closed.
+
+Why it balances either way: every split nets to zero, so across all accounts
+  Assets + Liabilities + Equity + Income + Expense = 0   (GnuCash sign convention)
+hence
+  Assets = (−Liabilities) + (−Equity) + (−(Income + Expense)).
+Presenting Liabilities and Equity as positive and adding the net income line
+(−(Income + Expense)) makes Assets = Liabilities + Equity + Current Year
+Earnings — an identity. Closing entries just move that net income out of the
+earnings line and into Equity (Retained Earnings); the total is unchanged. So
+the balance sheet uses raw balances (closing entries included) and always
+balances.
+"""
+from dataclasses import dataclass, field
+from datetime import date
+from fractions import Fraction
+from typing import Dict, List, Optional
+
+from gnucash import Account
+from gnucash.gnucash_core_c import (
+    ACCT_TYPE_ASSET,
+    ACCT_TYPE_EQUITY,
+    ACCT_TYPE_EXPENSE,
+    ACCT_TYPE_INCOME,
+    ACCT_TYPE_LIABILITY,
+)
+
+from services.fx_rates import FxRates
+
+CURRENT_EARNINGS_LABEL = "Current Year Earnings"
+
+
+@dataclass
+class BSLine:
+    path: str
+    name: str
+    depth: int                        # nesting depth (0 = direct child of root)
+    currency: str
+    balance: Fraction                 # presented (positive-normal) amount
+    cad_balance: Optional[Fraction]
+
+
+@dataclass
+class BSSection:
+    title: str
+    lines: List[BSLine] = field(default_factory=list)
+    currency_totals: Dict[str, Fraction] = field(default_factory=dict)
+    cad_total: Optional[Fraction] = None
+
+
+@dataclass
+class BalanceSheetResult:
+    as_of_date: date
+    assets: BSSection
+    liabilities: BSSection
+    equity: BSSection                 # includes the synthetic Current Year Earnings line
+    fx_rates_provided: bool
+    balances: bool                    # Assets == Liabilities + Equity (in CAD when FX given)
+
+
+class BalanceSheet:
+    def balance_as_of(self, account: Account, as_of_date: date) -> Fraction:
+        """Cumulative balance of `account` from inception through `as_of_date`
+        (inclusive). Includes closing entries — see the module docstring."""
+        total = Fraction(0)
+        for split in account.GetSplitList():
+            tx = split.GetParent()
+            d = tx.GetDate()
+            if date(d.year, d.month, d.day) <= as_of_date:
+                value = split.GetValue()
+                total += Fraction(value.num(), value.denom())
+        return total
+
+    def _full_path(self, account: Account) -> str:
+        parts, node = [], account
+        while node is not None and node.get_parent() is not None:
+            parts.append(node.GetName())
+            node = node.get_parent()
+        return ':'.join(reversed(parts))
+
+    def compute(self, root: Account, as_of_date: date,
+                fx_rates: Optional[FxRates] = None) -> BalanceSheetResult:
+        assets = BSSection("ASSETS")
+        liabilities = BSSection("LIABILITIES")
+        equity = BSSection("EQUITY")
+        earnings_by_ccy: Dict[str, Fraction] = {}
+
+        for account in root.get_descendants():
+            atype = account.GetType()
+            commodity = account.GetCommodity()
+            if commodity is None:
+                continue
+            ccy = commodity.get_mnemonic()
+            raw = self.balance_as_of(account, as_of_date)
+
+            if atype in (ACCT_TYPE_INCOME, ACCT_TYPE_EXPENSE):
+                # Fold into Current Year Earnings: net income = -(income + expense).
+                earnings_by_ccy[ccy] = earnings_by_ccy.get(ccy, Fraction(0)) - raw
+                continue
+
+            if atype == ACCT_TYPE_ASSET:
+                section, presented = assets, raw            # asset: debit-normal
+            elif atype == ACCT_TYPE_LIABILITY:
+                section, presented = liabilities, -raw      # liability: credit-normal
+            elif atype == ACCT_TYPE_EQUITY:
+                section, presented = equity, -raw           # equity: credit-normal
+            else:
+                continue
+
+            if presented == Fraction(0):
+                continue
+            cad = fx_rates.to_cad(presented, ccy) if fx_rates is not None else None
+            path = self._full_path(account)
+            depth = len(path.split(':')) - 1
+            section.lines.append(BSLine(path, account.GetName(), depth, ccy, presented, cad))
+            section.currency_totals[ccy] = section.currency_totals.get(ccy, Fraction(0)) + presented
+
+        # Current Year Earnings → an equity line per currency.
+        for ccy, amount in earnings_by_ccy.items():
+            if amount == Fraction(0):
+                continue
+            cad = fx_rates.to_cad(amount, ccy) if fx_rates is not None else None
+            equity.lines.append(BSLine(CURRENT_EARNINGS_LABEL, CURRENT_EARNINGS_LABEL,
+                                       0, ccy, amount, cad))
+            equity.currency_totals[ccy] = equity.currency_totals.get(ccy, Fraction(0)) + amount
+
+        balances = self._finalise(assets, liabilities, equity, fx_rates)
+        return BalanceSheetResult(
+            as_of_date=as_of_date, assets=assets, liabilities=liabilities,
+            equity=equity, fx_rates_provided=fx_rates is not None, balances=balances)
+
+    def _finalise(self, assets, liabilities, equity, fx_rates) -> bool:
+        if fx_rates is None:
+            # Single-currency books: balance per currency exactly.
+            ccys = set(assets.currency_totals) | set(liabilities.currency_totals) | set(equity.currency_totals)
+            ok = True
+            for c in ccys:
+                a = assets.currency_totals.get(c, Fraction(0))
+                le = liabilities.currency_totals.get(c, Fraction(0)) + equity.currency_totals.get(c, Fraction(0))
+                ok = ok and (a == le)
+            return ok
+        for sec in (assets, liabilities, equity):
+            sec.cad_total = sum((fx_rates.to_cad(v, c) for c, v in sec.currency_totals.items()),
+                                Fraction(0))
+        return assets.cad_total == (liabilities.cad_total + equity.cad_total)

--- a/services/balance_sheet_renderer.py
+++ b/services/balance_sheet_renderer.py
@@ -1,0 +1,23 @@
+"""Plain-text renderer for the balance sheet.
+
+Reuses the income statement's section renderer (`_render_section_text`) so both
+statements look identical in a `report` — same indented account tree, subtotals,
+and section totals. `BSSection`/`BSLine` are shape-compatible with the income
+statement's section/line (title, lines, currency_totals, cad_total; path, name,
+depth, currency, balance, cad_balance)."""
+from services.balance_sheet import BalanceSheetResult
+from services.income_statement_renderer import _render_section_text
+
+
+def render_text(result: BalanceSheetResult) -> str:
+    out = ["=" * 60, "BALANCE SHEET", f"As of: {result.as_of_date}", "=" * 60, ""]
+    if not result.fx_rates_provided:
+        out.append("NOTE: No FX rates supplied. CAD totals not available.\n")
+    out.extend(_render_section_text(result.assets, result.fx_rates_provided))
+    out.extend(_render_section_text(result.liabilities, result.fx_rates_provided))
+    out.extend(_render_section_text(result.equity, result.fx_rates_provided))
+    out.append("=" * 60)
+    status = "BALANCED" if result.balances else "NOT BALANCED — check the book"
+    out.append(f"  {'Assets = Liabilities + Equity:':<48} {status}")
+    out.append("=" * 60)
+    return "\n".join(out)

--- a/services/book_closer.py
+++ b/services/book_closer.py
@@ -12,11 +12,28 @@ from fractions import Fraction
 from typing import Dict, List, Optional, Set, Tuple
 
 from gnucash import Account, GncNumeric, Split, Transaction
-from gnucash.gnucash_core_c import ACCT_TYPE_EQUITY, ACCT_TYPE_EXPENSE, ACCT_TYPE_INCOME
+from gnucash.gnucash_core_c import (
+    ACCT_TYPE_EQUITY,
+    ACCT_TYPE_EXPENSE,
+    ACCT_TYPE_INCOME,
+    xaccTransGetIsClosingTxn,
+    xaccTransSetIsClosingTxn,
+)
 
 from infrastructure.gnucash.utils import find_account
 
 CLOSING_DESCRIPTION_PREFIX = "Closing entry"
+
+
+def is_closing_txn(tx) -> bool:
+    """True if a transaction is a book-closing entry. GnuCash's authoritative
+    marker is the closing-transaction flag (`xaccTransGetIsClosingTxn`); the
+    legacy `"Closing entry ("` description is also accepted so closings created
+    before the flag existed are still recognised. Used both to find closings to
+    re-close and to exclude them from the income statement."""
+    if xaccTransGetIsClosingTxn(tx.instance):
+        return True
+    return tx.GetDescription().startswith(f"{CLOSING_DESCRIPTION_PREFIX} (")
 
 
 class BookCloser:
@@ -111,7 +128,9 @@ class BookCloser:
         """
         Find existing closing transactions on the given date.
 
-        Identifies by: date == closing_date AND description starts with "Closing entry ("
+        Identifies by: date == closing_date AND `is_closing_txn` (the closing
+        flag, or the legacy description). The flag also catches closings created
+        by the GnuCash GUI, which carry a different description.
         Returns unique transactions (deduped by GUID).
         """
         closing_txns = []
@@ -123,8 +142,7 @@ class BookCloser:
                 tx_date = tx.GetDate()
                 if date(tx_date.year, tx_date.month, tx_date.day) != closing_date:
                     continue
-                desc = tx.GetDescription()
-                if not desc.startswith(f"{CLOSING_DESCRIPTION_PREFIX} ("):
+                if not is_closing_txn(tx):
                     continue
                 guid = tx.GetGUID().to_string()
                 if guid not in seen_guids:
@@ -232,6 +250,11 @@ class BookCloser:
         equity_split.SetParent(tx)
         equity_split.SetAccount(equity_account)
         equity_split.SetValue(GncNumeric(equity_numerator, currency_fraction))
+
+        # Mark it as a GnuCash closing transaction so reports (and our own
+        # income-statement / re-close detection) recognise it via the
+        # authoritative flag, not just the description. Persists to the XML.
+        xaccTransSetIsClosingTxn(tx.instance, True)
 
         tx.CommitEdit()
         return tx

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -28,6 +28,7 @@ from gnucash.gnucash_core_c import (
     ACCT_TYPE_RECEIVABLE,
     ACCT_TYPE_STOCK,
     gncTaxTableEntrySetAccount,
+    xaccTransSetIsClosingTxn,
 )
 
 from infrastructure.gnucash.kvp import (
@@ -2205,6 +2206,12 @@ class GnuCashImporter:
         if 'notes' in directive.metadata:
             notes = directive.metadata['notes']
             transaction.SetNotes(notes)
+
+        # Q-032: re-apply the book-closing flag so a roundtrip doesn't un-close
+        # the books (the exporter emits `closing: #True` on closing entries).
+        _closing = directive.metadata.get('closing')
+        if _closing is not None and not _is_falsy(str(_closing)):
+            xaccTransSetIsClosingTxn(transaction.instance, True)
 
         transaction.SetDateEnteredSecs(datetime.now())
         date = datetime.strptime(date_str, '%Y-%m-%d')

--- a/services/income_statement.py
+++ b/services/income_statement.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Optional
 from gnucash import Account
 from gnucash.gnucash_core_c import ACCT_TYPE_EXPENSE, ACCT_TYPE_INCOME
 
+from services.book_closer import is_closing_txn
 from services.fx_rates import FxRates
 
 
@@ -87,6 +88,11 @@ class IncomeStatementService:
         total = Fraction(0)
         for split in account.GetSplitList():
             tx = split.GetParent()
+            # Closing entries are equity transfers, not period activity — exclude
+            # them so the income statement reports the true result whether the
+            # books are closed or not.
+            if is_closing_txn(tx):
+                continue
             tx_date_raw = tx.GetDate()
             tx_date = date(tx_date_raw.year, tx_date_raw.month, tx_date_raw.day)
             if start_date <= tx_date <= end_date:

--- a/tests/fixtures/closing_book.txt
+++ b/tests/fixtures/closing_book.txt
@@ -1,0 +1,39 @@
+2026-01-01 commodity CAD
+	mnemonic: "CAD"
+	fullname: "Canadian Dollar"
+	namespace: "CURRENCY"
+	fraction: 100
+2026-01-01 open Assets
+	type: "Asset"
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Income
+	type: "Income"
+	placeholder: #True
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Income:Sales
+	type: "Income"
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Expenses
+	type: "Expense"
+	placeholder: #True
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Expenses:Office
+	type: "Expense"
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2026-01-01 open Equity
+	type: "Equity"
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+
+2026-06-01 * "Sale"
+	Assets 1000.00 CAD
+	Income:Sales -1000.00 CAD
+
+2026-07-01 * "Office supplies"
+	Expenses:Office 300.00 CAD
+	Assets -300.00 CAD

--- a/tests/integration/test_closing_entries.py
+++ b/tests/integration/test_closing_entries.py
@@ -1,0 +1,110 @@
+"""Q-032: closing entries are first-class — `close-books` flags them, the income
+statement excludes them (so it's correct closed or not), and the flag round-trips
+through plaintext.
+
+Book: Income 1000, Expenses 300 in 2026 → net income 700.
+"""
+
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+BOOK = str(Path('tests/fixtures/closing_book.txt'))
+
+
+def _new_book(runner, tmp_path, name='book.gnucash'):
+    gf = tmp_path / name
+    assert runner.invoke(cli, ['import', '--new', str(gf), BOOK]).exit_code == 0
+    time.sleep(1)
+    return gf
+
+
+def _income_statement(runner, gf):
+    r = runner.invoke(cli, ['income-statement', str(gf), '--fiscal-year-end', '2026-12-31'])
+    assert r.exit_code == 0, r.output
+    return r.output
+
+
+def _close(runner, gf):
+    r = runner.invoke(cli, ['close-books', str(gf), '--closing-date', '2026-12-31'])
+    assert r.exit_code == 0, r.output
+    time.sleep(1)
+
+
+def _closing_flags(gf):
+    """{tx description: xaccTransGetIsClosingTxn(tx)} — the authoritative flag."""
+    from gnucash.gnucash_core_c import xaccTransGetIsClosingTxn
+
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        seen = {}
+        for a in repo.book.get_root_account().get_descendants():
+            for s in a.GetSplitList():
+                t = s.GetParent()
+                seen[t.GetDescription()] = bool(xaccTransGetIsClosingTxn(t.instance))
+        return seen
+    finally:
+        repo.close()
+
+
+def test_income_statement_identical_before_and_after_close(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    before = _income_statement(runner, gf)
+    assert '700.00' in before
+    _close(runner, gf)
+    after = _income_statement(runner, gf)
+    # Closing zeroes Income/Expense, but the statement excludes closing entries —
+    # so it is byte-for-byte identical whether the books are closed or not.
+    assert after == before
+
+
+def test_close_books_flags_the_closing_transaction(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    _close(runner, gf)
+    flags = _closing_flags(gf)
+    assert flags.get('Closing entry (CAD)') is True   # authoritative GnuCash flag
+    assert flags.get('Sale') is False                 # real activity is not flagged
+
+
+def test_closing_flag_survives_plaintext_roundtrip(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    _close(runner, gf)
+    before = _income_statement(runner, gf)
+
+    exp = tmp_path / 'exp.txt'
+    assert runner.invoke(cli, ['export', str(gf), str(exp)]).exit_code == 0
+    assert 'closing: #True' in exp.read_text()        # exporter emits the flag
+
+    gf2 = tmp_path / 'B.gnucash'
+    assert runner.invoke(cli, ['import', '--new', str(gf2), str(exp)]).exit_code == 0
+    time.sleep(1)
+    # The flag (not just the description) is re-applied in the fresh book…
+    assert _closing_flags(gf2).get('Closing entry (CAD)') is True
+    # …and the income statement is still correct after the roundtrip.
+    assert _income_statement(runner, gf2) == before
+
+
+def test_reclose_finds_prior_closing_by_flag(tmp_path):
+    """`--force` re-close must find the existing closing — by the flag, robust to
+    the description."""
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    _close(runner, gf)
+    # A second close without --force is refused (already closed); --force re-closes.
+    r = runner.invoke(cli, ['close-books', str(gf), '--closing-date', '2026-12-31'])
+    assert r.exit_code != 0  # already closed
+    r2 = runner.invoke(cli, ['close-books', str(gf), '--closing-date', '2026-12-31', '--force'])
+    assert r2.exit_code == 0, r2.output
+    time.sleep(1)
+    # Still exactly one flagged closing (the old one was replaced, not duplicated).
+    flags = _closing_flags(gf)
+    assert list(flags.values()).count(True) == 1
+    assert _income_statement(runner, gf).__contains__('700.00')

--- a/tests/integration/test_reports.py
+++ b/tests/integration/test_reports.py
@@ -1,0 +1,72 @@
+"""F-002 + report: `balance-sheet` balances (closed or not), and `report` runs
+named statements against one open book.
+
+Book (tests/fixtures/closing_book.txt): Assets 700, net income 700.
+"""
+
+import time
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+BOOK = str(Path('tests/fixtures/closing_book.txt'))
+
+
+def _new_book(runner, tmp_path):
+    gf = tmp_path / 'book.gnucash'
+    assert runner.invoke(cli, ['import', '--new', str(gf), BOOK]).exit_code == 0
+    time.sleep(1)
+    return gf
+
+
+def _balance_sheet(runner, gf):
+    r = runner.invoke(cli, ['balance-sheet', str(gf), '--as-of', '2026-12-31'])
+    assert r.exit_code == 0, r.output
+    return r.output
+
+
+def _close(runner, gf):
+    assert runner.invoke(cli, ['close-books', str(gf),
+                               '--closing-date', '2026-12-31']).exit_code == 0
+    time.sleep(1)
+
+
+def test_balance_sheet_balances_before_close(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    out = _balance_sheet(runner, gf)
+    assert 'NOT BALANCED' not in out          # Assets = Liabilities + Equity holds
+    assert '700.00' in out
+    assert 'Current Year Earnings' in out     # net income not yet in equity
+
+
+def test_balance_sheet_balances_after_close(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    _close(runner, gf)
+    out = _balance_sheet(runner, gf)
+    assert 'NOT BALANCED' not in out          # still balances
+    assert '700.00' in out
+    assert 'Retained Earnings' in out         # net income now sits in equity
+
+
+def test_report_runs_both_statements_in_one_invocation(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    r = runner.invoke(cli, ['report', str(gf), 'income-statement', 'balance-sheet',
+                            '--fiscal-year-end', '2026-12-31'])
+    assert r.exit_code == 0, r.output
+    assert 'INCOME STATEMENT' in r.output and 'BALANCE SHEET' in r.output
+    assert 'NET INCOME' in r.output and 'NOT BALANCED' not in r.output
+    assert r.output.count('700.00') >= 2      # IS net income + BS
+
+
+def test_report_rejects_unknown_statement(tmp_path):
+    runner = CliRunner()
+    gf = _new_book(runner, tmp_path)
+    r = runner.invoke(cli, ['report', str(gf), 'cash-flow',
+                            '--fiscal-year-end', '2026-12-31'])
+    assert r.exit_code != 0
+    assert 'unknown statement' in r.output and 'cash-flow' in r.output

--- a/use_cases/export_transactions.py
+++ b/use_cases/export_transactions.py
@@ -15,6 +15,7 @@ from gnucash.gnucash_core_c import (
     GncGUID,
     string_to_guid,
     xaccAccountGetTypeStr,
+    xaccTransGetIsClosingTxn,
     xaccTransLookup,
 )
 
@@ -644,6 +645,11 @@ class ExportTransactionsUseCase:
             lines.append(f'\tdoc_link: {encode_value_as_string(tx_doc_link)}')
         if tx_notes and tx_notes.strip() != "":
             lines.append(f'\tnotes: {encode_value_as_string(tx_notes)}')
+
+        # Q-032: preserve the book-closing flag across a plaintext roundtrip
+        # (only emitted on closing transactions).
+        if xaccTransGetIsClosingTxn(transaction.instance):
+            lines.append('\tclosing: #True')
 
         # txn_type + owner: GnuCash internal classifier + customer/vendor
         # KVP backref set by the business-object machinery (txn_type='I'


### PR DESCRIPTION
Three interlocking financial-statement gaps, fixed together.

The income statement broke the moment the books were closed. close-books created a closing transaction with only a "Closing entry (…)" description and never set GnuCash's closing-transaction flag, and income-statement summed every split in the period. So after closing — the closing entry zeroes Income/Expense on the fiscal-year-end date, inside the period — the income statement included those closing entries and reported ~0. It was only correct before closing. There was also no balance sheet, and no way to get both statements for a T2 package without N command runs and N (expensive) book opens.

Closing entries are now first-class:
- close-books sets xaccTransSetIsClosingTxn(tx, True) on each closing transaction (persists to XML). `is_closing_txn` recognises a closing entry by the flag (authoritative) or the legacy description, so --force / --status also find GUI-created closings.
- income-statement excludes splits whose transaction is a closing entry, so it reports the true period result whether the books are closed, not closed, or stale-closed.
- The flag round-trips plaintext: the exporter emits `closing: #True` on closing transactions and the importer re-applies it via xaccTransSetIsClosingTxn (`closing` is a known tx key). The flag persists to the native .gnucash XML but the plaintext layer ignored it, so an export → import used to silently un-close the books and re-break the statement; it no longer does.

Balance sheet (closes F-002):
- `balance-sheet <book> --as-of DATE [--fx-rates] [--output]` — Assets / Liabilities / Equity as of the date, with a computed Current Year Earnings line so it balances whether or not the books are closed. It balances by the fundamental identity (every split nets to zero ⇒ Assets = Liabilities + Equity + net income); closing just moves the net income from the earnings line into Equity (Retained Earnings). It reuses the income statement's section renderer, so the two statements look identical (same indented account tree, subtotals) — one renderer, one style.

Combined report:
- `report <book> income-statement balance-sheet [--fiscal-year-end | --start --end] [--as-of] [--fx-rates] [--output]` — you name the statements explicitly (no opaque bundle; `report` is GnuCash's own term), and they run against one read-only book open, output combined. The income statement covers the period; the balance sheet is as of the period end. Read-only — no save/history/versioning, unlike migrate.

Tests: tests/integration/test_closing_entries.py — the income statement is byte-identical before and after close; close-books sets the flag (real activity is not flagged); the flag survives a plaintext roundtrip (asserted via xaccTransGetIsClosingTxn, not just the description); --force re-close finds the prior closing by flag. tests/integration/test_reports.py — the balance sheet balances before and after close (Current Year Earnings pre-close, Retained Earnings post-close); report runs both statements in one invocation; an unknown statement is rejected. Existing income-statement (21) and close-books (70) suites and the transaction roundtrip still pass. Passing on GnuCash 3.8 and 5.10.