### PR TITLE
perf: parallel pytest with xdist, drop broken Pylance extension

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -28,7 +28,6 @@ RUN groupadd -g 999 docker || true && \
 
 # Install VS Code extensions for better development experience
 RUN code-server --install-extension ms-python.python && \
-    code-server --install-extension ms-python.vscode-pylance && \
     code-server --install-extension charliermarsh.ruff && \
     code-server --install-extension ms-azuretools.vscode-docker && \
     code-server --install-extension yzhang.markdown-all-in-one && \

--- a/scripts/test-in-docker.sh
+++ b/scripts/test-in-docker.sh
@@ -19,9 +19,9 @@ export HOME="${HOME:-/tmp/home}"
 mkdir -p "$HOME/.local"
 
 echo "Installing package..."
-python3 -m pip install -e . weasyprint --break-system-packages --user -q
+python3 -m pip install -e . weasyprint pytest-xdist --break-system-packages --user -q
 
 echo ""
 echo "Running tests: $TEST_PATH"
 echo "================================"
-PATH="$HOME/.local/bin:$PATH" python3 -m pytest "$TEST_PATH" -v --tb=short
+PATH="$HOME/.local/bin:$PATH" python3 -m pytest "$TEST_PATH" -n auto -v --tb=short


### PR DESCRIPTION
  - Add pytest-xdist to the test container and run pytest with -n auto to execute tests in parallel across all available CPU cores. The test suite is CPU-bound (real GnuCash objects) and has no shared mutable state between test modules, so parallelism yields near-linear speedup.
  - Remove the ms-python.vscode-pylance extension from Dockerfile.dev: its installation has been failing recently and the language server is unnecessary for test runs — it only adds build time and background resource consumption without benefiting the test workflow.