### PR TITLE
perf(Q-034): cache engine/gobject loads and transaction signatures, avoiding O(n) redundant ctypes calls on import

### DIFF
--- a/docs/issues/Q-034-uncached-ctypes-library-loads-degrade-import-performance.md
+++ b/docs/issues/Q-034-uncached-ctypes-library-loads-degrade-import-performance.md
@@ -1,0 +1,44 @@
+---
+id: Q-034
+title: Uncached ctypes library loads and account-name walks degrade import performance linearly with transaction count
+category: bug
+severity: medium
+status: open
+---
+
+## Problem
+
+`load_gnc_engine()` has no caching. Every call sets `restype`/`argtypes` on ~70 ctypes function pointers and verifies ~20 more — pure-Python work that only needs to happen once. The function is called from the hot path `_read_owner_from_transaction()` which runs for **every transaction** during signature computation in `TransactionMatcher.get_signature()`.
+
+A typical import with duplicate detection calls `load_gnc_engine()` O(n) times where n is the number of transactions. Each call repeats ~90 ctypes attribute assignments. For a book with 1000 transactions, that's ~90,000 fully redundant Python operations.
+
+Secondary: `TransactionMatcher._get_account_full_name()` walks the account parent chain for every split every time it's called, and `get_signature()` recomputes from GnuCash API calls even when the same transaction object is checked across multiple matcher calls.
+
+## Cause
+
+1. `infrastructure/gnucash/engine.py:load_gnc_engine()` — no caching. Every call runs `_setup_lib_restypes()` + `verify_ctypes_functions()` which together configure and validate ~90 function pointers. The dlopen promotion is a fast no-op for already-loaded libs; the real cost is those ~90 Python attribute assignments repeated per call.
+
+2. `services/transaction_matcher.py:_get_account_full_name()` — no caching. Walks `get_parent()` chain for every account every time it appears in a split.
+
+3. `services/transaction_matcher.py:get_signature()` — no caching. The same transaction's signature is recomputed from scratch each time it passes through `find_duplicates`, `has_duplicate_signature`, or `get_duplicate_count`.
+
+Note: `kvp.py:_load_gnc_engine()` is uncached too, but its per-call cost is negligible — it only does two dlopen calls (cheap refcount bumps) without any type-setup or verification overhead.
+
+## Fix
+
+1. **`engine.py`**: `@functools.lru_cache(maxsize=1)` on `load_gnc_engine()`. The function is pure — always returns the same CDLL handle.
+
+2. **`kvp.py`**: `@functools.lru_cache(maxsize=1)` on `_load_gobject()`. The existing module-level `_gobj` guard already caches, but `lru_cache` is a belt-and-suspenders hardening in case the global is reset.
+
+3. **`transaction_matcher.py`**:
+   - `self._account_name_cache` dict checked in `_get_account_full_name()` before walking the parent chain.
+   - `transaction._cached_signature` attribute to avoid recomputing the same transaction's signature across multiple matcher calls.
+
+## Related
+
+- **Q-016** — full GUID emission (the GUID used as alternative cache key was added there)
+- **Q-020** — num-only roundtrip and import dedup signature (the signature format this optimizes)
+
+---
+
+**Created**: 2026-07-01

--- a/infrastructure/gnucash/engine.py
+++ b/infrastructure/gnucash/engine.py
@@ -32,6 +32,7 @@ give wrong results on any 64-bit platform if the pointer happens to be >4 GB).
 """
 import ctypes
 import logging
+from functools import lru_cache
 
 _ENGINE_LIB_PATHS = [
     '/usr/lib/x86_64-linux-gnu/gnucash/libgnc-engine.so',            # Debian 11/12/13, Ubuntu 22/24
@@ -202,6 +203,7 @@ def _setup_lib_restypes(lib: ctypes.CDLL) -> None:
     lib.gncEntryGetBillTaxTable.argtypes       = [ctypes.c_void_p]
 
 
+@lru_cache(maxsize=1)
 def load_gnc_engine() -> ctypes.CDLL:
     """Load libgnc-engine and return a correctly configured ctypes handle.
 

--- a/infrastructure/gnucash/kvp.py
+++ b/infrastructure/gnucash/kvp.py
@@ -23,6 +23,7 @@ import contextlib
 import ctypes
 import json
 import logging
+from functools import lru_cache
 from typing import Optional
 
 PT_DATA_SLOT = 'plaintext_metadata'
@@ -148,7 +149,7 @@ _G_TYPE_STRING = 64  # G_TYPE_STRING on all platforms (GLib constant)
 
 _gobj: Optional[ctypes.CDLL] = None
 
-
+@lru_cache(maxsize=1)
 def _load_gobject() -> Optional[ctypes.CDLL]:
     """Load libgobject-2.0 (needed for GValue init/set/get on GnuCash 3.8)."""
     global _gobj

--- a/services/transaction_matcher.py
+++ b/services/transaction_matcher.py
@@ -118,6 +118,7 @@ class TransactionMatcher:
 
     def __init__(self):
         """Initialize transaction matcher."""
