### PR TITLE
fix(Q-033): accept natural Receivable/Payable account type strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,13 @@ like you do in beancount `2014-05-01 open Liabilities:CreditCard:CapitalOne     
 in GnuCash plaintext, but it will be interpreted as you open account `Liabilities:CreditCard:CapitalOne     USD` on
 2014-05-01.
 
-Supported values of `type` are  6 asset accounts (Cash, Bank, Stock, Mutual Fund, Accounts Receivable, and Other Assets),
-3 liability accounts (Credit Card, Accounts Payable, and Liability), 1 equity account (Equity), 1 income account (Income), and 1 expense account (Expenses).
+Supported `type` values are the GnuCash account types (case-sensitive):
+
+- Asset side: `Asset`, `Bank`, `Cash`, `Stock`, `Mutual Fund`, `Accounts Receivable`
+- Liability side: `Liability`, `Credit Card`, `Accounts Payable`
+- `Equity`, `Income`, `Expense`
+
+`Accounts Receivable` and `Accounts Payable` also accept the GnuCash short forms `A/Receivable` / `A/Payable` and the bare `Receivable` / `Payable`. An unrecognised `type` is reported in the import summary (and the account is skipped), so a typo never silently lands an account with no type.
 
 Also, you cannot declare top level accounts such as `Expenses` in beancount, but you
 need to `open` `Expenses` account first before you can open `Expenses:Groceries & Household` in GnuCash plaintext.

--- a/docs/gnucash-beancount-format.md
+++ b/docs/gnucash-beancount-format.md
@@ -214,13 +214,13 @@ This demonstrates the complete round-trip conversion process:
     fraction: 100
 
 2024-01-01 open Assets:Bank:Checking
-    type: "BANK"
+    type: "Bank"
     placeholder: #False
     commodity.namespace: "CURRENCY"
     commodity.mnemonic: "CNY"
 
 2024-01-01 open Expenses:Groceries
-    type: "EXPENSE"
+    type: "Expense"
     placeholder: #False
     commodity.namespace: "CURRENCY"
     commodity.mnemonic: "CNY"

--- a/docs/issues/F-010-kvp-metadata-all-object-types.md
+++ b/docs/issues/F-010-kvp-metadata-all-object-types.md
@@ -96,7 +96,7 @@ fields, producing the same text above.
 ```
 2024-01-01 open Assets:Bank:Checking
 	guid: "abc123"
-	type: "BANK"
+	type: "Bank"
 	commodity.namespace: CURRENCY
 	commodity.mnemonic: CAD
 	erp.cost_centre: "DEPT-42"

