### PR TITLE
fix: revert pytest-xdist parallel CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
             gnucash-dev:${{ matrix.tag }} \
             sh -c "cd /workspace && \
               python3 -m pip install -e '.[dev]' -q --break-system-packages && \
-              pytest tests/ -n auto --dist=loadfile -v --tb=short"
+              pytest tests/ -v --tb=short"
         # Note: --break-system-packages is safe in Docker containers (isolated environment)
 
       - name: Run deployment test
@@ -96,7 +96,7 @@ jobs:
             gnucash-dev:latest \
             sh -c "cd /workspace && \
               python3 -m pip install -e '.[dev]' -q --break-system-packages && \
-              pytest tests/ -n auto --dist=loadfile --cov=. --cov-report=xml --cov-report=term"
+              pytest tests/ --cov=. --cov-report=xml --cov-report=term"
         # Note: --break-system-packages is safe in Docker (isolated environment)
 
       - name: Upload coverage to Codecov

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ WORKDIR /workspace
 # Install dev dependencies at build time
 # The package itself will be installed at runtime when workspace is mounted
 # Try with --break-system-packages first (Debian 12+, Ubuntu 22+), fall back to upgrade pip (Ubuntu 20)
-RUN python3 -m pip install pytest pytest-cov pytest-xdist weasyprint --break-system-packages 2>/dev/null || \
+RUN python3 -m pip install pytest pytest-cov weasyprint --break-system-packages 2>/dev/null || \
     (python3 -m pip install --upgrade pip && \
-     python3 -m pip install pytest pytest-cov pytest-xdist weasyprint --break-system-packages)
+     python3 -m pip install pytest pytest-cov weasyprint --break-system-packages)
 
 CMD ["bash"]

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -28,7 +28,7 @@ RUN pacman -Syu --noconfirm \
 
 WORKDIR /workspace
 
-RUN python3 -m pip install pytest pytest-cov pytest-xdist weasyprint --break-system-packages 2>/dev/null || \
-    python3 -m pip install pytest pytest-cov pytest-xdist weasyprint
+RUN python3 -m pip install pytest pytest-cov weasyprint --break-system-packages 2>/dev/null || \
+    python3 -m pip install pytest pytest-cov weasyprint
 
 CMD ["bash"]

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -27,8 +27,8 @@ RUN dnf install -y \
 
 WORKDIR /workspace
 
-RUN python3 -m pip install pytest pytest-cov pytest-xdist weasyprint --break-system-packages 2>/dev/null || \
+RUN python3 -m pip install pytest pytest-cov weasyprint --break-system-packages 2>/dev/null || \
     (python3 -m pip install --upgrade pip && \
-     python3 -m pip install pytest pytest-cov pytest-xdist weasyprint --break-system-packages)
+     python3 -m pip install pytest pytest-cov weasyprint --break-system-packages)
 
 CMD ["bash"]

--- a/Dockerfile.opensuse
+++ b/Dockerfile.opensuse
@@ -31,8 +31,8 @@ RUN zypper install -y \
 
 WORKDIR /workspace
 
-RUN python3 -m pip install pytest pytest-cov pytest-xdist weasyprint --break-system-packages 2>/dev/null || \
+RUN python3 -m pip install pytest pytest-cov weasyprint --break-system-packages 2>/dev/null || \
     (python3 -m pip install --upgrade pip && \
-     python3 -m pip install pytest pytest-cov pytest-xdist weasyprint --break-system-packages)
+     python3 -m pip install pytest pytest-cov weasyprint --break-system-packages)
 
 CMD ["bash"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ invoice = [
 dev = [
     "pytest>=7.0",
     "pytest-cov>=3.0",
-    "pytest-xdist>=3.0",
     "ruff>=0.1.0",  # Linter + formatter (replaces flake8, black, isort)
 ]
 


### PR DESCRIPTION
Revert the pytest-xdist and -n auto changes from the prior parallel-test PR: sleep removal alone provides a larger speedup without the platform-compatibility issues xdist hit on Python 3.8/3.9.

- Remove -n auto --dist=loadfile from CI workflow test commands
- Remove pytest-xdist from all Dockerfile pip install lines
- Remove pytest-xdist from pyproject.toml dev dependencies