+        self._account_name_cache = {}
         pass
 
     def find_duplicates(
@@ -181,6 +182,9 @@ class TransactionMatcher:
         Returns:
             5-tuple `(date_string, tuple_of_sorted_account_names, doc_link, tx_num, owner)`
         """
+        if hasattr(transaction, '_cached_signature'):
+            return transaction._cached_signature
+
         date_str = transaction.GetDate().strftime("%Y-%m-%d")
 
         splits = transaction.GetSplitList()
@@ -195,13 +199,16 @@ class TransactionMatcher:
         tx_num = transaction.GetNum()
         owner = _read_owner_from_transaction(transaction)
 
-        return (
+        sig = (
             date_str,
             tuple(sorted(account_names)),
             _normalise(doc_link),
             _normalise(tx_num),
             _normalise(owner),
         )
+
+        transaction._cached_signature = sig
+        return sig
 
     def get_signature_for_plaintext(
         self,
@@ -255,6 +262,9 @@ class TransactionMatcher:
 
     def _get_account_full_name(self, account) -> str:
         """Get full hierarchical name of account (e.g. `"Assets:Bank:Checking"`)."""
+        if account in self._account_name_cache:
+            return self._account_name_cache[account]
+
         names = []
         current = account
         while current is not None:
@@ -262,7 +272,10 @@ class TransactionMatcher:
             if account_name and account_name != "Root Account":
                 names.insert(0, account_name)
             current = current.get_parent()
-        return ":".join(names)
+        full_name = ":".join(names)
+
+        self._account_name_cache[account] = full_name
+        return full_name
 
     def _amounts_match(self, tx1, tx2) -> bool:
         """

--- a/tests/unit/infrastructure/gnucash/test_engine.py
+++ b/tests/unit/infrastructure/gnucash/test_engine.py
@@ -139,6 +139,29 @@ class TestIterateGlist:
 # ---------------------------------------------------------------------------
 
 class TestLoadGncEngineFallback:
+    def setup_method(self):
+        """Clear the lru_cache so each fallback test exercises the first-call path.
+
+        With @lru_cache(maxsize=1) the function body only executes once per
+        process.  Integration tests that open a real book call load_gnc_engine()
+        and fill the cache with the real CDLL handle, so by the time these unit
+        tests run the cached result would bypass the mocked fallback logic
+        entirely.  Clearing the cache lets the test exercise the fallback path
+        in isolation while the production code still benefits from caching.
+        """
+        load_gnc_engine.cache_clear()
+
+    def teardown_method(self):
+        """Clear the lru_cache so mocked results don't leak into other tests.
+
+        Tests in this class patch ctypes.CDLL and call load_gnc_engine(),
+        filling the cache with MagicMock handles.  Without clearing, any
+        subsequent test that calls load_gnc_engine() — directly or transitively
+        via _iter_taxtables, _find_taxtable_by_guid, etc. — gets the cached
+        MagicMock and fails with opaque ctypes errors.
+        """
+        load_gnc_engine.cache_clear()
+
     def test_runtime_error_from_verify_does_not_break_fallback_chain(self):
         """Bug #2: RuntimeError was not in the except clause.
 
@@ -175,6 +198,21 @@ class TestLoadGncEngineFallback:
                 patch("ctypes.CDLL", side_effect=OSError("not found")), \
                 pytest.raises(RuntimeError, match="Could not load"):
             load_gnc_engine()
+
+    def test_result_is_cached_on_subsequent_calls(self):
+        """@lru_cache(maxsize=1): the return value is cached; body runs once."""
+        # Fill the cache with a mock-backed call first
+        mock_lib = MagicMock()
+        with patch("infrastructure.gnucash.engine._setup_lib_restypes"), \
+                patch("ctypes.CDLL", return_value=mock_lib):
+            first = load_gnc_engine()
+
+        # Second call with different (broken) mocks — returns cached result
+        with patch("ctypes.CDLL", side_effect=OSError("should not be called")):
+            second = load_gnc_engine()
+
+        assert first is second
+        assert first is mock_lib
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`load_gnc_engine()` has no caching. Every call redoes ~90 ctypes attribute assignments (`restype`/`argtypes` set on ~70 function pointers, ~20 verified) — pure-Python work that only needs to happen once. The function is on the hot path: `_read_owner_from_transaction()` calls it for every transaction during duplicate-detection signature computation, so an import of a book with 1000 transactions repeats ~90,000 fully redundant Python operations.

Secondary hot spots: `_get_account_full_name()` walks the account parent chain for every split on every signature, and `get_signature()` recomputes from GnuCash API calls even when the same transaction object passes through multiple matcher invocations (find_duplicates → has_duplicate_signature → get_duplicate_count).

- `load_gnc_engine()`: `@functools.lru_cache(maxsize=1)`. The function is pure — always returns the same CDLL handle. The dlopen promotion is a fast no-op for already-loaded libs; the real cost was the ~90 Python attribute assignments repeated per call.
- `_load_gobject()`: `@functools.lru_cache(maxsize=1)`. The existing module-level `_gobj` guard already cached, but lru_cache is belt-and-suspenders hardening in case the global is reset.
- `TransactionMatcher.get_signature()`: caches the 5-tuple on `transaction._cached_signature` so repeated checks against the same transaction object skip the GnuCash API calls.
- `_get_account_full_name()`: `self._account_name_cache` dict keyed by account object avoids re-walking the `get_parent()` chain.

The `@lru_cache` on `load_gnc_engine()` introduces a test-isolation requirement: `TestLoadGncEngineFallback` patches `ctypes.CDLL` and fills the cache with MagicMock handles. Without a teardown clear, any subsequent test that calls `load_gnc_engine()` transitively (e.g. via `_iter_taxtables` → `_find_taxtables_by_name`) gets the cached mock and fails with opaque `MagicMock.__format__` errors. `teardown_method` now clears the cache after each test in that class so mocked results do not leak into other test modules.

Tests: `test_result_is_cached_on_subsequent_calls` asserts the cache returns the same CDLL handle across calls; 1164 pass (including the three that previously failed from cache pollution).