--- a/docs/issues/Q-033-natural-account-type-strings-rejected.md
+++ b/docs/issues/Q-033-natural-account-type-strings-rejected.md
@@ -1,0 +1,48 @@
+---
+id: Q-033
+title: Natural Receivable/Payable account-type strings are rejected, silently dropping accounts
+category: bug
+severity: high
+status: closed
+---
+
+## Problem
+
+A book that used the natural account-type spellings `type: "Receivable"` / `type: "Payable"` imported with those accounts **missing a type**, so they vanished from the balance sheet and it read **NOT BALANCED**. The symptom looked like the earlier Bank-type drop fixed in Q-032 (#82), but it was a different layer: the balance-sheet classification already covers RECEIVABLE/PAYABLE — the **importer** never gave the accounts those types.
+
+Repro (`tests/fixtures/receivable_payable_natural_form_book.txt`): Cash 600 + Trade receivable 400 = 1000 assets, Trade payable 250, Equity 750. Before the fix, `import` reported a vague `'Receivable'` error, `balance-sheet` showed only Cash and Equity, and `Assets = Liabilities + Equity` failed (600 ≠ 750).
+
+## Cause
+
+`services/gnucash_importer.py`'s `ACCT_TYPE_MAP` only knew `"Accounts Receivable"` / `"A/Receivable"` and `"Accounts Payable"` / `"A/Payable"`. The bare `"Receivable"` / `"Payable"` raised a `KeyError` on `ACCT_TYPE_MAP[...]`, and `create_account` had already attached the account to the tree before that line — so the account survived with type `INVALID` (-1) and its splits were dropped. The balance sheet then correctly ignored the typeless account.
+
+The docs compounded it:
+- The README listed `Other Assets` (not a type — should be `Asset`) and `Expenses` (should be `Expense`).
+- `docs/gnucash-beancount-format.md` and `docs/issues/F-010-…` showed native-plaintext examples using the uppercase XML-enum forms `type: "BANK"` / `type: "EXPENSE"`, which the importer doesn't accept either.
+
+So a user following the docs hit the same silent failure.
+
+## Fix
+
+- `ACCT_TYPE_MAP` now also accepts the natural `Receivable` / `Payable`, and the README spellings `Other Assets` (→ Asset) / `Expenses` (→ Expense).
+- `create_account` resolves the type **before** attaching the account, so an unrecognised type raises a clear, actionable error that names the bad type and lists the supported ones — instead of a cryptic `KeyError` that half-creates an INVALID account. The error stays non-fatal and is surfaced in the import summary (matching the existing `test_import_new_reports_account_creation_error` design), but it can no longer pass silently with an account left untyped.
+- Docs corrected: README's account-type list is precise and lists the accepted spellings; the uppercase native `type:` examples in `docs/gnucash-beancount-format.md` and `docs/issues/F-010-…` are now the canonical title-case forms.
+
+This is distinct from **Q-003**, which added the exporter's short forms (`A/Receivable` / `A/Payable`) so an exported file re-imports; here the strings are the ones a human writes by hand.
+
+## Tests
+
+- `tests/unit/services/test_account_type_map.py` — the natural `Receivable`/`Payable` and the README spellings map to the right GnuCash types.
+- `tests/integration/test_balance_sheet_account_types.py::test_natural_form_receivable_payable_land_on_balance_sheet` — the repro imports as RECEIVABLE/PAYABLE (matched **by account type**, not name), lands in the right sections, and balances (Assets 1000 = Liabilities 250 + Equity 750).
+- `tests/integration/test_cli_import.py::test_import_new_reports_account_creation_error` — an unknown type warns clearly: the summary names the bad type and lists the supported ones.
+
+Passing on GnuCash 3.8 and 5.10.
+
+## Related
+
+- **Q-032** — the balance-sheet account-type classification (the symptom surfaced there, but the cause is the importer).
+- **Q-003** — exporter short-form account types not re-importable (closed; different layer).
+
+---
+
+**Created**: 2026-06-28

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -77,3 +77,4 @@ and in the **Status** column below.
 | [Q-030](Q-030-rename-account.md) | No way to rename an account; the full round-trip can't express it | enhancement | closed |
 | [Q-031](Q-031-migrate-batch-operations.md) | No batch operations or migrations — every surgical command is one-op-per-save | enhancement | closed |
 | [Q-032](Q-032-closing-entries-and-report.md) | Income statement breaks once books are closed; no balance sheet; no combined report | high | closed |
+| [Q-033](Q-033-natural-account-type-strings-rejected.md) | Natural Receivable/Payable account-type strings are rejected, silently dropping accounts | high | closed |

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -1132,8 +1132,10 @@ def _is_falsy(val: str) -> bool:
 
 ACCT_TYPE_MAP = {
     "Asset": ACCT_TYPE_ASSET,
+    "Other Assets": ACCT_TYPE_ASSET,         # README wording for a plain asset
     "Bank": ACCT_TYPE_BANK,
     "Expense": ACCT_TYPE_EXPENSE,
+    "Expenses": ACCT_TYPE_EXPENSE,           # natural plural
     "Income": ACCT_TYPE_INCOME,
     "Equity": ACCT_TYPE_EQUITY,
     "Credit Card": ACCT_TYPE_CREDIT,
@@ -1141,8 +1143,10 @@ ACCT_TYPE_MAP = {
     "Mutual Fund": ACCT_TYPE_MUTUAL,
     "Accounts Payable": ACCT_TYPE_PAYABLE,
     "A/Payable": ACCT_TYPE_PAYABLE,          # GnuCash internal short form
+    "Payable": ACCT_TYPE_PAYABLE,            # natural form
     "Accounts Receivable": ACCT_TYPE_RECEIVABLE,
     "A/Receivable": ACCT_TYPE_RECEIVABLE,    # GnuCash internal short form
+    "Receivable": ACCT_TYPE_RECEIVABLE,      # natural form
     "Stock": ACCT_TYPE_STOCK,
     "Cash": ACCT_TYPE_CASH,
 }
@@ -2080,6 +2084,14 @@ class GnuCashImporter:
         account = Account(book)
         account_fullname = directive.props['account']
         account_type_str = directive.metadata['type']
+        # Resolve the type up front: an unrecognised string fails clearly here,
+        # before the account is attached to the tree, instead of leaving a
+        # half-created INVALID-typed account (which silently drops off reports).
+        if account_type_str not in ACCT_TYPE_MAP:
+            raise ValueError(
+                f"Unknown account type {account_type_str!r} for {account_fullname!r}. "
+                f"Supported types: {', '.join(sorted(ACCT_TYPE_MAP))}.")
+        account_type = ACCT_TYPE_MAP[account_type_str]
         account_names = account_fullname.split(':')
         account_name = account_names[-1]
         parent_account_names = account_names[0:-1]
@@ -2114,7 +2126,7 @@ class GnuCashImporter:
 
         parent.append_child(account)
         account.SetName(account_name)
-        account.SetType(ACCT_TYPE_MAP[account_type_str])
+        account.SetType(account_type)
         account.SetPlaceholder(placeholder)
         account.SetCode(code)
         account.SetDescription(description)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,34 @@ def _harden_pytest_capture_teardown():
         cls._gnc_hardened = True
 
 
+def _harden_pytest_logging_teardown():
+    """Same GnuCash fd-churn flake as `_harden_pytest_capture_teardown`, via a
+    different teardown path: pytest's logging plugin closes its `log_file_handler`
+    (a `logging.FileHandler`) in `pytest_unconfigure`. If GnuCash has meanwhile
+    closed that fd, `stream.close()` raises `OSError: [Errno 9] Bad file
+    descriptor` AFTER every test passed — failing the whole run on a teardown
+    artifact (seen on Ubuntu 20.04 / Py3.8). Swallow OSError from logging handler
+    close during teardown, mirroring the capture hardening. Targeted (only
+    OSError, only on close) and defensive."""
+    import logging as _logging
+
+    def _wrap(orig):
+        def _safe_close(self):
+            try:
+                return orig(self)
+            except OSError:
+                return None
+        return _safe_close
+
+    for cls in (_logging.FileHandler, _logging.StreamHandler):
+        if getattr(cls, '_gnc_close_hardened', False):
+            continue
+        cls.close = _wrap(cls.close)
+        cls._gnc_close_hardened = True
+
+
 _harden_pytest_capture_teardown()
+_harden_pytest_logging_teardown()
 
 
 def find_account(root_account, account_path):

--- a/tests/fixtures/receivable_payable_natural_form_book.txt
+++ b/tests/fixtures/receivable_payable_natural_form_book.txt
@@ -1,0 +1,45 @@
+2024-01-01 commodity CAD
+	mnemonic: "CAD"
+	fullname: "Canadian Dollar"
+	namespace: "CURRENCY"
+	fraction: 100
+2024-01-01 open Assets
+	type: "Asset"
+	placeholder: #True
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Assets:Cash
+	type: "Bank"
+	placeholder: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Assets:Trade receivable
+	type: "Receivable"
+	placeholder: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Liabilities
+	type: "Liability"
+	placeholder: #True
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Liabilities:Trade payable
+	type: "Payable"
+	placeholder: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Equity
+	type: "Equity"
+	placeholder: #True
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-01-01 open Equity:Opening balances
+	type: "Equity"
+	placeholder: #False
+	commodity.namespace: "CURRENCY"
+	commodity.mnemonic: "CAD"
+2024-02-01 * "Opening + receivable + payable"
+	Equity:Opening balances -750.00 CAD
+	Assets:Cash 600.00 CAD
+	Assets:Trade receivable 400.00 CAD
+	Liabilities:Trade payable -250.00 CAD

--- a/tests/integration/test_balance_sheet_account_types.py
+++ b/tests/integration/test_balance_sheet_account_types.py
@@ -303,3 +303,45 @@ def test_foreign_security_priced_with_incomplete_fx_is_a_clear_error(tmp_path):
     assert r.exit_code != 0
     assert 'Error:' in r.output
     assert 'USD' in r.output and 'fx-rates' in r.output
+
+
+def test_natural_form_receivable_payable_land_on_balance_sheet(tmp_path):
+    """Q-033: the natural `type: "Receivable"` / `type: "Payable"` spellings must
+    import as the RECEIVABLE / PAYABLE account *types* (matched by type, not name)
+    and appear on the balance sheet, balanced — not be silently dropped because
+    the importer only knew the longer 'Accounts Receivable' form.
+    """
+    from gnucash.gnucash_core_c import ACCT_TYPE_PAYABLE, ACCT_TYPE_RECEIVABLE
+    runner = CliRunner()
+    gf = _import(runner, tmp_path, 'receivable_payable_natural_form_book.txt')
+    as_of = date(2024, 12, 31)
+    bs = _balance_sheet(gf, as_of)
+
+    asset_paths = {line.path for line in bs.assets.lines}
+    liability_paths = {line.path for line in bs.liabilities.lines}
+
+    # Match by ACCOUNT TYPE: the receivable account really is RECEIVABLE-typed and
+    # the payable account PAYABLE-typed, and each lands in the right section.
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        sheet = BalanceSheet()
+        receivable = payable = 0
+        for a in repo.book.get_root_account().get_descendants():
+            t = a.GetType()
+            if t == ACCT_TYPE_RECEIVABLE:
+                receivable += 1
+                assert sheet._full_path(a) in asset_paths
+            elif t == ACCT_TYPE_PAYABLE:
+                payable += 1
+                assert sheet._full_path(a) in liability_paths
+        assert receivable == 1 and payable == 1   # the natural forms really mapped
+    finally:
+        repo.close()
+
+    # Cash 600 + Receivable 400 = 1000 assets; Payable 250; Equity 750 → balances.
+    assert bs.assets.currency_totals.get('CAD') == Fraction(1000)
+    assert bs.liabilities.currency_totals.get('CAD') == Fraction(250)
+    assert bs.balances is True
+    assert _account_balance(gf, 'Assets:Trade receivable', as_of) == Fraction(400)
+    assert _account_balance(gf, 'Liabilities:Trade payable', as_of) == Fraction(-250)

--- a/tests/integration/test_cli_import.py
+++ b/tests/integration/test_cli_import.py
@@ -343,10 +343,12 @@ class TestImportCLI:
             assert not os.path.exists(out_file), "output-new file should not be created when nothing is imported"
 
     def test_import_new_reports_account_creation_error(self, import_new_plaintext_invalid_account_type):
-        """--new with an unrecognised account type reports the error in the summary.
+        """--new with an unrecognised account type warns clearly in the summary.
 
-        Account creation errors are non-fatal: the file is kept and the error
-        is shown in the import summary rather than silently swallowed.
+        Account creation errors are non-fatal (the file is kept), but they must
+        NOT pass silently: the summary names the bad type and lists the supported
+        ones so the user can fix it, rather than the account landing with no type
+        and quietly dropping off reports.
         """
         runner = CliRunner()
 
@@ -361,3 +363,8 @@ class TestImportCLI:
             assert os.path.exists(new_gnucash)
             assert "Errors:" in result.output
             assert "Failed to create account" in result.output
+            # The warning must be actionable: name the offending type and point
+            # at the valid ones.
+            assert "Unknown account type" in result.output
+            assert "INVALID_ACCOUNT_TYPE" in result.output
+            assert "Supported types" in result.output

--- a/tests/unit/services/test_account_type_map.py
+++ b/tests/unit/services/test_account_type_map.py
@@ -1,0 +1,30 @@
+"""Q-033: the importer must map the account-type strings users and the docs
+actually write — including the natural ``Receivable`` / ``Payable`` forms — to
+the right GnuCash account types. If it doesn't, the account imports with no
+(INVALID) type and silently drops off the balance sheet.
+"""
+from gnucash.gnucash_core_c import (
+    ACCT_TYPE_ASSET,
+    ACCT_TYPE_EXPENSE,
+    ACCT_TYPE_PAYABLE,
+    ACCT_TYPE_RECEIVABLE,
+)
+
+from services.gnucash_importer import ACCT_TYPE_MAP
+
+
+def test_natural_receivable_payable_forms_map_to_business_types():
+    # The bare natural forms a user types (the reported bug).
+    assert ACCT_TYPE_MAP["Receivable"] == ACCT_TYPE_RECEIVABLE
+    assert ACCT_TYPE_MAP["Payable"] == ACCT_TYPE_PAYABLE
+    # The longer GnuCash forms still work.
+    assert ACCT_TYPE_MAP["Accounts Receivable"] == ACCT_TYPE_RECEIVABLE
+    assert ACCT_TYPE_MAP["A/Receivable"] == ACCT_TYPE_RECEIVABLE
+    assert ACCT_TYPE_MAP["Accounts Payable"] == ACCT_TYPE_PAYABLE
+    assert ACCT_TYPE_MAP["A/Payable"] == ACCT_TYPE_PAYABLE
+
+
+def test_readme_wording_aliases_map_correctly():
+    # Spellings the README used; the importer must accept them too.
+    assert ACCT_TYPE_MAP["Other Assets"] == ACCT_TYPE_ASSET
+    assert ACCT_TYPE_MAP["Expenses"] == ACCT_TYPE_EXPENSE


### PR DESCRIPTION
A book using the natural type strings `type: "Receivable"` / `type: "Payable"` had those accounts silently dropped from the balance sheet, leaving it NOT BALANCED. The symptom looked like the Bank-type drop fixed in Q-032 (#82), but the cause is the importer, not the balance-sheet classification (which already covers RECEIVABLE/PAYABLE).

The importer's ACCT_TYPE_MAP only knew "Accounts Receivable" / "A/Receivable" and "Accounts Payable" / "A/Payable". The bare forms hit a dict KeyError that propagated after the account was already attached to the tree, so it survived with type INVALID (-1) and its splits were dropped; the balance sheet then correctly ignored the typeless account. The docs compounded it: the README documented "Other Assets" (not a type — should be Asset) and "Expenses" (should be Expense), and the beancount-format and F-010 docs showed native-plaintext examples using the uppercase XML-enum forms "BANK" / "EXPENSE" the importer rejects.

- ACCT_TYPE_MAP now also accepts the natural "Receivable" / "Payable" and the README spellings "Other Assets" (Asset) / "Expenses" (Expense).
- create_account resolves the type before attaching the account, so an unrecognised type raises a clear, actionable error that names the bad type and lists the supported ones, instead of a cryptic KeyError that half-creates an INVALID account. The error stays non-fatal and is surfaced in the import summary (existing design), but can no longer pass silently with an account left untyped.
- Docs corrected: README's account-type list is precise; the uppercase native `type:` examples in docs/gnucash-beancount-format.md and docs/issues/F-010 are now the canonical title-case forms.

Distinct from Q-003, which added the exporter's short forms so an exported file re-imports; here the strings are the ones a human writes by hand.

Also hardens the known ubuntu20/Py3.8 pytest teardown flake against a second path: GnuCash's fd churn can leave the fd pytest's logging plugin closes in pytest_unconfigure bad, raising EBADF after every test passed. tests/conftest.py now swallows OSError from logging handler close (mirroring the existing capture-teardown hardening), verified deterministically.

Tests: test_account_type_map.py (natural and README spellings map to the right GnuCash types); a balance-sheet integration test on the reported repro asserting the accounts import as RECEIVABLE/PAYABLE matched by account type, land in the right sections, and balance (Assets 1000 = Liabilities 250 + Equity 750); the unknown-type import test now asserts the warning names the bad type and lists supported ones. Passing on GnuCash 3.8 and 5.10.