### PR TITLE
Persist bill entry tax flags; cover tax-inclusive pricing + payments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,16 +327,34 @@ posting), so GnuCash puts it in a **new lot** instead of the bill's lot.
 `inv.GetPostedLot().get_split_list()` then returns only 1 split (the posting)
 and the exporter emits `payment: none` for a paid bill.
 
-### 8. GnuCash does not persist `bill_taxable = false` to XML
+### 8. Vendor-bill entries must be attached with `gncBillAddEntry`, not `Invoice.AddEntry`
 
-GnuCash 5.x only writes `entry:b-taxable` to the XML file when the value is
-`true`. When `false`, the field is omitted and defaults to `true` on reload.
-Consequently, all bill entries always read as `taxable = true` after a
-save/reload cycle, regardless of what `SetBillTaxable(False)` was called with.
+A `GncEntry` carries two owner-side field groups — customer-invoice (`i-*`) and
+vendor-bill (`b-*`) — and two owner pointers. `gncInvoiceAddEntry` (SWIG
+`Invoice.AddEntry`) sets the entry's **invoice** pointer; `gncBillAddEntry` sets
+its **bill** pointer. GnuCash's entry XML writer serialises the bill-side tax
+flags only inside `if (gncEntryGetBill(entry))`:
 
-**Impact on round-trip tests**: the reference fixture must use `taxable: true`
-for all bill entries. Do NOT compare against `taxable: false` in bill export.
+- attached via `Invoice.AddEntry` → the file gets `<entry:invoice>` plus
+  `i-taxable` / `i-taxincluded`, and **omits** `entry:b-taxable` /
+  `entry:b-taxincluded`. On reload those default (`b-taxable`→true,
+  `b-taxincluded`→false), so `taxable: false` silently flips to `true` and
+  `tax_included: true` is lost (the price is then treated as tax-exclusive and
+  the bill is over-taxed).
+- attached via `gncBillAddEntry` → the file gets `<entry:bill>` plus
+  `b-taxable` / `b-taxincluded`, and both round-trip exactly as authored.
+
+The importer attaches bill entries with `_bill_add_entry` (`gncBillAddEntry`);
+posting is unaffected because both APIs append to the same `invoice->entries`
+GList. This is symmetric to `_bill_remove_all_entries` (`gncBillRemoveEntry`),
+since `Invoice.RemoveEntry` is likewise customer-invoice-only.
+
+**Impact on round-trip tests**: bill export now reflects the source `taxable:` /
+`tax_included:` values verbatim — reference fixtures use whatever the source
+declares (e.g. `taxable: false` stays `false`). This supersedes the earlier
+belief that GnuCash could not persist `bill_taxable = false`; the real cause was
+attaching bill entries on the customer-invoice side.
 
 ---
 
-**Last Updated**: 2026-05-20
+**Last Updated**: 2026-07-11

--- a/README.md
+++ b/README.md
@@ -1046,6 +1046,33 @@ invoice "INV-2026-004"
     memo: "Second instalment"
 ```
 
+A **vendor bill** takes multiple `payment:` blocks the same way, on Accounts Payable with the signs flipped. A $100 bill paid in two instalments of $40 and $35 leaves one open AP lot for the $25 still owed:
+
+```
+bill "BILL-PARTIAL-100"
+  ...
+  posted:
+    date: 2026-02-01
+    due: 2026-03-03
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Bill BILL-PARTIAL-100"
+    accumulate: true
+  payment:
+    date: 2026-02-10
+    amount: 40
+    bank_account: "Assets:Bank"
+    memo: "First instalment"
+  payment:
+    date: 2026-02-20
+    amount: 35
+    bank_account: "Assets:Bank"
+    memo: "Second instalment"
+```
+
+That bill's AP lot holds the posting (−$100) plus both payments (+$40, +$35) and stays open at a **−$25** balance — a still-owed liability. It is the sign-inverse of a partly-paid *invoice*, whose AR lot stays open at a **positive** balance (the receivable you're still owed). Each `amount:` in a bill's `payment:` block is written positive in plaintext; the importer records it as money leaving the bank (a debit to AP, a credit to Bank), the opposite direction to an invoice payment.
+
+To find which bills are still outstanding, render a whole vendor at once with `print-bill <book> --vendor V001 --format plaintext -o -` and compare each bill's `bill_total:` to the sum of its `payment:` `amount:` lines — a shortfall is unpaid (its posted AP lot stays open at a negative balance). Overpayment credit is separate: it lives in its own AP lot attached to no bill, so surface it with `find-prepayments --vendor V001` (below), which totals a vendor's credit even when it accumulated across several bills. See **[docs/bill-payment-reconciliation.md § Detecting a vendor's bill payment state](docs/bill-payment-reconciliation.md#detecting-a-vendors-bill-payment-state-paid--partial--overpaid)** for the worked paid / partial / overpaid example.
+
 **Adding a payment via re-import is incremental.** If a posted invoice is already in the book with one `payment:` block, editing the plaintext to append a second `payment:` block and re-importing applies *only* the new payment on the still-posted invoice. Two sub-paths, both incremental:
 
 * The new payment block has no `txn_guid:` — the importer calls `ApplyPayment` to create a fresh bank-side transaction.
@@ -1088,7 +1115,33 @@ After the payment, `Assets:Accounts Receivable` shows a net **-$50** for this cu
 
 For the `txn_guid:` retarget path (Q-004), when the pre-existing bank transaction's counter-split is larger than the invoice's remaining balance, the `prepayment:` field is **required**. The importer splits the counter-split into the invoice-portion (closes the lot) and the residual (new pre-payment lot on AR/AP). Omitting `prepayment:` on an over-sized retarget is rejected with an explicit error that names the bank tx, the counter-split amount, the invoice's remaining, and the expected `prepayment` value.
 
-The same applies symmetrically to bills (AP, opposite signs): overpaying a $100 bill by $50 produces an open AP lot with **+$50** balance — a vendor credit you can apply against the next bill from the same supplier.
+**Vendor bills are the mirror image (Accounts Payable, opposite signs).** A bill posts as a *credit* to AP — a liability going up — which is the sign-inverse of an invoice's *debit* to AR (an asset going up), so every split below flips sign relative to the invoice case. Overpaying a $100 bill by $50 (one $150 payment *out* of the bank) creates one payment transaction with three splits across two accounts and two AP lots:
+
+```
+Transaction 2026-01-10 — payment on BILL-OVERPAY-100
+  Assets:Bank                    -$150.00   (the cash you sent the vendor)
+  Liabilities:Accounts Payable   +$100.00   (in bill lot — closes BILL-OVERPAY-100 at $0)
+  Liabilities:Accounts Payable    +$50.00   (in NEW pre-payment lot — vendor credit)
+```
+
+The bill lot nets to zero (posting −$100 + payment +$100) and the $50 residual opens a second AP lot whose balance is **+$50** — a positive (debit) balance on a liability, i.e. a *vendor credit*: the supplier now owes you $50 toward a future bill. That is the exact inverse of a customer overpayment, where the residual AR lot carries **−$50** (money you owe the customer). The exported bill records the two allocations separately — `amount:` is the $100 that settled the bill lot and `prepayment:` is the $50 residual, and the two together account for the full $150 that left the bank:
+
+```
+bill "BILL-OVERPAY-100"
+  ...
+  posted:
+    ap_account: "Liabilities:Accounts Payable"
+    memo: "Bill BILL-OVERPAY-100"
+    accumulate: true
+  payment:
+    date: 2026-01-10
+    amount: 100
+    bank_account: "Assets:Bank"
+    memo: "Paid 150 on a 100 bill (overpaid 50)"
+    prepayment: 50
+```
+
+Consume the credit on the next bill from `V001` with `auto_apply_credit: true` (below), or list it with `find-prepayments --vendor V001`.
 
 #### Bad debt: writing off an uncollectable invoice via `payment:` to an expense
 
@@ -1157,6 +1210,8 @@ invoice "INV-2026-006"
 ```
 
 On import the invoice is posted normally, then `gncInvoiceAutoApplyPayments` runs and takes from the open prepay lot(s) toward the invoice's outstanding balance. If credit ≥ invoice the lot closes via consumption; the residual stays open as a smaller credit (split in-place by GnuCash). If credit < invoice the full credit consumes; the invoice stays partially open. The flag composes with cash `payment:` blocks — cash goes first, credit auto-applies for any remainder. The exporter detects the post-auto-apply book state and emits `auto_apply_credit: true` again on round-trip; identical re-import is a no-op.
+
+A credit larger than one document is drawn down across several: mark each invoice/bill `auto_apply_credit: true` and GnuCash consumes the credit in **posting order** until it runs out. A $150 credit against two $100 documents settles the first in full and leaves the second **$50 outstanding** (its lot open at +$50 for an invoice, −$50 for a bill), with the credit at $0. Because cash applies before credit on each document, that second document can also carry a `payment: amount: 50` — the $50 cash plus the $50 of remaining credit close it. This works identically on the receivable (invoice) and payable (bill) sides, sign-flipped.
 
 #### Listing open credits: `find-prepayments`
 
@@ -1511,7 +1566,7 @@ accounts → customers/vendors/taxtables → standalone transactions → invoice
 
 Standalone transactions are created (with their declared `guid:` on both the transaction and each split) **before** any invoice or bill is processed, so the `payment:` blocks' `txn_guid:`/`txn_split_guid:` references always resolve in the same import call — no two-step import needed, even for a fresh book.
 
-See **[docs/comprehensive-roundtrip-example.md](docs/comprehensive-roundtrip-example.md)** for the canonical end-to-end roundtrip walkthrough — a single source book exercising every plaintext surface (accounts, customers, vendors, tax tables, invoices and bills, all payment shapes: cash, retarget, overpayment with prepayment credit, credit consumption via `auto_apply_credit`, and the multi-invoice-one-bank-tx shape) exported and re-imported into a fresh book with semantic identity preserved down to per-split GUIDs. And **[docs/invoice-payment-reconciliation.md](docs/invoice-payment-reconciliation.md)** for the bank-feed-first workflow, bill examples, error reference, and the invoice-first alternative.
+See **[docs/comprehensive-roundtrip-example.md](docs/comprehensive-roundtrip-example.md)** for the canonical end-to-end roundtrip walkthrough — a single source book exercising every plaintext surface (accounts, customers, vendors, tax tables, invoices and bills, all payment shapes: cash, retarget, overpayment with prepayment credit, credit consumption via `auto_apply_credit`, and the multi-invoice-one-bank-tx shape) exported and re-imported into a fresh book with semantic identity preserved down to per-split GUIDs. And **[docs/invoice-payment-reconciliation.md](docs/invoice-payment-reconciliation.md)** for the bank-feed-first workflow, error reference, and the invoice-first alternative, plus **[docs/bill-payment-reconciliation.md](docs/bill-payment-reconciliation.md)** for the vendor-bill (Accounts Payable) side — partial payments, vendor credits, detection, and `unapply-payment` corrections.
 
 #### Cash-basis sales (Q-018)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -98,7 +98,8 @@ Coverage expanded across services and use cases:
 ### Documentation
 
 - [docs/bank-import-workflow.md](docs/bank-import-workflow.md) — end-to-end walk-through of the statement reconciliation pipeline.
-- [docs/invoice-payment-reconciliation.md](docs/invoice-payment-reconciliation.md) — payment lifecycle, incremental edits, orphan recovery, prepayment consumption.
+- [docs/invoice-payment-reconciliation.md](docs/invoice-payment-reconciliation.md) — invoice (Accounts Receivable) payment lifecycle, incremental edits, orphan recovery, prepayment consumption.
+- [docs/bill-payment-reconciliation.md](docs/bill-payment-reconciliation.md) — vendor-bill (Accounts Payable) payments: partial payments, vendor credits, detecting paid/partial/overpaid state, and `unapply-payment` corrections.
 - [docs/payment-manual-edit-behavior.md](docs/payment-manual-edit-behavior.md) — reference for what the importer does to a payment block under each kind of diff (entry change vs. payment-only change).
 - [docs/research/2026-05-14-invoice-post-pay-unpost-cycle.md](docs/research/2026-05-14-invoice-post-pay-unpost-cycle.md) and [docs/post-mortems/2026-05-08-bill-postto-account-segfault.md](docs/post-mortems/2026-05-08-bill-postto-account-segfault.md) — research and post-mortem notes from this cycle.
 

--- a/docs/bill-payment-reconciliation.md
+++ b/docs/bill-payment-reconciliation.md
@@ -1,0 +1,268 @@
+# Bill Payment Reconciliation (Vendor Bills)
+
+Covers linking bank transactions to vendor-bill payments on the **Accounts Payable** side — partial payments, overpayment (vendor credit), how to detect each state, and how to correct a mis-applied payment with `unapply-payment`.
+
+This is the payable-side companion to [docs/invoice-payment-reconciliation.md](invoice-payment-reconciliation.md) (the receivable/invoice side). The two share the same plaintext shape (`payment:` blocks, `txn_guid:` / `txn_split_guid:`, the bank-feed-first workflow) — read that doc for the shared mechanics and the GUID / error / idempotency reference; this doc covers only what is different about bills. For the canonical end-to-end roundtrip across both sides, see [docs/comprehensive-roundtrip-example.md](comprehensive-roundtrip-example.md).
+
+This document describes:
+
+- [Background: bills mirror invoices on the payable side](#background-bills-mirror-invoices-on-the-payable-side)
+- [Bill partial payments](#bill-partial-payments)
+- [Bill overpayment (vendor credit)](#bill-overpayment-vendor-credit)
+- [Detecting a vendor's bill payment state (paid / partial / overpaid)](#detecting-a-vendors-bill-payment-state-paid--partial--overpaid)
+- [Correcting a mis-applied bill payment: fresh + linked, then unapply / re-link](#correcting-a-mis-applied-bill-payment-fresh--linked-then-unapply--re-link)
+- [Managing a vendor credit: consume, refund, or write off](#managing-a-vendor-credit-consume-refund-or-write-off)
+
+---
+
+## Background: bills mirror invoices on the payable side
+
+A bill's `payment:` block has the same *shape* as an invoice's — provide `bank_account` and `txn_guid` — but the accounting is the mirror image, not a copy. A bill posts as a **credit to Accounts Payable** (a liability going up) where an invoice posts a **debit to Accounts Receivable** (an asset going up); a bill payment sends money **out** (debit AP, credit Bank) where an invoice payment brings money **in**. Every sign in the bill examples below is flipped from the AR case. The plaintext still carries positive `amount:` values — the importer records the outgoing direction for bills internally.
+
+Just like an invoice, a bill payment can **link an existing bank transaction** (e.g. one already loaded from a bank feed) instead of minting a new one: give the `payment:` block a `txn_guid:` (and optionally `txn_split_guid:`) naming that bank tx, and the importer retargets its AP-side split into the bill's posted lot rather than creating a duplicate:
+
+```
+vendor "VEND-001"
+	guid: "f66df24e6e75424ba08c2b0a47ec292c"
+	name: "Office Supplies Co."
+	currency: CAD
+
+bill "BILL-2026-001"
+	vendor_id: "VEND-001"
+	vendor_guid: "f66df24e6e75424ba08c2b0a47ec292c"
+	currency: CAD
+	date_opened: 2026-01-01
+	entry:
+		...
+	posted:
+		date: 2026-01-01
+		due: 2026-01-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-2026-001"
+		accumulate: true
+	payment:
+		bank_account: "Assets:Bank"
+		txn_guid: "abc123def456abc123def456abc123de"
+		txn_split_guid: "11223344556677889900aabbccddeeff"
+```
+
+Use `find-transactions` with a negative amount to find outgoing payments:
+
+```bash
+gnucash-plaintext find-transactions ledger.gnucash \
+    --account "Assets:Bank" \
+    --date 2026-01-25 \
+    --amount 200
+```
+
+## Bill partial payments
+
+A bill can carry several `payment:` blocks, one per instalment. A $100 bill paid $40 then $35 keeps a single open AP lot for the $25 still outstanding. Observed directly from the posted book — the posting transaction, then the lot's split list:
+
+```
+posting   Expenses:Supplies              +$100.00   (debit expense)
+posting   Liabilities:Accounts Payable   -$100.00   (credit AP — the liability you owe)
+
+AP lot (open, balance -$25.00):
+  -$100.00  posting   2026-02-01  "Bill BILL-PARTIAL-100"
+   +$40.00  payment   2026-02-10  "First instalment"
+   +$35.00  payment   2026-02-20  "Second instalment"
+```
+
+The lot balance is **negative** (−$25) because it is an unpaid liability you still owe. The equivalent partly-paid *invoice* keeps its AR lot open at a **positive** balance (a receivable still owed to you) — same story, opposite sign. Exported, the bill carries one `payment:` block per instalment (positive `amount:` each):
+
+```
+bill "BILL-PARTIAL-100"
+	...
+	posted:
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-PARTIAL-100"
+		accumulate: true
+	payment:
+		date: 2026-02-10
+		amount: 40.00
+		bank_account: "Assets:Bank"
+		txn_guid: "792d3b1ba2bb40009129fd3ee9a70271"
+		txn_split_guid: "5062327a7da743138c3011bd23a2046d"
+		memo: "First instalment"
+	payment:
+		date: 2026-02-20
+		amount: 35.00
+		bank_account: "Assets:Bank"
+		txn_guid: "563f541d5a60474885e0459d1fb174cb"
+		txn_split_guid: "1f33738186034c9aa0c262654c0d520a"
+		memo: "Second instalment"
+```
+
+Tax does not change the mechanics — it only raises the payable total. A taxed bill of net $1000 + GST 5% + PST 7% = **$1120** paid $60 stays open at **−$1052** (its posting is −$1120, the payment +$60); a shortfall is always measured against the tax-inclusive total.
+
+## Bill overpayment (vendor credit)
+
+Paying more than the bill total leaves an open AP credit lot — the vendor now owes you. A $100 bill paid $150 in one payment splits the AP side across the bill lot and a new pre-payment lot. Observed from the posted book:
+
+```
+payment tx 2026-01-10:
+  Assets:Bank                    -$150.00   (cash sent to the vendor — money out)
+  Liabilities:Accounts Payable   +$100.00   (bill lot — closes it at $0)
+  Liabilities:Accounts Payable    +$50.00   (new pre-payment lot)
+
+AP lot (closed, balance +$0.00):  posting -$100.00, payment +$100.00
+AP lot (open,   balance +$50.00): payment +$50.00
+```
+
+The residual lot's **+$50** balance is a *vendor credit* — a positive (debit) balance on a liability account means the supplier owes you $50 toward a future bill. This is the sign-inverse of a *customer* overpayment, whose residual AR lot carries **−$50** (money you owe the customer). Export records the split allocation: `amount:` is the $100 that settled the bill lot and `prepayment:` is the $50 residual (together the full $150 that left the bank):
+
+```
+bill "BILL-OVERPAY-100"
+	...
+	posted:
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-OVERPAY-100"
+		accumulate: true
+	payment:
+		date: 2026-01-10
+		amount: 100.00
+		bank_account: "Assets:Bank"
+		txn_guid: "56d18d5680b04ce2889911901d6be753"
+		txn_split_guid: "527be23007ac44daac35cf9cc177ae9d"
+		memo: "Paid 150 on a 100 bill (overpaid 50)"
+		prepayment: 50.00
+```
+
+For a taxed bill the residual is measured against the tax-inclusive total the same way: net $100 + 12% = $112 paid $150 leaves a **+$38** vendor credit and exports `prepayment: 38.00`.
+
+Apply the credit to the next bill from the same vendor with `auto_apply_credit: true`, or list open vendor credits with `find-prepayments --vendor V001`.
+
+A credit bigger than one bill is drawn down across several. Mark each bill `auto_apply_credit: true` and GnuCash consumes the credit in **posting order** (the order the bills appear on import) until it runs out. A $150 credit against two $100 bills settles the first in full and leaves the second **$50 outstanding** (its AP lot open at −$50), with the credit exhausted:
+
+```
+credit before: 150.00
+BILL-MB-1 ($100, auto_apply_credit)  → lot 0.00     (settled from credit)
+BILL-MB-2 ($100, auto_apply_credit)  → lot -50.00   (took the last 50; 50 still owed)
+credit after: 0.00
+```
+
+The flag also composes with a cash `payment:` block on the same bill: the cash applies **first** and the credit covers the remainder. So if that second bill also carries a `payment: amount: 50`, the $50 cash plus the $50 of remaining credit settle it — both bills close and the credit reaches $0.
+
+One further asymmetry with invoices: a bill payment's transfer account must be an asset or owner's-equity account — routing it to an expense or income is rejected (`bill payment must use an asset ...`). Writing an unpaid bill off is debt forgiveness (a gain), not bad debt; the bad-debt write-off to an expense exists only for invoices, i.e. money owed *to* you.
+
+## Detecting a vendor's bill payment state (paid / partial / overpaid)
+
+There is no single "list outstanding bills" command; you read each state off the tools below. The examples here use one vendor `V001` with three bills — `BILL-PAID-100` paid in full, `BILL-PART-100` paid $60 of $100, and `BILL-OVER-100` paid $150 on $100.
+
+**Partial / outstanding bills — `print-bill --vendor`.** `print-bill` selects every bill for a vendor (also `--from` / `--to` / an id glob). Compare each `bill_total:` against the sum of its `payment:` `amount:` lines; any shortfall is still owed:
+
+```
+$ print-bill book.gnucash --vendor V001 --format plaintext -o -
+
+bill "BILL-PAID-100"
+	...
+	payment:
+		amount: 100.00
+	bill_total: 100.00        → paid 100 of 100: settled
+bill "BILL-PART-100"
+	...
+	payment:
+		amount: 60.00
+	bill_total: 100.00        → paid 60 of 100: $40 OUTSTANDING
+bill "BILL-OVER-100"
+	...
+	payment:
+		amount: 100.00
+	bill_total: 100.00        → bill lot settled; the extra $50 is a separate vendor credit
+```
+
+The exact outstanding figure is the bill's posted AP-lot balance: `0.00` when settled and **negative** while still owed. For the three bills above the balances are `+0.00`, `−40.00`, and `+0.00` respectively (`gncInvoiceIsPaid` is `True`, `False`, `True`) — the overpaid bill's own lot closes at zero, and its $50 excess lives in a *separate* credit lot, which is why an overpayment never masks the settled bill.
+
+**Overpayment / vendor credits — `find-prepayments --vendor`.** A vendor credit is an open AP lot attached to no bill, so scanning bills won't reveal it. `find-prepayments` surfaces every credit and totals it per vendor — this is also how you find credit that accumulated across *several* bills for the same supplier:
+
+```
+$ find-prepayments book.gnucash --vendor V001
+
+Found 1 open pre-payment credit.
+
+  • vendor V001 (Supplier Co.)  CAD 50.00  in Liabilities:Accounts Payable
+    source bank tx: 2026-03-07 on Assets:Bank  "Supplier Co."
+      memo: "Overpaid by 50"
+      guid: ff7dd833-8680-45b2-93ba-e181825415eb
+    ...
+Total credit available: CAD 50.00 for vendor V001 (Supplier Co.).
+```
+
+The same credits are also written into every exported AP account as an `open_prepayment:` block, so a plain `export --include-business-objects` shows each account's outstanding credits at a glance:
+
+```
+2026-03-01 open Liabilities:Accounts Payable
+	open_prepayment:
+		vendor: "V001"
+		vendor_guid: "3f6d4a17b218c47e85d290f3e9a2b1c4"
+		amount: 50.00 CAD
+```
+
+From there, settle a partially-paid bill by appending another `payment:` block for the shortfall and re-importing (incremental — only the new payment is applied), and consume a vendor credit against the next bill with `auto_apply_credit: true` (which draws from the open credit across whichever bills it originated from), or refund it by deleting the source bank tx via `delete-transactions --by-guid`.
+
+Credits are always owner-scoped. In a book with several suppliers each holding a credit, `find-prepayments --vendor V-2` returns only V-2's credit, and the unfiltered `find-prepayments` lists every credit under its owner with a per-owner total — so a $20 vendor credit is never confused with a $15 customer credit or another vendor's $30. Apply each only to the next bill/invoice for that same owner.
+
+## Correcting a mis-applied bill payment: fresh + linked, then unapply / re-link
+
+A single bill is often settled by a *mix* of payment kinds, and the fix for a mistake is `unapply-payment` (peel a payment; the document stays posted, the bank tx is never deleted) rather than unpost. Worked on the taxed $1120 bill (net 1000 + GST 50 + PST 70), settled by two partial payments — a fresh $1000 (`ApplyPayment`, mints its own bank tx) plus a *linked* $120 (a `payment:` block whose `txn_guid:` retargets a pre-existing $120 bank tx):
+
+```
+bill "BILL-HERO-1120"      posted lot -1120
+	payment: amount: 1000                       (fresh — no txn_guid)
+	payment: amount: 120  txn_guid: "…the $120 bank tx…"   (linked)
+→ posted lot balance 0.00 (settled)
+```
+
+Three corrections from that settled state, each observed:
+
+- **Linked the wrong tx** — peel just the $120: `unapply-payment book BILL-HERO-1120 --bill --txn <120-bank-tx> --to "Liabilities:Due to vendor"`. The $1000 stays applied, the bill drops to **−$120** outstanding, and the $120 bank tx survives (only its split's account changed).
+- **Pay from a prior credit instead** — peel everything: `unapply-payment book BILL-HERO-1120 --bill --all --to "Liabilities:Due to vendor"`. The bill returns to **−$1120** fully outstanding; re-import it with `auto_apply_credit: true` to settle it from an existing vendor credit rather than cash (the credit lot is consumed by the amount of the bill, any residual staying open).
+- **Applied the wrong bank tx for the net** — peel the $1000 (`--txn <1000-bank-tx>`), leaving the $120 applied and **−$1000** outstanding; then import the correct $1000 bank tx and re-import the bill with a `payment:` block whose `txn_guid:` links it. The lot closes again (0.00), now settled by the corrected tx, and the original $1000 tx survives in your `--to` account.
+
+On a bill with several payments, `unapply-payment` needs a selector (`--txn <bank-tx-guid>`, repeatable, or `--all`); omitting it on a multi-payment record is an error, never a guess. See the README's `unapply-payment` section for the full option reference.
+
+## Managing a vendor credit: consume, refund, or write off
+
+A vendor credit is money the supplier owes you back (you overpaid them) — GnuCash holds it as an open, **positive** AP lot attached to no bill. Managing it is therefore separate from any single bill: there are three dispositions, all non-destructive (none touches the original overpayment transaction), and the **counter account states the intent**:
+
+| Disposition | How you record it | Counter account | Cash movement | What it means |
+|---|---|---|---|---|
+| **Consume** on the next bill | `auto_apply_credit: true` on that bill's header | — (internal lot move) | none | The vendor's next bill(s) draw the credit down |
+| **Refund** (the vendor pays you back) | `lot_owner: vendor:V001` on an AP split | an **asset** (bank / cash) | **+ into the bank** | Collect the receivable in cash — **not an expense** |
+| **Write off** (you'll never recover it) | `lot_owner: vendor:V001` on an AP split | an **expense** | none | Recognise the loss — the *only* case that hits an expense |
+
+- **Consume it on the next bill** — `auto_apply_credit: true` (above). The usual path: GnuCash draws the credit into the vendor's next bill(s).
+- **Refund** — the vendor returns the money. Record a normal transaction whose AP split carries a `lot_owner:` marker; the counter account is the bank:
+
+```
+2026-02-15 * "Refund received from Supplier"
+	currency.mnemonic: "CAD"
+	Assets:Bank 50.00 CAD
+	Liabilities:Accounts Payable -50.00 CAD
+		lot_owner: vendor:V001
+```
+
+- **Write off** — you will never use it (e.g. the vendor ceased trading). Same shape, counter = an expense:
+
+```
+2026-02-15 * "Write off Supplier overpayment — ceased trading"
+	currency.mnemonic: "CAD"
+	Expenses:Supplies 50.00 CAD
+	Liabilities:Accounts Payable -50.00 CAD
+		lot_owner: vendor:V001
+```
+
+The `lot_owner: vendor:V001` marker joins the AP split to the vendor's oldest open credit lot and reduces it — an exact amount closes the lot, a smaller amount leaves the residual credit open (a partial refund). A `vendor:` marker must sit on an AP account (a `customer:` marker on an AR account); the importer rejects the mismatch.
+
+**What the refund moves, and why it is not an expense.** Observed from the book (bill $100 paid $150, then the vendor refunds $50): the $50 comes **out of the AP credit and into the bank** — `Liabilities:Accounts Payable` goes `+50 → 0` (the amount the vendor owed us is collected) and `Assets:Bank` rises by $50; the credit lot closes. Nothing else moves — the bill's original $100 expense is untouched. This matches the intuition that overpaying a vendor is, in effect, a **receivable** (the vendor owes you your money back): GnuCash carries it as a positive (debit) balance on Accounts Payable rather than in a separate asset account, and the refund collects it in cash. Only the **write-off** above hits an expense — that's the different case where the money is *gone*, not returned.
+
+### The credit round-trips in the export — the "special directives"
+
+You never have to re-derive an overpayment by hand: the credit state is carried by three exported directives, so it survives export → fresh-book re-import intact:
+
+- **`prepayment: N`** on a bill's `payment:` block — the overpayment residual that opened the credit (see [Bill overpayment](#bill-overpayment-vendor-credit)).
+- **`open_prepayment:`** block on each AP account — the owner, owner guid, and amount of every open credit (see [Detecting…](#detecting-a-vendors-bill-payment-state-paid--partial--overpaid)). It is informational: the importer rebuilds credits from the `lot_owner:` markers, not from this block, so a hand-edited summary that disagrees only prints a warning and is overwritten on the next export.
+- **`lot_owner: vendor:ID[:guid]`** on the AP split of a disposal transaction — the durable link between a clearing / refund / write-off split and the vendor's credit lot. The trailing owner guid is emitted on export and optional by hand.
+
+So the whole lifecycle lives in plaintext: `find-prepayments --vendor` (or the `open_prepayment:` blocks) to see credits, `auto_apply_credit:` to consume, or a `lot_owner:` transaction to refund / write off.

--- a/docs/invoice-payment-reconciliation.md
+++ b/docs/invoice-payment-reconciliation.md
@@ -1,23 +1,22 @@
-# Invoice and Bill Payment Reconciliation
+# Invoice Payment Reconciliation
 
-Covers the scenarios where bank transactions and invoice/bill payments need
+Covers the scenarios where bank transactions and invoice payments need
 to be linked without creating duplicate bank entries, and how the GUID-based
-identity model affects re-imports.
+identity model affects re-imports. For the vendor-bill (Accounts Payable) side, see [docs/bill-payment-reconciliation.md](bill-payment-reconciliation.md).
 
 For the canonical end-to-end roundtrip walkthrough — a single source book exercising every plaintext surface (accounts, customers, vendors, tax tables, invoices and bills, every payment shape from cash through retarget, overpayment, credit consumption, and multi-invoice shared bank tx) exported and re-imported into a fresh book with all GUIDs preserved — see [docs/comprehensive-roundtrip-example.md](comprehensive-roundtrip-example.md).
 
 ## Background
 
 When an invoice is paid in GnuCash, `ApplyPayment()` always creates a **new**
-bank+AR transaction. Similarly, when a vendor bill is paid, it creates a new
-bank+AP transaction. If a matching bank transaction was already imported from
+bank+AR transaction. If a matching bank transaction was already imported from
 a bank feed (QFX, CSV, HTML, etc.), you end up with two bank entries for the
 same cash movement — one from the feed, one from the payment.
 
 The `txn_guid:` field on a `payment:` block solves this cleanly: instead of
 creating a new transaction, the importer **modifies the existing bank
-transaction in-place**, retargeting its counter-split to AR (or AP for bills)
-and linking it to the invoice/bill lot. All original bank metadata — notes,
+transaction in-place**, retargeting its counter-split to AR
+and linking it to the invoice lot. All original bank metadata — notes,
 description, split memos, FITID — is preserved.
 
 The companion `txn_split_guid:` field names the *specific* AR/AP-side split that belongs to this invoice/bill. It's optional in hand-written plaintext (the importer falls back to the iterative-retarget mechanism that walks the bank tx's counter-splits in plaintext order) but is **always** emitted on export so a round-tripped book reconstructs bit-for-bit on a fresh re-import — including the shape where one bank transaction covers several invoices or bills, each claiming one specific AR/AP-side split via its own `txn_split_guid:`.
@@ -25,7 +24,8 @@ The companion `txn_split_guid:` field names the *specific* AR/AP-side split that
 This document describes:
 
 - [Workflow: Import bank feed first, then reconcile invoices](#workflow-import-bank-feed-first-then-reconcile-invoices)
-- [Vendor bills work the same way](#vendor-bills-work-the-same-way)
+- Vendor bills (Accounts Payable) are covered in [docs/bill-payment-reconciliation.md](bill-payment-reconciliation.md)
+- [Managing a customer credit: consume, refund, or forfeit](#managing-a-customer-credit-consume-refund-or-forfeit)
 - [GUID format conventions](#guid-format-conventions)
 - [Round-trip identity: the exporter writes back what you imported](#round-trip-identity-the-exporter-writes-back-what-you-imported)
 - [Idempotency](#idempotency)
@@ -200,44 +200,42 @@ If restructuring isn't acceptable (e.g. the bank tx must stay byte-identical to 
 
 ---
 
-## Vendor bills work the same way
+## Managing a customer credit: consume, refund, or forfeit
 
-Bills use AP instead of AR. The `payment:` block in a `bill` directive is
-identical — just provide `bank_account` and `txn_guid`:
+When a customer pays more than an invoice, the excess opens a **customer credit** — money you hold that isn't yours and may owe back. GnuCash carries it as an open, **negative** (credit) AR lot attached to no invoice (the overpaying `payment:` block records the residual as `prepayment: N`). It is managed in three ways, all non-destructive (none touches the original overpayment transaction), and the **counter account states the intent**:
+
+| Disposition | How you record it | Counter account | Cash movement | What it means |
+|---|---|---|---|---|
+| **Consume** on the next invoice | `auto_apply_credit: true` on that invoice's header | — (internal lot move) | none | The customer's next invoice(s) draw the credit down |
+| **Refund** (the customer asks for it back) | `lot_owner: customer:C001` on an AR split | an **asset** (bank / cash) | **− out of the bank** | Settle the liability in cash — **not an expense** |
+| **Forfeit** (the customer never claims it) | `lot_owner: customer:C001` on an AR split | an **income** account | none | Recognise the gain — the *only* case that hits income |
+
+- **Consume it on the next invoice** — `auto_apply_credit: true` on that invoice's header: GnuCash draws the credit into the customer's next invoice(s), across several in posting order until it runs out.
+- **Refund** — the customer asks for their money back and you pay it. Record a normal transaction whose AR split carries a `lot_owner:` marker; the counter is the bank, so money leaves:
 
 ```
-vendor "VEND-001"
-	guid: "f66df24e6e75424ba08c2b0a47ec292c"
-	name: "Office Supplies Co."
-	currency: CAD
-
-bill "BILL-2026-001"
-	vendor_id: "VEND-001"
-	vendor_guid: "f66df24e6e75424ba08c2b0a47ec292c"
-	currency: CAD
-	date_opened: 2026-01-01
-	entry:
-		...
-	posted:
-		date: 2026-01-01
-		due: 2026-01-31
-		ap_account: "Liabilities:Accounts Payable"
-		memo: "Bill BILL-2026-001"
-		accumulate: true
-	payment:
-		bank_account: "Assets:Bank"
-		txn_guid: "abc123def456abc123def456abc123de"
-		txn_split_guid: "11223344556677889900aabbccddeeff"
+2026-02-01 * "Refund overpayment to Acme"
+	currency.mnemonic: "CAD"
+	Assets:Bank -50.00 CAD
+	Assets:Accounts Receivable 50.00 CAD
+		lot_owner: customer:C001
 ```
 
-Use `find-transactions` with a negative amount to find outgoing payments:
+- **Forfeit** — the customer never claims the credit and you recognise it as income (a gain). Same shape, counter = an income account:
 
-```bash
-gnucash-plaintext find-transactions ledger.gnucash \
-    --account "Assets:Bank" \
-    --date 2026-01-25 \
-    --amount 200
 ```
+2026-02-15 * "Forfeit Acme overpayment to income"
+	currency.mnemonic: "CAD"
+	Income -50.00 CAD
+	Assets:Accounts Receivable 50.00 CAD
+		lot_owner: customer:C001
+```
+
+The `lot_owner: customer:C001` marker joins the AR split to the customer's oldest open credit lot and reduces it — an exact amount closes the lot, a smaller amount leaves the residual credit open (a partial refund). A `customer:` marker must sit on an AR account (a `vendor:` marker on an AP account); the importer rejects the mismatch.
+
+**What the refund moves, and why it is not an expense.** Observed from the book (invoice $100 paid $150, then we refund $50): the $50 goes **out of the bank and clears the AR credit** — `Assets:Bank` falls by $50 and `Assets:Accounts Receivable` goes `−50 → 0`; the credit lot closes. Nothing else moves — no expense and no reduction of income. This matches the intuition that a customer overpayment is, in effect, a **liability** (money we hold that isn't ours and may owe back): GnuCash carries it as a credit (negative balance) on Accounts Receivable rather than in a separate liability account, and the refund settles it in cash. Only the **forfeit** above touches income — that's the different case where the customer never claims it and it becomes a gain.
+
+Detect open credits with `find-prepayments --customer C001` or the `open_prepayment:` blocks on AR accounts. The whole state round-trips through export via three directives — `prepayment:` (on the overpaying payment), `open_prepayment:` (the per-account credit summary), and `lot_owner:` (the disposal split) — so a credit survives export → fresh-book re-import without manual bookkeeping. This is the exact mirror of the vendor side, sign-flipped: see [docs/bill-payment-reconciliation.md § Managing a vendor credit](bill-payment-reconciliation.md#managing-a-vendor-credit-consume-refund-or-write-off) (there the refund arrives *in* the bank and the write-off goes to an expense).
 
 ---
 

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -17,6 +17,7 @@ and in the **Status** column below.
 | [T-005](T-005-multi-currency-close-books-untested.md) | Multi-currency close-books path has no test | medium | closed |
 | [T-006](T-006-fx-rates-yaml-error-paths-untested.md) | FX rates YAML error paths are untested | low | closed |
 | [T-007](T-007-plaintext-parser-edge-cases-untested.md) | Plaintext parser edge cases are not tested | medium | closed |
+| [T-008](T-008-tax-included-and-payment-reconciliation-coverage.md) | tax_included pricing untested; bill tax flags not persisted; payment/credit reconciliation gaps | high | open |
 
 ## Security
 

--- a/docs/issues/T-008-tax-included-and-payment-reconciliation-coverage.md
+++ b/docs/issues/T-008-tax-included-and-payment-reconciliation-coverage.md
@@ -1,0 +1,69 @@
+---
+id: T-008
+title: tax_included pricing branch untested; discovered bill tax flags not persisted; payment/credit reconciliation gaps
+category: tests
+severity: high
+status: open
+---
+
+## Problem
+
+The `tax_included: true` (tax-inclusive pricing) branch — where the entered
+price already contains the tax and the code backs the net out via
+`net = gross / (1 + total_rate)` — existed in both
+`services/invoice_renderer.py` (`compute_entry_informational`) and
+`services/bill_renderer.py` (`compute_bill_entry_informational`) but had **no
+fixture or test**. Adding coverage for both invoices and bills uncovered a
+production bug and several adjacent reconciliation gaps.
+
+### Production bug found (and fixed)
+
+Vendor-bill entries were attached to the bill with SWIG `Invoice.AddEntry`
+(`gncInvoiceAddEntry`), the **customer-invoice** owner API, which sets the
+entry's *invoice* pointer. GnuCash's entry XML writer guards the bill-side tax
+flags behind `if (gncEntryGetBill(entry))`, so those entries serialised on the
+invoice side (`entry:invoice`, `i-taxincluded`) and **never persisted
+`entry:b-taxable` / `entry:b-taxincluded`**. Consequently `tax_included: true`
+(and `taxable: false`) on a bill silently reverted on save/reload, over-taxing
+the bill. Proven by an XML probe: an entry added via `gncBillAddEntry` writes
+`<entry:bill>` with `b-taxincluded=1`, whereas `Invoice.AddEntry` omits it.
+This also explains — and supersedes — the earlier CLAUDE.md finding #8 belief
+that GnuCash "cannot persist `bill_taxable = false`".
+
+### Reconciliation coverage gaps (untested before this work)
+
+- overpayment / partial payment on a **taxed** invoice/bill (payment applied
+  against the tax-inclusive total);
+- settling one document with a **mix** of a fresh `ApplyPayment` and a linked
+  existing bank tx (`txn_guid:`), then `unapply-payment` (single / `--all`) and
+  re-link — on the bill side (`--all` and multi-partial bill unapply were
+  uncovered);
+- a vendor/customer **credit consumed across two documents** (second goes
+  partial when the credit runs out) and credit + cash settling two documents;
+- credit **owner attribution** across several vendors/customers;
+- refund tests asserted only that the credit lot closed, not that the cash
+  actually moved or that no expense/income was touched.
+
+## Affected files
+
+- `services/gnucash_importer.py` — bill entry attach (`_bill_add_entry` /
+  `gncBillAddEntry`) + `SetBillTaxIncluded`
+- `services/invoice_renderer.py`, `services/bill_renderer.py` (branch under test)
+- `tests/integration/test_tax_included_pricing.py`,
+  `test_overpayment_partial_payment_with_and_without_tax.py`,
+  `test_taxed_bill_mixed_payment_unapply_and_relink.py`,
+  `test_credit_attribution_multiple_owners.py`,
+  `test_credit_consumption_across_bills.py`,
+  `test_credit_consumption_across_invoices.py`,
+  `test_prepayment_settlement.py` (strengthened refunds)
+- `tests/fixtures/*` (tax_included_*, overpay_partial_*, hero_*, credit_*)
+- `tests/research/bill_payment_reconciliation_probe.py`
+- `docs/bill-payment-reconciliation.md` (new), `docs/invoice-payment-reconciliation.md`
+- `tests/fixtures/business_objects_only.txt` (reference now reflects persisted
+  `taxable: false`), `CLAUDE.md` finding #8 corrected
+
+## Resolution
+
+Addressed in branch `test/tax-included-pricing`: the `gncBillAddEntry` fix, the
+tax_included coverage for invoices and bills, and the payment / credit
+reconciliation tests and docs above. Close on merge to `main`.

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -434,6 +434,32 @@ def _bill_remove_all_entries(book, bill) -> None:
         old_entry.Destroy()
 
 
+def _bill_add_entry(bill, entry) -> None:
+    """Attach an entry to a vendor bill via the C `gncBillAddEntry`.
+
+    SWIG `Invoice.AddEntry(entry)` wraps `gncInvoiceAddEntry`, which sets the
+    entry's *customer-invoice* owner pointer (`gncEntrySetInvoice`). GnuCash's
+    entry XML writer guards the bill-side tax flags behind
+    `if (gncEntryGetBill(entry))`, so a bill entry attached the customer-invoice
+    way serialises on the invoice side (`entry:invoice`, `i-taxincluded`) and
+    never persists `entry:b-taxable` / `entry:b-taxincluded`. Its
+    `tax_included: true` is silently dropped on save and reads back false after
+    reload, so the price is treated as tax-exclusive and the bill is
+    over-taxed. `gncBillAddEntry` sets the entry's *bill* owner pointer
+    (`gncEntrySetBill`) so the writer emits `entry:bill` with `b-taxable` /
+    `b-taxincluded`, and the tax-inclusive flag survives the round-trip.
+    Symmetric to `_bill_remove_all_entries` (`gncBillRemoveEntry`); both append
+    to the same `invoice->entries` GList that posting iterates, so the only
+    behavioural change is that the bill-side owner link (and its tax flags) is
+    now recorded correctly.
+    """
+    import ctypes
+    lib = ctypes.CDLL(None)
+    lib.gncBillAddEntry.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    lib.gncBillAddEntry.restype = None
+    lib.gncBillAddEntry(int(bill.instance), int(entry.instance))
+
+
 def _swig_invoice_guid_str(invoice) -> str:
     """Read an Invoice's GUID via ctypes (qof_instance_get_guid + guid_to_string_buff).
     SWIG `Invoice.GetGUID()` is missing on some platforms; this works everywhere
@@ -3101,11 +3127,22 @@ class GnuCashImporter:
                 entry.SetQuantity(string_to_gnc_numeric_quantity(entry_directive.metadata['quantity']))
                 entry.SetBillPrice(string_to_gnc_numeric_quantity(entry_directive.metadata['price']))
                 entry.SetBillTaxable(entry_directive.metadata['taxable'] == 'true')
+                # Mirror the invoice-side wiring (SetInvTaxIncluded): a bill
+                # entry's `tax_included: true` means the entered price already
+                # contains the tax, so GnuCash must back the net out at post
+                # time (net = gross / (1 + total_rate)). `tax_included` is
+                # optional on bill entries — default false (tax added on top).
+                entry.SetBillTaxIncluded(
+                    entry_directive.metadata.get('tax_included', 'false') == 'true')
                 if 'tax_table' in entry_directive.metadata:
                     tt_ptr = gc.gncTaxTableLookupByName(book.instance, entry_directive.metadata['tax_table'])
                     if tt_ptr:
                         entry.SetBillTaxTable(TaxTable(instance=tt_ptr))
-                bill.AddEntry(entry)
+                # Attach on the vendor-bill side (gncBillAddEntry), NOT the
+                # customer-invoice side (Invoice.AddEntry), so GnuCash persists
+                # the bill-side tax flags (b-taxable / b-taxincluded). See
+                # _bill_add_entry.
+                _bill_add_entry(bill, entry)
                 entry.CommitEdit()
             elif entry_directive.type == DirectiveType.POSTED:
                 ap_acct_name = entry_directive.metadata['ap_account']

--- a/tests/fixtures/business_objects_only.txt
+++ b/tests/fixtures/business_objects_only.txt
@@ -159,7 +159,7 @@ bill "BILL-2026-001"
 		account: "Expenses:Supplies"
 		quantity: 1
 		price: 100
-		taxable: true
+		taxable: false
 		tax_included: false
 	posted:
 		date: 2026-01-01
@@ -179,7 +179,7 @@ bill "BILL-2026-002"
 		account: "Expenses:Supplies"
 		quantity: 2
 		price: 75
-		taxable: true
+		taxable: false
 		tax_included: false
 	posted: none
 	payment: none
@@ -194,7 +194,7 @@ bill "BILL-2026-003"
 		account: "Expenses:Supplies"
 		quantity: 1
 		price: 200
-		taxable: true
+		taxable: false
 		tax_included: false
 	posted:
 		date: 2026-01-20
@@ -218,7 +218,7 @@ bill "BILL-2026-004"
 		account: "Expenses:Supplies"
 		quantity: 3
 		price: 100
-		taxable: true
+		taxable: false
 		tax_included: false
 	posted:
 		date: 2026-02-01
@@ -247,7 +247,7 @@ bill "BILL-2026-005"
 		account: "Expenses:Supplies"
 		quantity: 1
 		price: 400
-		taxable: true
+		taxable: false
 		tax_included: false
 	posted:
 		date: 2026-02-05

--- a/tests/fixtures/credit_attribution_three_vendors_three_customers.txt
+++ b/tests/fixtures/credit_attribution_three_vendors_three_customers.txt
@@ -1,0 +1,170 @@
+vendor "V-1"
+	name: "Vendor One"
+	currency: CAD
+
+vendor "V-2"
+	name: "Vendor Two"
+	currency: CAD
+
+vendor "V-3"
+	name: "Vendor Three"
+	currency: CAD
+
+customer "C-1"
+	name: "Customer One"
+	currency: CAD
+
+customer "C-2"
+	name: "Customer Two"
+	currency: CAD
+
+customer "C-3"
+	name: "Customer Three"
+	currency: CAD
+
+bill "BILL-V1-OVER10"
+	vendor_id: "V-1"
+	currency: CAD
+	date_opened: 2026-06-01
+	entry:
+		date: 2026-06-01
+		description: "Supplies"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-01
+		due: 2026-07-01
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-V1-OVER10"
+		accumulate: true
+	payment:
+		date: 2026-06-05
+		amount: 110
+		bank_account: "Assets:Bank"
+		memo: "Overpaid vendor 1 by 10"
+
+bill "BILL-V2-OVER20"
+	vendor_id: "V-2"
+	currency: CAD
+	date_opened: 2026-06-01
+	entry:
+		date: 2026-06-01
+		description: "Supplies"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-01
+		due: 2026-07-01
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-V2-OVER20"
+		accumulate: true
+	payment:
+		date: 2026-06-05
+		amount: 120
+		bank_account: "Assets:Bank"
+		memo: "Overpaid vendor 2 by 20"
+
+bill "BILL-V3-OVER30"
+	vendor_id: "V-3"
+	currency: CAD
+	date_opened: 2026-06-01
+	entry:
+		date: 2026-06-01
+		description: "Supplies"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-01
+		due: 2026-07-01
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-V3-OVER30"
+		accumulate: true
+	payment:
+		date: 2026-06-05
+		amount: 130
+		bank_account: "Assets:Bank"
+		memo: "Overpaid vendor 3 by 30"
+
+invoice "INV-C1-OVER15"
+	customer_id: "C-1"
+	currency: CAD
+	date_opened: 2026-06-01
+	entry:
+		date: 2026-06-01
+		description: "Services"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-01
+		due: 2026-07-01
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-C1-OVER15"
+		accumulate: true
+	payment:
+		date: 2026-06-05
+		amount: 115
+		bank_account: "Assets:Bank"
+		memo: "Customer 1 overpaid by 15"
+
+invoice "INV-C2-OVER25"
+	customer_id: "C-2"
+	currency: CAD
+	date_opened: 2026-06-01
+	entry:
+		date: 2026-06-01
+		description: "Services"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-01
+		due: 2026-07-01
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-C2-OVER25"
+		accumulate: true
+	payment:
+		date: 2026-06-05
+		amount: 125
+		bank_account: "Assets:Bank"
+		memo: "Customer 2 overpaid by 25"
+
+invoice "INV-C3-OVER35"
+	customer_id: "C-3"
+	currency: CAD
+	date_opened: 2026-06-01
+	entry:
+		date: 2026-06-01
+		description: "Services"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-01
+		due: 2026-07-01
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-C3-OVER35"
+		accumulate: true
+	payment:
+		date: 2026-06-05
+		amount: 135
+		bank_account: "Assets:Bank"
+		memo: "Customer 3 overpaid by 35"

--- a/tests/fixtures/credit_primer_150.txt
+++ b/tests/fixtures/credit_primer_150.txt
@@ -1,0 +1,27 @@
+vendor "V-MB"
+	name: "Multi-Bill Supplier"
+	currency: CAD
+
+bill "BILL-MB-PRIMER-50"
+	vendor_id: "V-MB"
+	currency: CAD
+	date_opened: 2026-06-01
+	entry:
+		date: 2026-06-01
+		description: "Earlier bill, overpaid to leave a 150 vendor credit"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 50
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-01
+		due: 2026-06-30
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-MB-PRIMER-50"
+		accumulate: true
+	payment:
+		date: 2026-06-02
+		amount: 200
+		bank_account: "Assets:Bank"
+		memo: "Overpaid 200 on a 50 bill → 150 vendor credit"

--- a/tests/fixtures/credit_primer_invoice_150.txt
+++ b/tests/fixtures/credit_primer_invoice_150.txt
@@ -1,0 +1,28 @@
+customer "C-MB"
+	name: "Multi-Invoice Customer"
+	currency: CAD
+
+invoice "INV-MB-PRIMER-50"
+	customer_id: "C-MB"
+	currency: CAD
+	date_opened: 2026-06-01
+	entry:
+		date: 2026-06-01
+		description: "Earlier invoice, overpaid to leave a 150 customer credit"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 50
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-01
+		due: 2026-06-30
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-MB-PRIMER-50"
+		accumulate: true
+	payment:
+		date: 2026-06-02
+		amount: 200
+		bank_account: "Assets:Bank"
+		memo: "Customer overpaid 200 on a 50 invoice → 150 credit"

--- a/tests/fixtures/credit_two_bills_both_flagged.txt
+++ b/tests/fixtures/credit_two_bills_both_flagged.txt
@@ -1,0 +1,41 @@
+bill "BILL-MB-1"
+	vendor_id: "V-MB"
+	currency: CAD
+	date_opened: 2026-06-10
+	auto_apply_credit: true
+	entry:
+		date: 2026-06-10
+		description: "First bill — settled in full from the credit"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-10
+		due: 2026-07-10
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-MB-1"
+		accumulate: true
+	payment: none
+
+bill "BILL-MB-2"
+	vendor_id: "V-MB"
+	currency: CAD
+	date_opened: 2026-06-11
+	auto_apply_credit: true
+	entry:
+		date: 2026-06-11
+		description: "Second bill — credit runs out, goes partial"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-11
+		due: 2026-07-11
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-MB-2"
+		accumulate: true
+	payment: none

--- a/tests/fixtures/credit_two_bills_second_has_cash.txt
+++ b/tests/fixtures/credit_two_bills_second_has_cash.txt
@@ -1,0 +1,45 @@
+bill "BILL-MBC-1"
+	vendor_id: "V-MB"
+	currency: CAD
+	date_opened: 2026-06-10
+	auto_apply_credit: true
+	entry:
+		date: 2026-06-10
+		description: "First bill — settled in full from the credit"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-10
+		due: 2026-07-10
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-MBC-1"
+		accumulate: true
+	payment: none
+
+bill "BILL-MBC-2"
+	vendor_id: "V-MB"
+	currency: CAD
+	date_opened: 2026-06-11
+	auto_apply_credit: true
+	entry:
+		date: 2026-06-11
+		description: "Second bill — 50 from the remaining credit, 50 cash"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-11
+		due: 2026-07-11
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-MBC-2"
+		accumulate: true
+	payment:
+		date: 2026-06-12
+		amount: 50
+		bank_account: "Assets:Bank"
+		memo: "Cash for the rest of bill 2 after the credit ran out"

--- a/tests/fixtures/credit_two_invoices_both_flagged.txt
+++ b/tests/fixtures/credit_two_invoices_both_flagged.txt
@@ -1,0 +1,43 @@
+invoice "INV-MB-1"
+	customer_id: "C-MB"
+	currency: CAD
+	date_opened: 2026-06-10
+	auto_apply_credit: true
+	entry:
+		date: 2026-06-10
+		description: "First invoice — settled in full from the credit"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-10
+		due: 2026-07-10
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-MB-1"
+		accumulate: true
+	payment: none
+
+invoice "INV-MB-2"
+	customer_id: "C-MB"
+	currency: CAD
+	date_opened: 2026-06-11
+	auto_apply_credit: true
+	entry:
+		date: 2026-06-11
+		description: "Second invoice — credit runs out, goes partial"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-11
+		due: 2026-07-11
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-MB-2"
+		accumulate: true
+	payment: none

--- a/tests/fixtures/credit_two_invoices_second_has_cash.txt
+++ b/tests/fixtures/credit_two_invoices_second_has_cash.txt
@@ -1,0 +1,47 @@
+invoice "INV-MBC-1"
+	customer_id: "C-MB"
+	currency: CAD
+	date_opened: 2026-06-10
+	auto_apply_credit: true
+	entry:
+		date: 2026-06-10
+		description: "First invoice — settled in full from the credit"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-10
+		due: 2026-07-10
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-MBC-1"
+		accumulate: true
+	payment: none
+
+invoice "INV-MBC-2"
+	customer_id: "C-MB"
+	currency: CAD
+	date_opened: 2026-06-11
+	auto_apply_credit: true
+	entry:
+		date: 2026-06-11
+		description: "Second invoice — 50 from the remaining credit, 50 cash"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-06-11
+		due: 2026-07-11
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-MBC-2"
+		accumulate: true
+	payment:
+		date: 2026-06-12
+		amount: 50
+		bank_account: "Assets:Bank"
+		memo: "Cash for the rest of invoice 2 after the credit ran out"

--- a/tests/fixtures/hero_bank_tx_120.txt
+++ b/tests/fixtures/hero_bank_tx_120.txt
@@ -1,0 +1,4 @@
+2026-05-15 * "Wire to vendor — tax portion 120"
+	currency.mnemonic: "CAD"
+	Assets:Bank -120.00 CAD
+	Liabilities:Accounts Payable 120.00 CAD

--- a/tests/fixtures/hero_prior_credit_primer.txt
+++ b/tests/fixtures/hero_prior_credit_primer.txt
@@ -1,0 +1,27 @@
+vendor "V-HERO"
+	name: "Hero Supplier"
+	currency: CAD
+
+bill "BILL-HERO-PRIMER-300"
+	vendor_id: "V-HERO"
+	currency: CAD
+	date_opened: 2026-05-01
+	entry:
+		date: 2026-05-01
+		description: "Earlier bill, heavily overpaid to leave a vendor credit"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 300
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-05-01
+		due: 2026-05-31
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-HERO-PRIMER-300"
+		accumulate: true
+	payment:
+		date: 2026-05-03
+		amount: 1500
+		bank_account: "Assets:Bank"
+		memo: "Overpaid 1500 on a 300 bill → 1200 vendor credit"

--- a/tests/fixtures/hero_taxed_bill_1120.txt
+++ b/tests/fixtures/hero_taxed_bill_1120.txt
@@ -1,0 +1,44 @@
+taxtable "GST+PST"
+	entry:
+		account: "Liabilities:Tax:GST"
+		rate: 5.0%
+		type: PERCENT
+	entry:
+		account: "Liabilities:Tax:PST"
+		rate: 7.0%
+		type: PERCENT
+
+vendor "V-HERO"
+	name: "Hero Supplier"
+	currency: CAD
+
+bill "BILL-HERO-1120"
+	vendor_id: "V-HERO"
+	currency: CAD
+	date_opened: 2026-05-10
+	entry:
+		date: 2026-05-10
+		description: "Materials (net 1000 + GST 50 + PST 70 = 1120)"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 1000
+		taxable: true
+		tax_included: false
+		tax_table: "GST+PST"
+	posted:
+		date: 2026-05-10
+		due: 2026-06-09
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-HERO-1120"
+		accumulate: true
+	payment:
+		date: 2026-05-14
+		amount: 1000
+		bank_account: "Assets:Bank"
+		memo: "Fresh payment of net 1000"
+	payment:
+		date: 2026-05-15
+		amount: 120
+		bank_account: "Assets:Bank"
+		txn_guid: "{txn_guid}"
+		memo: "Linked existing bank tx for the 120 tax portion"

--- a/tests/fixtures/overpay_partial_taxed_bills.txt
+++ b/tests/fixtures/overpay_partial_taxed_bills.txt
@@ -1,0 +1,63 @@
+taxtable "GST+PST"
+	entry:
+		account: "Liabilities:Tax:GST"
+		rate: 5.0%
+		type: PERCENT
+	entry:
+		account: "Liabilities:Tax:PST"
+		rate: 7.0%
+		type: PERCENT
+
+vendor "V-TAX-BILL"
+	name: "Taxed Supplier"
+	currency: CAD
+
+bill "BILL-TAX-OVER-112"
+	vendor_id: "V-TAX-BILL"
+	currency: CAD
+	date_opened: 2026-04-01
+	entry:
+		date: 2026-04-01
+		description: "Materials (net 100 + 12% tax = 112)"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 100
+		taxable: true
+		tax_included: false
+		tax_table: "GST+PST"
+	posted:
+		date: 2026-04-01
+		due: 2026-05-01
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-TAX-OVER-112"
+		accumulate: true
+	payment:
+		date: 2026-04-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		memo: "Paid 150 on a 112 bill (overpaid 38)"
+
+bill "BILL-TAX-PART-112"
+	vendor_id: "V-TAX-BILL"
+	currency: CAD
+	date_opened: 2026-04-02
+	entry:
+		date: 2026-04-02
+		description: "Materials (net 100 + 12% tax = 112)"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 100
+		taxable: true
+		tax_included: false
+		tax_table: "GST+PST"
+	posted:
+		date: 2026-04-02
+		due: 2026-05-02
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-TAX-PART-112"
+		accumulate: true
+	payment:
+		date: 2026-04-11
+		amount: 60
+		bank_account: "Assets:Bank"
+		memo: "Part payment (52 outstanding on a 112 bill)"

--- a/tests/fixtures/overpay_partial_taxed_invoices.txt
+++ b/tests/fixtures/overpay_partial_taxed_invoices.txt
@@ -1,0 +1,65 @@
+taxtable "GST+PST"
+	entry:
+		account: "Liabilities:Tax:GST"
+		rate: 5.0%
+		type: PERCENT
+	entry:
+		account: "Liabilities:Tax:PST"
+		rate: 7.0%
+		type: PERCENT
+
+customer "C-TAX-INV"
+	name: "Taxed Customer"
+	currency: CAD
+
+invoice "INV-TAX-OVER-112"
+	customer_id: "C-TAX-INV"
+	currency: CAD
+	date_opened: 2026-04-01
+	entry:
+		date: 2026-04-01
+		description: "Services (net 100 + 12% tax = 112)"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: true
+		tax_included: false
+		tax_table: "GST+PST"
+	posted:
+		date: 2026-04-01
+		due: 2026-05-01
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-TAX-OVER-112"
+		accumulate: true
+	payment:
+		date: 2026-04-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		memo: "Customer paid 150 on a 112 invoice (overpaid 38)"
+
+invoice "INV-TAX-PART-112"
+	customer_id: "C-TAX-INV"
+	currency: CAD
+	date_opened: 2026-04-02
+	entry:
+		date: 2026-04-02
+		description: "Services (net 100 + 12% tax = 112)"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: true
+		tax_included: false
+		tax_table: "GST+PST"
+	posted:
+		date: 2026-04-02
+		due: 2026-05-02
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-TAX-PART-112"
+		accumulate: true
+	payment:
+		date: 2026-04-11
+		amount: 60
+		bank_account: "Assets:Bank"
+		memo: "Part payment (52 outstanding on a 112 invoice)"

--- a/tests/fixtures/overpay_partial_untaxed_bills.txt
+++ b/tests/fixtures/overpay_partial_untaxed_bills.txt
@@ -1,0 +1,51 @@
+vendor "V-NOTAX-BILL"
+	name: "Untaxed Supplier"
+	currency: CAD
+
+bill "BILL-NOTAX-OVER-100"
+	vendor_id: "V-NOTAX-BILL"
+	currency: CAD
+	date_opened: 2026-04-01
+	entry:
+		date: 2026-04-01
+		description: "Materials (no tax, total 100)"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-04-01
+		due: 2026-05-01
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-NOTAX-OVER-100"
+		accumulate: true
+	payment:
+		date: 2026-04-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		memo: "Paid 150 on a 100 bill (overpaid 50)"
+
+bill "BILL-NOTAX-PART-100"
+	vendor_id: "V-NOTAX-BILL"
+	currency: CAD
+	date_opened: 2026-04-02
+	entry:
+		date: 2026-04-02
+		description: "Materials (no tax, total 100)"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-04-02
+		due: 2026-05-02
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-NOTAX-PART-100"
+		accumulate: true
+	payment:
+		date: 2026-04-11
+		amount: 60
+		bank_account: "Assets:Bank"
+		memo: "Part payment (40 outstanding on a 100 bill)"

--- a/tests/fixtures/overpay_partial_untaxed_invoices.txt
+++ b/tests/fixtures/overpay_partial_untaxed_invoices.txt
@@ -1,0 +1,53 @@
+customer "C-NOTAX-INV"
+	name: "Untaxed Customer"
+	currency: CAD
+
+invoice "INV-NOTAX-OVER-100"
+	customer_id: "C-NOTAX-INV"
+	currency: CAD
+	date_opened: 2026-04-01
+	entry:
+		date: 2026-04-01
+		description: "Services (no tax, total 100)"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-04-01
+		due: 2026-05-01
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-NOTAX-OVER-100"
+		accumulate: true
+	payment:
+		date: 2026-04-10
+		amount: 150
+		bank_account: "Assets:Bank"
+		memo: "Customer paid 150 on a 100 invoice (overpaid 50)"
+
+invoice "INV-NOTAX-PART-100"
+	customer_id: "C-NOTAX-INV"
+	currency: CAD
+	date_opened: 2026-04-02
+	entry:
+		date: 2026-04-02
+		description: "Services (no tax, total 100)"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted:
+		date: 2026-04-02
+		due: 2026-05-02
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-NOTAX-PART-100"
+		accumulate: true
+	payment:
+		date: 2026-04-11
+		amount: 60
+		bank_account: "Assets:Bank"
+		memo: "Part payment (40 outstanding on a 100 invoice)"

--- a/tests/fixtures/tax_included_bill.txt
+++ b/tests/fixtures/tax_included_bill.txt
@@ -1,0 +1,29 @@
+taxtable "GST+PST"
+	entry:
+		account: "Liabilities:Tax:GST"
+		rate: 5.0%
+		type: PERCENT
+	entry:
+		account: "Liabilities:Tax:PST"
+		rate: 7.0%
+		type: PERCENT
+
+vendor "V-TAXINCL-1"
+	name: "Tax-Inclusive Vendor"
+	currency: CAD
+
+bill "BILL-TAXINCL-1120"
+	vendor_id: "V-TAXINCL-1"
+	currency: CAD
+	date_opened: 2026-05-12
+	entry:
+		date: 2026-05-12
+		description: "Tax-inclusive priced supplies (gross 1120 = net 1000 + 12% tax)"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 1120
+		taxable: true
+		tax_included: true
+		tax_table: "GST+PST"
+	posted: none
+	payment: none

--- a/tests/fixtures/tax_included_bill_posted.txt
+++ b/tests/fixtures/tax_included_bill_posted.txt
@@ -1,0 +1,34 @@
+taxtable "GST+PST"
+	entry:
+		account: "Liabilities:Tax:GST"
+		rate: 5.0%
+		type: PERCENT
+	entry:
+		account: "Liabilities:Tax:PST"
+		rate: 7.0%
+		type: PERCENT
+
+vendor "V-TAXINCL-2"
+	name: "Tax-Inclusive Vendor Posted"
+	currency: CAD
+
+bill "BILL-TAXINCL-POSTED-1120"
+	vendor_id: "V-TAXINCL-2"
+	currency: CAD
+	date_opened: 2026-05-12
+	entry:
+		date: 2026-05-12
+		description: "Tax-inclusive priced supplies, 4 x 280 gross = 1120"
+		account: "Expenses:Office Supplies"
+		quantity: 4
+		price: 280
+		taxable: true
+		tax_included: true
+		tax_table: "GST+PST"
+	posted:
+		date: 2026-05-12
+		due: 2026-06-11
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-TAXINCL-POSTED-1120"
+		accumulate: true
+	payment: none

--- a/tests/fixtures/tax_included_invoice.txt
+++ b/tests/fixtures/tax_included_invoice.txt
@@ -1,0 +1,30 @@
+taxtable "GST+PST"
+	entry:
+		account: "Liabilities:Tax:GST"
+		rate: 5.0%
+		type: PERCENT
+	entry:
+		account: "Liabilities:Tax:PST"
+		rate: 7.0%
+		type: PERCENT
+
+customer "C-TAXINCL-1"
+	name: "Tax-Inclusive Customer"
+	currency: CAD
+
+invoice "INV-TAXINCL-1120"
+	customer_id: "C-TAXINCL-1"
+	currency: CAD
+	date_opened: 2026-05-10
+	entry:
+		date: 2026-05-10
+		description: "Tax-inclusive priced service (gross 1120 = net 1000 + 12% tax)"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 1120
+		taxable: true
+		tax_included: true
+		tax_table: "GST+PST"
+	posted: none
+	payment: none

--- a/tests/fixtures/tax_included_invoice_posted.txt
+++ b/tests/fixtures/tax_included_invoice_posted.txt
@@ -1,0 +1,35 @@
+taxtable "GST+PST"
+	entry:
+		account: "Liabilities:Tax:GST"
+		rate: 5.0%
+		type: PERCENT
+	entry:
+		account: "Liabilities:Tax:PST"
+		rate: 7.0%
+		type: PERCENT
+
+customer "C-TAXINCL-2"
+	name: "Tax-Inclusive Customer Posted"
+	currency: CAD
+
+invoice "INV-TAXINCL-POSTED-1120"
+	customer_id: "C-TAXINCL-2"
+	currency: CAD
+	date_opened: 2026-05-10
+	entry:
+		date: 2026-05-10
+		description: "Tax-inclusive priced service, 4 x 280 gross = 1120"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 4
+		price: 280
+		taxable: true
+		tax_included: true
+		tax_table: "GST+PST"
+	posted:
+		date: 2026-05-10
+		due: 2026-06-09
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-TAXINCL-POSTED-1120"
+		accumulate: true
+	payment: none

--- a/tests/integration/test_credit_attribution_multiple_owners.py
+++ b/tests/integration/test_credit_attribution_multiple_owners.py
@@ -1,0 +1,102 @@
+"""Overpayment credits are tied to a specific vendor / customer.
+
+A book with three vendors and three customers, each overpaid by a
+distinct amount, so a credit is unambiguously attributable to its owner:
+
+  vendor V-1 +10, V-2 +20, V-3 +30   (open AP credit lots)
+  customer C-1 +15, C-2 +25, C-3 +35 (open AR credit lots)
+
+`find-prepayments --vendor <id>` / `--customer <id>` filters to one
+owner's credits, and the unfiltered command lists all six with a
+per-owner total — this is how a user learns which supplier / customer a
+credit belongs to and applies it to the right next bill / invoice.
+"""
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURES = Path('tests/fixtures')
+ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
+FIXTURE = 'credit_attribution_three_vendors_three_customers.txt'
+
+
+def _book(runner, tmp_path):
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS])
+    assert r.exit_code == 0, r.output
+    fx = tmp_path / FIXTURE
+    fx.write_text((FIXTURES / FIXTURE).read_text())
+    r = runner.invoke(cli, ['import', str(gf), str(fx),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    return gf
+
+
+def _credits(gf, *, vendor_id=None, customer_id=None):
+    """{owner_id: total credit} from find_prepayments_in_book."""
+    from repositories.gnucash_repository import GnuCashRepository
+    from use_cases.unpost_business_objects import find_prepayments_in_book
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        out = {}
+        for c in find_prepayments_in_book(
+                repo.book, customer_id=customer_id, vendor_id=vendor_id):
+            out[c.owner_id] = round(out.get(c.owner_id, 0.0) + float(c.amount), 2)
+        return out
+    finally:
+        repo.close()
+
+
+def test_credit_filter_returns_only_that_vendor(tmp_path):
+    """`find_prepayments(vendor_id='V-2')` returns only V-2's $20 credit —
+    not V-1/V-3 and no customers."""
+    runner = CliRunner()
+    gf = _book(runner, tmp_path)
+    assert _credits(gf, vendor_id='V-2') == {'V-2': 20.00}
+    assert _credits(gf, vendor_id='V-1') == {'V-1': 10.00}
+    assert _credits(gf, vendor_id='V-3') == {'V-3': 30.00}
+
+
+def test_credit_filter_returns_only_that_customer(tmp_path):
+    """`find_prepayments(customer_id='C-3')` returns only C-3's $35 credit."""
+    runner = CliRunner()
+    gf = _book(runner, tmp_path)
+    assert _credits(gf, customer_id='C-3') == {'C-3': 35.00}
+    assert _credits(gf, customer_id='C-1') == {'C-1': 15.00}
+
+
+def test_all_six_credits_are_attributed_to_their_owner(tmp_path):
+    """Unfiltered: every credit is present and keyed to the right owner."""
+    runner = CliRunner()
+    gf = _book(runner, tmp_path)
+    assert _credits(gf) == {
+        'V-1': 10.00, 'V-2': 20.00, 'V-3': 30.00,
+        'C-1': 15.00, 'C-2': 25.00, 'C-3': 35.00,
+    }
+
+
+def test_cli_find_prepayments_vendor_filter_shows_one_owner(tmp_path):
+    """`find-prepayments --vendor V-2` names V-2 and its $20, and does NOT
+    leak the other owners' credits into the output."""
+    runner = CliRunner()
+    gf = _book(runner, tmp_path)
+    r = runner.invoke(cli, ['find-prepayments', str(gf), '--vendor', 'V-2'])
+    assert r.exit_code == 0, r.output
+    assert 'vendor V-2' in r.output and 'CAD 20.00' in r.output, r.output
+    for other in ('V-1', 'V-3', 'C-1', 'C-2', 'C-3'):
+        assert f'vendor {other}' not in r.output and f'customer {other}' \
+            not in r.output, f'{other} leaked into V-2 filter:\n{r.output}'
+    assert 'Total credit available: CAD 20.00 for vendor V-2' in r.output, r.output
+
+
+def test_cli_find_prepayments_customer_filter_shows_one_owner(tmp_path):
+    """`find-prepayments --customer C-1` names C-1 and its $15 only."""
+    runner = CliRunner()
+    gf = _book(runner, tmp_path)
+    r = runner.invoke(cli, ['find-prepayments', str(gf), '--customer', 'C-1'])
+    assert r.exit_code == 0, r.output
+    assert 'customer C-1' in r.output and 'CAD 15.00' in r.output, r.output
+    assert 'Total credit available: CAD 15.00 for customer C-1' in r.output, r.output

--- a/tests/integration/test_credit_consumption_across_bills.py
+++ b/tests/integration/test_credit_consumption_across_bills.py
@@ -1,0 +1,115 @@
+"""A vendor credit consumed across TWO bills — including running out.
+
+The vendor V-MB holds a $150 pre-payment credit (from an earlier
+overpayment). Two follow-on bills each carry `auto_apply_credit: true`, so
+GnuCash's `gncInvoiceAutoApplyPayments` draws the credit down across both:
+
+  * credit spans two bills, the second goes partial when it runs out:
+    bill 1 ($100) settles fully from the credit, bill 2 ($100) takes the
+    remaining $50 and stays $50 outstanding; the credit hits $0.
+  * credit + one cash payment settle two bills: the credit fully pays
+    bill 1 and half of bill 2, and a $50 cash payment on bill 2 covers the
+    rest — both bills settled, credit $0.
+
+Posting order is the fixture order (bill 1 before bill 2), so the first
+bill is the one paid in full and the second is the one the credit runs
+out on.
+"""
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURES = Path('tests/fixtures')
+ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
+
+
+def _fx(name):
+    return (FIXTURES / name).read_text()
+
+
+def _import(runner, gf, text, name, tmp_path):
+    p = tmp_path / name
+    p.write_text(text)
+    return runner.invoke(cli, ['import', str(gf), str(p),
+                               '--include-business-objects'])
+
+
+def _book_with_credit(runner, tmp_path):
+    """Fresh book → accounts → primer that leaves V-MB a $150 vendor credit."""
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS])
+    assert r.exit_code == 0, r.output
+    r = _import(runner, gf, _fx('credit_primer_150.txt'), 'primer.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+    return gf
+
+
+def _lot(gf, bill_id):
+    """The bill's posted AP-lot balance (0 settled, negative still owed)."""
+    import gnucash.gnucash_business as gb
+    from gnucash import Query
+
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        q = Query()
+        q.search_for('gncInvoice')
+        q.set_book(repo.book)
+        bill = next((gb.Invoice(instance=r) for r in q.run()
+                     if gb.Invoice(instance=r).GetID() == bill_id), None)
+        q.destroy()
+        assert bill is not None, f'{bill_id!r} not found'
+        lot = bill.GetPostedLot()
+        assert lot is not None, f'{bill_id!r} not posted'
+        return round(lot.get_balance().to_double(), 2)
+    finally:
+        repo.close()
+
+
+def _credit(gf, vendor_id):
+    from repositories.gnucash_repository import GnuCashRepository
+    from use_cases.unpost_business_objects import find_prepayments_in_book
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        return round(sum(float(c.amount) for c in find_prepayments_in_book(
+            repo.book, vendor_id=vendor_id)), 2)
+    finally:
+        repo.close()
+
+
+def test_credit_spans_two_bills_second_goes_partial(tmp_path):
+    """$150 credit, two $100 bills both `auto_apply_credit`: bill 1 settles
+    from the credit; bill 2 takes the remaining $50 and stays $50
+    outstanding; the credit is exhausted."""
+    runner = CliRunner()
+    gf = _book_with_credit(runner, tmp_path)
+    assert _credit(gf, 'V-MB') == 150.00
+
+    r = _import(runner, gf, _fx('credit_two_bills_both_flagged.txt'),
+                'two.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+
+    assert _lot(gf, 'BILL-MB-1') == 0.00, 'first bill fully paid from credit'
+    assert _lot(gf, 'BILL-MB-2') == -50.00, 'second bill partial — credit ran out'
+    assert _credit(gf, 'V-MB') == 0.00, 'credit fully consumed'
+
+
+def test_credit_full_first_bill_credit_plus_cash_settle_second(tmp_path):
+    """$150 credit + a $50 cash payment settle two $100 bills: the credit
+    fully pays bill 1 and half of bill 2, the $50 cash covers bill 2's
+    rest. Both bills settle, credit exhausted."""
+    runner = CliRunner()
+    gf = _book_with_credit(runner, tmp_path)
+    assert _credit(gf, 'V-MB') == 150.00
+
+    r = _import(runner, gf, _fx('credit_two_bills_second_has_cash.txt'),
+                'two.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+
+    assert _lot(gf, 'BILL-MBC-1') == 0.00, 'first bill fully paid from credit'
+    assert _lot(gf, 'BILL-MBC-2') == 0.00, 'second bill: 50 credit + 50 cash'
+    assert _credit(gf, 'V-MB') == 0.00, 'credit fully consumed'

--- a/tests/integration/test_credit_consumption_across_invoices.py
+++ b/tests/integration/test_credit_consumption_across_invoices.py
@@ -1,0 +1,114 @@
+"""A customer credit consumed across TWO invoices — the AR mirror of
+test_credit_consumption_across_bills.py.
+
+Customer C-MB holds a $150 pre-payment credit (from an earlier
+overpayment). Two follow-on invoices each carry `auto_apply_credit: true`,
+so the credit is drawn down across both in posting order:
+
+  * credit spans two invoices, the second goes partial when it runs out:
+    invoice 1 ($100) settles fully from the credit, invoice 2 ($100) takes
+    the remaining $50 and stays $50 outstanding (AR lot +50 — still owed to
+    us, the sign-inverse of the bill case); the credit hits $0.
+  * credit + one cash payment settle two invoices: the credit fully pays
+    invoice 1 and half of invoice 2, and a $50 cash payment on invoice 2
+    covers the rest — both settled, credit $0.
+"""
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURES = Path('tests/fixtures')
+ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
+
+
+def _fx(name):
+    return (FIXTURES / name).read_text()
+
+
+def _import(runner, gf, text, name, tmp_path):
+    p = tmp_path / name
+    p.write_text(text)
+    return runner.invoke(cli, ['import', str(gf), str(p),
+                               '--include-business-objects'])
+
+
+def _book_with_credit(runner, tmp_path):
+    """Fresh book → accounts → primer that leaves C-MB a $150 customer credit."""
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS])
+    assert r.exit_code == 0, r.output
+    r = _import(runner, gf, _fx('credit_primer_invoice_150.txt'),
+                'primer.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+    return gf
+
+
+def _lot(gf, invoice_id):
+    """The invoice's posted AR-lot balance (0 settled, positive still owed)."""
+    import gnucash.gnucash_business as gb
+    from gnucash import Query
+
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        q = Query()
+        q.search_for('gncInvoice')
+        q.set_book(repo.book)
+        inv = next((gb.Invoice(instance=r) for r in q.run()
+                    if gb.Invoice(instance=r).GetID() == invoice_id), None)
+        q.destroy()
+        assert inv is not None, f'{invoice_id!r} not found'
+        lot = inv.GetPostedLot()
+        assert lot is not None, f'{invoice_id!r} not posted'
+        return round(lot.get_balance().to_double(), 2)
+    finally:
+        repo.close()
+
+
+def _credit(gf, customer_id):
+    from repositories.gnucash_repository import GnuCashRepository
+    from use_cases.unpost_business_objects import find_prepayments_in_book
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        return round(sum(float(c.amount) for c in find_prepayments_in_book(
+            repo.book, customer_id=customer_id)), 2)
+    finally:
+        repo.close()
+
+
+def test_credit_spans_two_invoices_second_goes_partial(tmp_path):
+    """$150 credit, two $100 invoices both `auto_apply_credit`: invoice 1
+    settles from the credit; invoice 2 takes the remaining $50 and stays
+    $50 outstanding (AR lot +50); the credit is exhausted."""
+    runner = CliRunner()
+    gf = _book_with_credit(runner, tmp_path)
+    assert _credit(gf, 'C-MB') == 150.00
+
+    r = _import(runner, gf, _fx('credit_two_invoices_both_flagged.txt'),
+                'two.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+
+    assert _lot(gf, 'INV-MB-1') == 0.00, 'first invoice fully paid from credit'
+    assert _lot(gf, 'INV-MB-2') == 50.00, 'second invoice partial — credit ran out'
+    assert _credit(gf, 'C-MB') == 0.00, 'credit fully consumed'
+
+
+def test_credit_full_first_invoice_credit_plus_cash_settle_second(tmp_path):
+    """$150 credit + a $50 cash payment settle two $100 invoices: the credit
+    fully pays invoice 1 and half of invoice 2, the $50 cash covers invoice
+    2's rest. Both settle, credit exhausted."""
+    runner = CliRunner()
+    gf = _book_with_credit(runner, tmp_path)
+    assert _credit(gf, 'C-MB') == 150.00
+
+    r = _import(runner, gf, _fx('credit_two_invoices_second_has_cash.txt'),
+                'two.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+
+    assert _lot(gf, 'INV-MBC-1') == 0.00, 'first invoice fully paid from credit'
+    assert _lot(gf, 'INV-MBC-2') == 0.00, 'second invoice: 50 credit + 50 cash'
+    assert _credit(gf, 'C-MB') == 0.00, 'credit fully consumed'

--- a/tests/integration/test_overpayment_partial_payment_with_and_without_tax.py
+++ b/tests/integration/test_overpayment_partial_payment_with_and_without_tax.py
@@ -1,0 +1,166 @@
+"""Overpayment and partial payment, WITH and WITHOUT tax, on bills and invoices.
+
+The payment machinery works against the *payable total*, which for a taxed
+record is net + tax. This module pins that for all four combinations
+(overpay / partial × taxed / untaxed) on both sides, using a fresh
+`ApplyPayment` (a `payment:` block with no `txn_guid:`):
+
+  taxed  record: net 100 + GST 5% + PST 7% = 112 total
+  untaxed record: 100 total
+
+  overpay: pay 150 → record lot closes at 0; the residual opens a credit
+           lot (150 − total): taxed 38, untaxed 50.
+  partial: pay 60  → record lot stays open at the shortfall (total − 60):
+           taxed 52, untaxed 40 (AP negative for bills, AR positive for
+           invoices).
+
+The link-existing-tx path and unapply/re-link are covered in
+test_taxed_bill_mixed_payment_unapply_and_relink.py.
+"""
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURES = Path('tests/fixtures')
+ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
+
+
+def _book(runner, tmp_path, fixture_name):
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS])
+    assert r.exit_code == 0, f'accounts: {r.output}'
+    fx = tmp_path / fixture_name
+    fx.write_text((FIXTURES / fixture_name).read_text())
+    r = runner.invoke(cli, ['import', str(gf), str(fx),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f'{fixture_name}: {r.output}'
+    return gf
+
+
+def _find(repo, obj_id):
+    import gnucash.gnucash_business as gb
+    from gnucash import Query
+    q = Query()
+    try:
+        q.search_for('gncInvoice')
+        q.set_book(repo.book)
+        return next((i for raw in q.run() for i in [gb.Invoice(instance=raw)]
+                     if i.GetID() == obj_id), None)
+    finally:
+        q.destroy()
+
+
+def _posted_lot_balance(gf, obj_id):
+    """The record's own posted-lot balance: 0 when settled, and the signed
+    shortfall while still owed (AP negative for bills, AR positive for
+    invoices)."""
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        obj = _find(repo, obj_id)
+        assert obj is not None, f'{obj_id!r} not found'
+        lot = obj.GetPostedLot()
+        assert lot is not None, f'{obj_id!r} not posted'
+        return round(lot.get_balance().to_double(), 2)
+    finally:
+        repo.close()
+
+
+def _owner_credit_total(gf, *, vendor_id=None, customer_id=None):
+    """Sum of open pre-payment credit lots for the owner (0 if none)."""
+    from repositories.gnucash_repository import GnuCashRepository
+    from use_cases.unpost_business_objects import find_prepayments_in_book
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        credits_ = find_prepayments_in_book(
+            repo.book, customer_id=customer_id, vendor_id=vendor_id)
+        return round(sum(float(c.amount) for c in credits_), 2)
+    finally:
+        repo.close()
+
+
+def _export(runner, gf, tmp_path):
+    out = tmp_path / 'export.txt'
+    r = runner.invoke(cli, ['export', str(gf), str(out),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    return out.read_text()
+
+
+# ── Bills — overpayment ────────────────────────────────────────────
+
+def test_taxed_bill_overpayment_credit_is_residual_over_tax_inclusive_total(tmp_path):
+    """Taxed bill total 112 paid 150: bill lot closes, vendor credit = 38."""
+    runner = CliRunner()
+    gf = _book(runner, tmp_path, 'overpay_partial_taxed_bills.txt')
+    assert _posted_lot_balance(gf, 'BILL-TAX-OVER-112') == 0.00
+    assert _owner_credit_total(gf, vendor_id='V-TAX-BILL') == 38.00
+    exported = _export(runner, gf, tmp_path)
+    assert 'prepayment: 38.00' in exported, exported
+
+
+def test_untaxed_bill_overpayment_credit_is_residual_over_total(tmp_path):
+    """Untaxed bill total 100 paid 150: bill lot closes, vendor credit = 50."""
+    runner = CliRunner()
+    gf = _book(runner, tmp_path, 'overpay_partial_untaxed_bills.txt')
+    assert _posted_lot_balance(gf, 'BILL-NOTAX-OVER-100') == 0.00
+    assert _owner_credit_total(gf, vendor_id='V-NOTAX-BILL') == 50.00
+    exported = _export(runner, gf, tmp_path)
+    assert 'prepayment: 50.00' in exported, exported
+
+
+# ── Bills — partial payment ────────────────────────────────────────
+
+def test_taxed_bill_partial_outstanding_against_tax_inclusive_total(tmp_path):
+    """Taxed bill total 112 paid 60: AP lot open at -52; no credit."""
+    runner = CliRunner()
+    gf = _book(runner, tmp_path, 'overpay_partial_taxed_bills.txt')
+    assert _posted_lot_balance(gf, 'BILL-TAX-PART-112') == -52.00
+    assert _owner_credit_total(gf, vendor_id='V-TAX-BILL') == 38.00  # only the OVER bill's credit
+
+
+def test_untaxed_bill_partial_outstanding_against_total(tmp_path):
+    """Untaxed bill total 100 paid 60: AP lot open at -40."""
+    runner = CliRunner()
+    gf = _book(runner, tmp_path, 'overpay_partial_untaxed_bills.txt')
+    assert _posted_lot_balance(gf, 'BILL-NOTAX-PART-100') == -40.00
+
+
+# ── Invoices — overpayment ─────────────────────────────────────────
+
+def test_taxed_invoice_overpayment_credit_is_residual_over_tax_inclusive_total(tmp_path):
+    """Taxed invoice total 112 paid 150: invoice lot closes, customer credit = 38."""
+    runner = CliRunner()
+    gf = _book(runner, tmp_path, 'overpay_partial_taxed_invoices.txt')
+    assert _posted_lot_balance(gf, 'INV-TAX-OVER-112') == 0.00
+    assert _owner_credit_total(gf, customer_id='C-TAX-INV') == 38.00
+    exported = _export(runner, gf, tmp_path)
+    assert 'prepayment: 38.00' in exported, exported
+
+
+def test_untaxed_invoice_overpayment_credit_is_residual_over_total(tmp_path):
+    """Untaxed invoice total 100 paid 150: invoice lot closes, customer credit = 50."""
+    runner = CliRunner()
+    gf = _book(runner, tmp_path, 'overpay_partial_untaxed_invoices.txt')
+    assert _posted_lot_balance(gf, 'INV-NOTAX-OVER-100') == 0.00
+    assert _owner_credit_total(gf, customer_id='C-NOTAX-INV') == 50.00
+
+
+# ── Invoices — partial payment ─────────────────────────────────────
+
+def test_taxed_invoice_partial_outstanding_against_tax_inclusive_total(tmp_path):
+    """Taxed invoice total 112 paid 60: AR lot open at +52 (still owed to us)."""
+    runner = CliRunner()
+    gf = _book(runner, tmp_path, 'overpay_partial_taxed_invoices.txt')
+    assert _posted_lot_balance(gf, 'INV-TAX-PART-112') == 52.00
+
+
+def test_untaxed_invoice_partial_outstanding_against_total(tmp_path):
+    """Untaxed invoice total 100 paid 60: AR lot open at +40."""
+    runner = CliRunner()
+    gf = _book(runner, tmp_path, 'overpay_partial_untaxed_invoices.txt')
+    assert _posted_lot_balance(gf, 'INV-NOTAX-PART-100') == 40.00

--- a/tests/integration/test_prepayment_settlement.py
+++ b/tests/integration/test_prepayment_settlement.py
@@ -117,13 +117,32 @@ def _balances(gf, names=('Assets.Bank', 'Assets.Accounts Receivable',
 # --------------------------------------------------------------------------
 
 def test_customer_refund_closes_credit(tmp_path):
+    """Customer overpaid (−$50 open AR credit — money we hold and owe back);
+    they ask for it and we refund. The four refund questions, all asserted:
+    (1) the credit lot closes; (2) $50 moves Bank → AR (the −50 credit
+    clears to 0); (3) it is NOT an expense and NOT a reduction of income —
+    only Bank and AR move; (4) the overpayment was in effect a liability,
+    carried as a credit ON Accounts Receivable, settled in cash."""
     runner = CliRunner()
     gf = _setup_customer_credit(runner, tmp_path)
     assert any(not lt['closed'] and lt['balance'] == -50.0
                for lt in _lots(gf, 'Assets.Accounts Receivable'))
+    accts = ('Assets.Bank', 'Assets.Accounts Receivable', 'Income.Sales',
+             'Expenses.Supplies')
+    before = _balances(gf, accts)
     r = _import_fixture(runner, gf, 'q_refund_prepayment.txt', tmp_path)
     assert r.exit_code == 0, r.output
+    after = _balances(gf, accts)
+    # (1) credit lot closed
     assert _open_nonzero(_lots(gf, 'Assets.Accounts Receivable')) == []
+    # (2) $50 out of the bank; (2)+(4) the AR credit reduced to exactly zero
+    assert round(after['Assets.Bank'] - before['Assets.Bank'], 2) == -50.0
+    assert round(after['Assets.Accounts Receivable']
+                 - before['Assets.Accounts Receivable'], 2) == 50.0
+    assert round(after['Assets.Accounts Receivable'], 2) == 0.0
+    # (3) NOT an expense and NOT income — nothing else moved
+    assert after['Expenses.Supplies'] == before['Expenses.Supplies']
+    assert after['Income.Sales'] == before['Income.Sales']
 
 
 def test_customer_forfeit_to_income_closes_credit(tmp_path):
@@ -137,13 +156,32 @@ def test_customer_forfeit_to_income_closes_credit(tmp_path):
 
 
 def test_vendor_refund_received_closes_credit(tmp_path):
+    """We overpaid a vendor (+$50 open AP credit — a receivable; the vendor
+    owes us); the vendor refunds us. (1) the credit lot closes; (2) $50
+    moves AP → Bank (the +50 credit clears to 0, cash arrives); (3) it is
+    NOT an expense — the bill's original $100 expense is untouched;
+    (4) the overpayment was in effect a receivable, carried as a credit ON
+    Accounts Payable, collected in cash."""
     runner = CliRunner()
     gf = _setup_vendor_credit(runner, tmp_path)
     assert any(not lt['closed'] and lt['balance'] == 50.0
                for lt in _lots(gf, 'Liabilities.Accounts Payable'))
+    accts = ('Assets.Bank', 'Liabilities.Accounts Payable', 'Income.Sales',
+             'Expenses.Supplies')
+    before = _balances(gf, accts)
     r = _import_fixture(runner, gf, 'q_vendor_refund.txt', tmp_path)
     assert r.exit_code == 0, r.output
+    after = _balances(gf, accts)
+    # (1) credit lot closed
     assert _open_nonzero(_lots(gf, 'Liabilities.Accounts Payable')) == []
+    # (2) $50 into the bank; (2)+(4) the AP credit reduced to exactly zero
+    assert round(after['Assets.Bank'] - before['Assets.Bank'], 2) == 50.0
+    assert round(after['Liabilities.Accounts Payable']
+                 - before['Liabilities.Accounts Payable'], 2) == -50.0
+    assert round(after['Liabilities.Accounts Payable'], 2) == 0.0
+    # (3) NOT an expense — the $100 bill expense is unchanged by the refund
+    assert after['Expenses.Supplies'] == before['Expenses.Supplies']
+    assert after['Income.Sales'] == before['Income.Sales']
 
 
 def test_vendor_bad_debt_writes_off_credit(tmp_path):

--- a/tests/integration/test_tax_included_pricing.py
+++ b/tests/integration/test_tax_included_pricing.py
@@ -1,0 +1,323 @@
+"""`tax_included: true` (tax-INCLUSIVE pricing) coverage — invoices & bills.
+
+When an entry declares `tax_included: true`, the entered price already
+contains the tax; the renderers and the importer back the net amount out
+with `net = gross / (1 + total_rate)`. This is the one tax branch that had
+no fixture/test. With a GST 5% + PST 7% table (12% total) and a gross of
+1120:
+
+    net (subtotal) = 1120 / 1.12 = 1000.00
+    GST 5% of 1000 =                 50.00
+    PST 7% of 1000 =                 70.00
+    tax total      =                120.00
+    grand total    =               1120.00   (unchanged — tax was inside)
+
+Contrast (locks in the back-out): the SAME entered 1120 with
+`tax_included: false` would be subtotal 1120, GST 56, PST 78.40, total
+1254.40. So the exact 1000/50/70/1120 assertions below catch a regression
+in the gross → net back-out.
+
+The draft-render tests exercise `compute_entry_informational` /
+`compute_bill_entry_informational` (the pre-posting back-out). The
+posted-split tests exercise GnuCash's own posting-time back-out (the entry
+flag reaching the engine), then prove `tax_included: true` survives an
+export → fresh-book re-import unchanged.
+"""
+from pathlib import Path
+
+import gnucash.gnucash_business as gb
+from click.testing import CliRunner
+from gnucash import Query
+
+from cli.main import cli
+from infrastructure.gnucash.utils import get_account_full_name
+from repositories.gnucash_repository import GnuCashRepository
+
+FIXTURES = Path('tests/fixtures')
+ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
+
+
+def _fx(name):
+    return (FIXTURES / name).read_text()
+
+
+def _import_into_fresh_book(runner, tmp_path, fixture_name):
+    """Fresh book → accounts → the given tax_included fixture (business
+    objects). Drives the real import pipeline; no GnuCash-type mocking."""
+    gnc = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gnc), ACCOUNTS])
+    assert r.exit_code == 0, f'accounts: {r.output}'
+    fx_path = tmp_path / fixture_name
+    fx_path.write_text(_fx(fixture_name))
+    r = runner.invoke(cli, ['import', str(gnc), str(fx_path),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f'{fixture_name}: {r.output}'
+    return gnc
+
+
+def _find_business_object(repo, business_id):
+    """Look up an invoice OR bill by id (both are gncInvoice QOF objects)."""
+    q = Query()
+    try:
+        q.search_for('gncInvoice')
+        q.set_book(repo.book)
+        return next(
+            (i for raw in q.run() for i in [gb.Invoice(instance=raw)]
+             if i.GetID() == business_id),
+            None,
+        )
+    finally:
+        q.destroy()
+
+
+def _posting_tx_splits(gnc_path, business_id):
+    """Return {account_full_name: rounded signed amount} for the posting
+    transaction of the given invoice/bill id — the real materialised
+    posting splits, so the tax back-out done by GnuCash at post time is
+    observed, not assumed."""
+    repo = GnuCashRepository(str(gnc_path))
+    repo.open()
+    try:
+        inv = _find_business_object(repo, business_id)
+        assert inv is not None, f'{business_id!r} not found in book'
+        tx = inv.GetPostedTxn()
+        assert tx is not None, f'{business_id!r} is not posted'
+        splits = {}
+        for i in range(tx.CountSplits()):
+            sp = tx.GetSplit(i)
+            name = get_account_full_name(sp.GetAccount())
+            splits[name] = round(
+                splits.get(name, 0.0) + sp.GetAmount().to_double(), 2)
+        return splits
+    finally:
+        repo.close()
+
+
+def _first_entry_tax_included(gnc_path, business_id, is_bill):
+    """Read the tax_included flag straight off the first entry of the
+    re-imported invoice/bill — proves the flag round-tripped into the
+    engine, not just into the exported text."""
+    repo = GnuCashRepository(str(gnc_path))
+    repo.open()
+    try:
+        inv = _find_business_object(repo, business_id)
+        assert inv is not None, f'{business_id!r} not found in book'
+        entry = list(inv.GetEntries())[0]
+        return bool(
+            entry.GetBillTaxIncluded() if is_bill
+            else entry.GetInvTaxIncluded())
+    finally:
+        repo.close()
+
+
+# ── Draft render: invoice ──────────────────────────────────────────
+
+def test_tax_included_invoice_draft_plaintext_backs_out_net_and_tax(tmp_path):
+    """Unposted invoice, gross 1120, tax_included: true. `print-invoice
+    --format plaintext` must back the net out to 1000: entry_amount
+    1000.00, entry_tax 120.00, GST 50.00 / PST 70.00 breakdown, and
+    invoice_subtotal/tax_total/total = 1000/120/1120."""
+    runner = CliRunner()
+    gnc = _import_into_fresh_book(runner, tmp_path, 'tax_included_invoice.txt')
+    out = tmp_path / 'inv.txt'
+    r = runner.invoke(cli, ['print-invoice', str(gnc), 'INV-TAXINCL-1120',
+                            '--format', 'plaintext', '-o', str(out)])
+    assert r.exit_code == 0, f'print-invoice: {r.output}'
+    text = out.read_text()
+
+    assert 'tax_included: true' in text, f'flag not rendered:\n{text}'
+    assert 'entry_amount: 1000.00' in text, f'net back-out wrong:\n{text}'
+    assert 'entry_tax: 120.00' in text, f'tax wrong:\n{text}'
+    assert 'account: "Liabilities:Tax:GST"' in text
+    assert 'account: "Liabilities:Tax:PST"' in text
+    assert 'amount: 50.00' in text, f'GST 5% of 1000 = 50.00:\n{text}'
+    assert 'amount: 70.00' in text, f'PST 7% of 1000 = 70.00:\n{text}'
+    assert 'invoice_subtotal: 1000.00' in text
+    assert 'invoice_tax_total: 120.00' in text
+    assert 'invoice_total: 1120.00' in text
+    # Anti-regression: a lost back-out would make subtotal the gross 1120.
+    assert 'invoice_subtotal: 1120.00' not in text
+    # Unposted → provisional caveat.
+    assert '# Tax figures are provisional' in text
+
+
+def test_tax_included_invoice_draft_html_backs_out_net_and_tax(tmp_path):
+    """Same invoice rendered to HTML: GST/PST rows show $50.00/$70.00,
+    Subtotal is the net CAD 1,000.00, grand total the unchanged gross
+    CAD 1,120.00, plus the provisional notice."""
+    runner = CliRunner()
+    gnc = _import_into_fresh_book(runner, tmp_path, 'tax_included_invoice.txt')
+    out = tmp_path / 'inv.html'
+    r = runner.invoke(cli, ['print-invoice', str(gnc), 'INV-TAXINCL-1120',
+                            '--format', 'html', '-o', str(out)])
+    assert r.exit_code == 0, f'print-invoice: {r.output}'
+    html = out.read_text()
+
+    assert '>GST<' in html and '>PST<' in html
+    assert '$50.00' in html, f'GST tax line $50.00 missing:\n{html}'
+    assert '$70.00' in html, f'PST tax line $70.00 missing:\n{html}'
+    assert ('CAD\xa01,000.00' in html or 'CAD&#160;1,000.00' in html
+            or 'CAD 1,000.00' in html), f'net subtotal missing:\n{html[-2500:]}'
+    assert ('CAD\xa01,120.00' in html or 'CAD&#160;1,120.00' in html
+            or 'CAD 1,120.00' in html), f'grand total missing:\n{html[-2500:]}'
+    assert 'provisional' in html.lower()
+
+
+# ── Draft render: bill ─────────────────────────────────────────────
+
+def test_tax_included_bill_draft_plaintext_backs_out_net_and_tax(tmp_path):
+    """Unposted bill, gross 1120, tax_included: true. `print-bill
+    --format plaintext` must back the net out identically to the invoice
+    side: entry_amount 1000.00, entry_tax 120.00, GST 50 / PST 70, and
+    bill_subtotal/tax_total/total = 1000/120/1120."""
+    runner = CliRunner()
+    gnc = _import_into_fresh_book(runner, tmp_path, 'tax_included_bill.txt')
+    out = tmp_path / 'bill.txt'
+    r = runner.invoke(cli, ['print-bill', str(gnc), 'BILL-TAXINCL-1120',
+                            '--format', 'plaintext', '-o', str(out)])
+    assert r.exit_code == 0, f'print-bill: {r.output}'
+    text = out.read_text()
+
+    assert 'tax_included: true' in text, f'flag not rendered:\n{text}'
+    assert 'entry_amount: 1000.00' in text, f'net back-out wrong:\n{text}'
+    assert 'entry_tax: 120.00' in text, f'tax wrong:\n{text}'
+    assert 'account: "Liabilities:Tax:GST"' in text
+    assert 'account: "Liabilities:Tax:PST"' in text
+    assert 'amount: 50.00' in text, f'GST 5% of 1000 = 50.00:\n{text}'
+    assert 'amount: 70.00' in text, f'PST 7% of 1000 = 70.00:\n{text}'
+    assert 'bill_subtotal: 1000.00' in text
+    assert 'bill_tax_total: 120.00' in text
+    assert 'bill_total: 1120.00' in text
+    assert 'bill_subtotal: 1120.00' not in text
+    assert '# Tax figures are provisional' in text
+
+
+def test_tax_included_bill_draft_html_backs_out_net_and_tax(tmp_path):
+    """Same bill rendered to HTML: GST/PST rows $50.00/$70.00, net
+    Subtotal CAD 1,000.00, grand total the unchanged gross CAD 1,120.00,
+    provisional notice."""
+    runner = CliRunner()
+    gnc = _import_into_fresh_book(runner, tmp_path, 'tax_included_bill.txt')
+    out = tmp_path / 'bill.html'
+    r = runner.invoke(cli, ['print-bill', str(gnc), 'BILL-TAXINCL-1120',
+                            '--format', 'html', '-o', str(out)])
+    assert r.exit_code == 0, f'print-bill: {r.output}'
+    html = out.read_text()
+
+    assert '>GST<' in html and '>PST<' in html
+    assert '$50.00' in html, f'GST tax line $50.00 missing:\n{html}'
+    assert '$70.00' in html, f'PST tax line $70.00 missing:\n{html}'
+    assert ('CAD\xa01,000.00' in html or 'CAD&#160;1,000.00' in html
+            or 'CAD 1,000.00' in html), f'net subtotal missing:\n{html[-2500:]}'
+    assert ('CAD\xa01,120.00' in html or 'CAD&#160;1,120.00' in html
+            or 'CAD 1,120.00' in html), f'grand total missing:\n{html[-2500:]}'
+    assert 'provisional' in html.lower()
+
+
+# ── Posted round-trip: invoice ─────────────────────────────────────
+
+def test_tax_included_invoice_posted_splits_back_out_tax(tmp_path):
+    """Posted invoice (4 × 280 gross = 1120, tax_included: true). GnuCash
+    materialises the posting splits with the tax backed out: AR +1120,
+    Income −1000, GST −50, PST −70 (balanced)."""
+    runner = CliRunner()
+    gnc = _import_into_fresh_book(
+        runner, tmp_path, 'tax_included_invoice_posted.txt')
+    splits = _posting_tx_splits(gnc, 'INV-TAXINCL-POSTED-1120')
+
+    assert splits.get('Assets:Accounts Receivable') == 1120.00, splits
+    assert splits.get('Income:Sales') == -1000.00, splits
+    assert splits.get('Liabilities:Tax:GST') == -50.00, splits
+    assert splits.get('Liabilities:Tax:PST') == -70.00, splits
+    assert round(sum(splits.values()), 2) == 0.00, splits
+
+
+def test_tax_included_invoice_survives_export_reimport(tmp_path):
+    """Posted tax_included invoice → export → fresh-book re-import. The
+    exporter emits `tax_included: true` and the backed-out informational
+    totals; the importer's recompute/tamper-check passes; the flag and
+    the 1000/50/70/1120 posting semantics are identical in the dest
+    book."""
+    runner = CliRunner()
+    gnc = _import_into_fresh_book(
+        runner, tmp_path, 'tax_included_invoice_posted.txt')
+
+    exported = tmp_path / 'exported.txt'
+    r = runner.invoke(cli, ['export', str(gnc), str(exported),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f'export: {r.output}'
+    exported_text = exported.read_text()
+    # The canonical business-object export carries the source-of-truth
+    # fields (incl. `tax_included: true`) rather than the print-only
+    # informational totals; preservation of the 1000/50/70/1120 semantics
+    # is proven below via the re-imported posting splits.
+    assert 'tax_included: true' in exported_text, exported_text
+    assert 'price: 280' in exported_text and 'quantity: 4' in exported_text, (
+        exported_text)
+
+    dst = tmp_path / 'dst.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(dst), str(exported),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f're-import (recompute/tamper-check): {r.output}'
+
+    assert _first_entry_tax_included(
+        dst, 'INV-TAXINCL-POSTED-1120', is_bill=False) is True
+    splits = _posting_tx_splits(dst, 'INV-TAXINCL-POSTED-1120')
+    assert splits.get('Assets:Accounts Receivable') == 1120.00, splits
+    assert splits.get('Income:Sales') == -1000.00, splits
+    assert splits.get('Liabilities:Tax:GST') == -50.00, splits
+    assert splits.get('Liabilities:Tax:PST') == -70.00, splits
+
+
+# ── Posted round-trip: bill ────────────────────────────────────────
+
+def test_tax_included_bill_posted_splits_back_out_tax(tmp_path):
+    """Posted bill (4 × 280 gross = 1120, tax_included: true). GnuCash
+    materialises the AP posting splits with the tax backed out and the
+    OPPOSITE sign to an invoice: AP −1120, Expense +1000, GST +50,
+    PST +70 (balanced)."""
+    runner = CliRunner()
+    gnc = _import_into_fresh_book(
+        runner, tmp_path, 'tax_included_bill_posted.txt')
+    splits = _posting_tx_splits(gnc, 'BILL-TAXINCL-POSTED-1120')
+
+    assert splits.get('Liabilities:Accounts Payable') == -1120.00, splits
+    assert splits.get('Expenses:Office Supplies') == 1000.00, splits
+    assert splits.get('Liabilities:Tax:GST') == 50.00, splits
+    assert splits.get('Liabilities:Tax:PST') == 70.00, splits
+    assert round(sum(splits.values()), 2) == 0.00, splits
+
+
+def test_tax_included_bill_survives_export_reimport(tmp_path):
+    """Posted tax_included bill → export → fresh-book re-import. The
+    exporter emits `tax_included: true` and the backed-out bill_*
+    informational totals; the flag and the AP posting semantics
+    (−1120 / +1000 / +50 / +70) are identical in the dest book."""
+    runner = CliRunner()
+    gnc = _import_into_fresh_book(
+        runner, tmp_path, 'tax_included_bill_posted.txt')
+
+    exported = tmp_path / 'exported.txt'
+    r = runner.invoke(cli, ['export', str(gnc), str(exported),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f'export: {r.output}'
+    exported_text = exported.read_text()
+    # Export carries `tax_included: true` (source-of-truth); the
+    # 1000/50/70/1120 AP semantics are proven below via the re-imported
+    # posting splits.
+    assert 'tax_included: true' in exported_text, exported_text
+    assert 'price: 280' in exported_text and 'quantity: 4' in exported_text, (
+        exported_text)
+
+    dst = tmp_path / 'dst.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(dst), str(exported),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f're-import: {r.output}'
+
+    assert _first_entry_tax_included(
+        dst, 'BILL-TAXINCL-POSTED-1120', is_bill=True) is True
+    splits = _posting_tx_splits(dst, 'BILL-TAXINCL-POSTED-1120')
+    assert splits.get('Liabilities:Accounts Payable') == -1120.00, splits
+    assert splits.get('Expenses:Office Supplies') == 1000.00, splits
+    assert splits.get('Liabilities:Tax:GST') == 50.00, splits
+    assert splits.get('Liabilities:Tax:PST') == 70.00, splits

--- a/tests/integration/test_taxed_bill_mixed_payment_unapply_and_relink.py
+++ b/tests/integration/test_taxed_bill_mixed_payment_unapply_and_relink.py
@@ -1,0 +1,361 @@
+"""A taxed bill paid by a MIX of a fresh payment and a linked bank tx, then
+peeled apart with `unapply-payment` and re-linked.
+
+The bill: net 1000 + GST 5% ($50) + PST 7% ($70) = $1120 total. It is
+settled by two partial payments of different kinds:
+
+  * payment 1 — a fresh `ApplyPayment` of $1000 (no `txn_guid:`), which
+    mints its own bank transaction,
+  * payment 2 — a LINK of a pre-existing $120 bank transaction (a
+    `payment:` block whose `txn_guid:` retargets that tx's AP split into
+    the bill's lot).
+
+From the fully-paid state this module exercises the real correction
+workflows a user hits:
+
+  * unapply only the linked $120 (they linked the wrong tx) → bill drops
+    to partially-paid with $120 outstanding, the $120 bank tx survives,
+  * unapply BOTH (`--all`) → bill fully outstanding at $1120,
+  * unapply only the fresh $1000 → the linked $120 stays applied,
+  * unapply the $1000 then LINK a different pre-existing $1000 bank tx →
+    bill settled again by the new tx.
+
+Sign convention (AP, per CLAUDE.md §7): the bill posts CR AP −1120; each
+payment is DR AP +N into the lot; the posted-lot balance is 0 when
+settled and negative while still owed.
+"""
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURES = Path('tests/fixtures')
+ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
+TO = 'Liabilities'  # re-home freed splits here (any account type is accepted)
+
+
+def _fx(name):
+    return (FIXTURES / name).read_text()
+
+
+def _bank_tx_guid(gf, amount):
+    """GUID of the bank transaction whose Assets:Bank split == amount."""
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        from infrastructure.gnucash.utils import get_account_full_name
+
+        def find(a, name):
+            if get_account_full_name(a) == name:
+                return a
+            for c in a.get_children():
+                g = find(c, name)
+                if g:
+                    return g
+            return None
+        bank = find(repo.book.get_root_account(), 'Assets:Bank')
+        for s in bank.GetSplitList():
+            if round(s.GetAmount().to_double(), 2) == round(amount, 2):
+                return s.GetParent().GetGUID().to_string()
+        return None
+    finally:
+        repo.close()
+
+
+def _posted_lot_balance(gf, bill_id):
+    import gnucash.gnucash_business as gb
+    from gnucash import Query
+
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        q = Query()
+        q.search_for('gncInvoice')
+        q.set_book(repo.book)
+        bill = next((gb.Invoice(instance=r) for r in q.run()
+                     if gb.Invoice(instance=r).GetID() == bill_id), None)
+        q.destroy()
+        assert bill is not None, f'{bill_id!r} not found'
+        lot = bill.GetPostedLot()
+        assert lot is not None, f'{bill_id!r} not posted'
+        return round(lot.get_balance().to_double(), 2)
+    finally:
+        repo.close()
+
+
+def _bank_tx_count(gf):
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        from infrastructure.gnucash.utils import get_account_full_name
+
+        def find(a, name):
+            if get_account_full_name(a) == name:
+                return a
+            for c in a.get_children():
+                g = find(c, name)
+                if g:
+                    return g
+            return None
+        bank = find(repo.book.get_root_account(), 'Assets:Bank')
+        return len({s.GetParent().GetGUID().to_string()
+                    for s in bank.GetSplitList()})
+    finally:
+        repo.close()
+
+
+def _vendor_credit_total(gf, vendor_id):
+    """Sum of the vendor's open pre-payment credit lots."""
+    from repositories.gnucash_repository import GnuCashRepository
+    from use_cases.unpost_business_objects import find_prepayments_in_book
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        return round(sum(float(c.amount) for c in find_prepayments_in_book(
+            repo.book, vendor_id=vendor_id)), 2)
+    finally:
+        repo.close()
+
+
+def _import(runner, gf, text, name, tmp_path, biz=True):
+    p = tmp_path / name
+    p.write_text(text)
+    args = ['import', str(gf), str(p)]
+    if biz:
+        args.append('--include-business-objects')
+    return runner.invoke(cli, args)
+
+
+def _setup_fully_paid(runner, tmp_path):
+    """Fresh book → accounts → pre-existing $120 bank tx → hero bill whose
+    two payments are a fresh $1000 and a link of that $120 tx. Returns
+    (gf, guid_1000_fresh, guid_120_linked)."""
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS])
+    assert r.exit_code == 0, r.output
+
+    # Pre-existing $120 outgoing bank tx (Assets:Bank -120 / AP +120).
+    r = _import(runner, gf, _fx('hero_bank_tx_120.txt'), 'bank120.txt',
+                tmp_path, biz=False)
+    assert r.exit_code == 0, r.output
+    guid_120 = _bank_tx_guid(gf, -120.0)
+    assert guid_120 is not None
+
+    # Bill: fresh $1000 payment + linked $120 payment (retargets the tx above).
+    bill_text = _fx('hero_taxed_bill_1120.txt').replace('{txn_guid}', guid_120)
+    r = _import(runner, gf, bill_text, 'bill.txt', tmp_path)
+    assert r.exit_code == 0, f'hero bill import: {r.output}'
+    guid_1000 = _bank_tx_guid(gf, -1000.0)
+    assert guid_1000 is not None
+    return gf, guid_1000, guid_120
+
+
+# ── Mixed apply + link settles the taxed bill ──────────────────────
+
+def test_taxed_bill_settled_by_fresh_1000_and_linked_120(tmp_path):
+    """The two-kind payment set (fresh $1000 + linked $120) fully settles
+    the $1120 taxed bill: posted lot balance 0, and the two bank txs
+    (fresh $1000 out + linked $120) are both present."""
+    runner = CliRunner()
+    gf, _guid_1000, _guid_120 = _setup_fully_paid(runner, tmp_path)
+    assert _posted_lot_balance(gf, 'BILL-HERO-1120') == 0.00
+    assert _bank_tx_count(gf) == 2
+
+
+# ── Unapply the linked tax payment (linked the wrong tx) ───────────
+
+def test_unapply_linked_120_leaves_fresh_1000_applied(tmp_path):
+    """Peel only the linked $120: the bill drops to partially-paid with
+    $120 outstanding (AP lot −120), the $1000 stays applied, and the
+    $120 bank tx is re-homed (not deleted)."""
+    runner = CliRunner()
+    gf, _guid_1000, guid_120 = _setup_fully_paid(runner, tmp_path)
+
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'BILL-HERO-1120',
+                            '--bill', '--txn', guid_120, '--to', TO])
+    assert r.exit_code == 0, r.output
+    assert 'unapplied 1 payment' in r.output, r.output
+    assert _posted_lot_balance(gf, 'BILL-HERO-1120') == -120.00
+    assert _bank_tx_count(gf) == 2, 'no bank tx deleted'
+
+
+# ── Unapply BOTH (→ fully outstanding, e.g. to pay from a credit) ──
+
+def test_unapply_all_returns_bill_fully_outstanding(tmp_path):
+    """Peel every payment: the bill returns to fully outstanding at
+    −$1120 (the point from which a prior vendor credit could settle it
+    via `auto_apply_credit: true`)."""
+    runner = CliRunner()
+    gf, _guid_1000, _guid_120 = _setup_fully_paid(runner, tmp_path)
+
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'BILL-HERO-1120',
+                            '--bill', '--all', '--to', TO])
+    assert r.exit_code == 0, r.output
+    assert 'unapplied 2 payments' in r.output, r.output
+    assert _posted_lot_balance(gf, 'BILL-HERO-1120') == -1120.00
+
+
+# ── Unapply the fresh net payment (linked tax stays) ───────────────
+
+def test_unapply_fresh_1000_leaves_linked_120_applied(tmp_path):
+    """Peel only the fresh $1000: the linked $120 stays applied, leaving
+    $1000 outstanding (AP lot −1000)."""
+    runner = CliRunner()
+    gf, guid_1000, _guid_120 = _setup_fully_paid(runner, tmp_path)
+
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'BILL-HERO-1120',
+                            '--bill', '--txn', guid_1000, '--to', TO])
+    assert r.exit_code == 0, r.output
+    assert _posted_lot_balance(gf, 'BILL-HERO-1120') == -1000.00
+
+
+# ── Unapply the fresh $1000, then LINK a different $1000 bank tx ────
+
+def test_unapply_1000_then_relink_to_another_bank_tx(tmp_path):
+    """Unapply the fresh $1000, then settle the re-opened $1000 by LINKING
+    a different pre-existing $1000 bank tx (the 'I applied the wrong bank
+    tx' fix). The bill returns to settled (lot 0) via the new tx, and the
+    original $1000 tx survives (re-homed by the unapply)."""
+    runner = CliRunner()
+    gf, guid_1000, guid_120 = _setup_fully_paid(runner, tmp_path)
+
+    # Peel the fresh $1000 → $1000 outstanding.
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'BILL-HERO-1120',
+                            '--bill', '--txn', guid_1000, '--to', TO])
+    assert r.exit_code == 0, r.output
+    assert _posted_lot_balance(gf, 'BILL-HERO-1120') == -1000.00
+
+    # Import a DIFFERENT pre-existing $1000 outgoing bank tx.
+    new_bank = ('2026-05-20 * "Correct wire for the net 1000"\n'
+                '\tcurrency.mnemonic: "CAD"\n'
+                '\tAssets:Bank -1000.00 CAD\n'
+                '\tLiabilities:Accounts Payable 1000.00 CAD\n')
+    r = _import(runner, gf, new_bank, 'newbank.txt', tmp_path, biz=False)
+    assert r.exit_code == 0, r.output
+    guid_new_1000 = next(g for g in [_bank_tx_guid(gf, -1000.0)] if g)
+
+    # Re-import the bill with BOTH payments: the already-applied $120
+    # (matched by its tx guid) and the new $1000 linked to the new tx.
+    relink = f'''vendor "V-HERO"
+\tname: "Hero Supplier"
+\tcurrency: CAD
+
+bill "BILL-HERO-1120"
+\tvendor_id: "V-HERO"
+\tcurrency: CAD
+\tdate_opened: 2026-05-10
+\tentry:
+\t\tdate: 2026-05-10
+\t\tdescription: "Materials (net 1000 + GST 50 + PST 70 = 1120)"
+\t\taccount: "Expenses:Office Supplies"
+\t\tquantity: 1
+\t\tprice: 1000
+\t\ttaxable: true
+\t\ttax_included: false
+\t\ttax_table: "GST+PST"
+\tposted:
+\t\tdate: 2026-05-10
+\t\tdue: 2026-06-09
+\t\tap_account: "Liabilities:Accounts Payable"
+\t\tmemo: "Bill BILL-HERO-1120"
+\t\taccumulate: true
+\tpayment:
+\t\tdate: 2026-05-15
+\t\tamount: 120
+\t\tbank_account: "Assets:Bank"
+\t\ttxn_guid: "{guid_120}"
+\t\tmemo: "Linked existing bank tx for the 120 tax portion"
+\tpayment:
+\t\tdate: 2026-05-20
+\t\tamount: 1000
+\t\tbank_account: "Assets:Bank"
+\t\ttxn_guid: "{guid_new_1000}"
+\t\tmemo: "Relinked net 1000 to the correct bank tx"
+'''
+    r = _import(runner, gf, relink, 'relink.txt', tmp_path)
+    assert r.exit_code == 0, f'relink import: {r.output}'
+    assert _posted_lot_balance(gf, 'BILL-HERO-1120') == 0.00, 'settled by new tx'
+
+
+# ── Unapply BOTH, then settle the bill from a PRIOR vendor credit ───
+
+def test_unapply_all_then_settle_from_prior_vendor_credit(tmp_path):
+    """The full 'I meant to pay this from the credit' workflow: the vendor
+    already holds a $1200 credit from an earlier overpayment; the $1120
+    bill was paid in cash (fresh $1000 + linked $120); unapply BOTH, then
+    re-import with `auto_apply_credit: true` so the bill is settled from
+    the credit instead. The bill lot closes and the credit drops
+    $1200 → $80."""
+    runner = CliRunner()
+    gf = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS])
+    assert r.exit_code == 0, r.output
+
+    # Prior $1200 vendor credit for V-HERO (earlier bill overpaid).
+    r = _import(runner, gf, _fx('hero_prior_credit_primer.txt'),
+                'primer.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+    assert _vendor_credit_total(gf, 'V-HERO') == 1200.00
+
+    # The $1120 bill, paid in cash: fresh $1000 + linked $120.
+    r = _import(runner, gf, _fx('hero_bank_tx_120.txt'), 'bank120.txt',
+                tmp_path, biz=False)
+    assert r.exit_code == 0, r.output
+    guid_120 = _bank_tx_guid(gf, -120.0)
+    bill_text = _fx('hero_taxed_bill_1120.txt').replace('{txn_guid}', guid_120)
+    r = _import(runner, gf, bill_text, 'bill.txt', tmp_path)
+    assert r.exit_code == 0, r.output
+    assert _posted_lot_balance(gf, 'BILL-HERO-1120') == 0.00
+    assert _vendor_credit_total(gf, 'V-HERO') == 1200.00  # credit untouched by cash
+
+    # Unapply both cash payments → bill fully outstanding again.
+    r = runner.invoke(cli, ['unapply-payment', str(gf), 'BILL-HERO-1120',
+                            '--bill', '--all', '--to', TO])
+    assert r.exit_code == 0, r.output
+    assert _posted_lot_balance(gf, 'BILL-HERO-1120') == -1120.00
+
+    # Re-import with auto_apply_credit → settle from the prior credit.
+    settle_from_credit = '''taxtable "GST+PST"
+\tentry:
+\t\taccount: "Liabilities:Tax:GST"
+\t\trate: 5.0%
+\t\ttype: PERCENT
+\tentry:
+\t\taccount: "Liabilities:Tax:PST"
+\t\trate: 7.0%
+\t\ttype: PERCENT
+
+vendor "V-HERO"
+\tname: "Hero Supplier"
+\tcurrency: CAD
+
+bill "BILL-HERO-1120"
+\tvendor_id: "V-HERO"
+\tcurrency: CAD
+\tdate_opened: 2026-05-10
+\tauto_apply_credit: true
+\tentry:
+\t\tdate: 2026-05-10
+\t\tdescription: "Materials (net 1000 + GST 50 + PST 70 = 1120)"
+\t\taccount: "Expenses:Office Supplies"
+\t\tquantity: 1
+\t\tprice: 1000
+\t\ttaxable: true
+\t\ttax_included: false
+\t\ttax_table: "GST+PST"
+\tposted:
+\t\tdate: 2026-05-10
+\t\tdue: 2026-06-09
+\t\tap_account: "Liabilities:Accounts Payable"
+\t\tmemo: "Bill BILL-HERO-1120"
+\t\taccumulate: true
+\tpayment: none
+'''
+    r = _import(runner, gf, settle_from_credit, 'settle.txt', tmp_path)
+    assert r.exit_code == 0, f'settle-from-credit import: {r.output}'
+    assert _posted_lot_balance(gf, 'BILL-HERO-1120') == 0.00, 'settled from credit'
+    assert _vendor_credit_total(gf, 'V-HERO') == 80.00, '1200 credit − 1120 bill = 80'

--- a/tests/research/bill_payment_reconciliation_probe.py
+++ b/tests/research/bill_payment_reconciliation_probe.py
@@ -1,0 +1,515 @@
+"""Probe: observed vendor-bill payment behaviour (overpayment + partial).
+
+Grounds the docs in tests/../docs for AP-side bill payments. Imports real
+bills through the production CLI, posts + pays them, then prints the REAL
+posting-transaction splits, the REAL AP lot balances/signs and split
+lists, and the REAL exported plaintext block (via the production
+exporter). Nothing here is hand-computed — the docs copy these numbers.
+
+Run in Docker (not collected by pytest — no `test_` prefix):
+
+    docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp/home \
+        -v "$PWD:/workspace" -w /workspace gnucash-dev:latest bash -c \
+        'python3 -m pip install -e . weasyprint --break-system-packages \
+         --user -q; python3 tests/research/bill_payment_reconciliation_probe.py'
+"""
+import tempfile
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+ACCOUNTS = 'tests/fixtures/payment_roundtrip_accounts.txt'
+
+VENDOR = '''
+vendor "V001"
+\tname: "Supplier Co."
+\tcurrency: CAD
+'''
+
+# A) Overpayment: $100 bill paid $150 in one payment.
+BILL_OVERPAY = VENDOR + '''
+bill "BILL-OVERPAY-100"
+\tvendor_id: "V001"
+\tcurrency: CAD
+\tdate_opened: 2026-01-01
+\tentry:
+\t\tdate: 2026-01-01
+\t\tdescription: "Materials"
+\t\taccount: "Expenses:Supplies"
+\t\tquantity: 1
+\t\tprice: 100
+\t\ttaxable: false
+\t\ttax_included: false
+\tposted:
+\t\tdate: 2026-01-01
+\t\tdue: 2026-01-31
+\t\tap_account: "Liabilities:Accounts Payable"
+\t\tmemo: "Bill BILL-OVERPAY-100"
+\t\taccumulate: true
+\tpayment:
+\t\tdate: 2026-01-10
+\t\tamount: 150
+\t\tbank_account: "Assets:Bank"
+\t\tmemo: "Paid 150 on a 100 bill (overpaid 50)"
+\t\tprepayment: 50
+'''
+
+# B) Partial payments: $100 bill, two instalments ($40 + $35), $25 open.
+BILL_PARTIAL = VENDOR + '''
+bill "BILL-PARTIAL-100"
+\tvendor_id: "V001"
+\tcurrency: CAD
+\tdate_opened: 2026-02-01
+\tentry:
+\t\tdate: 2026-02-01
+\t\tdescription: "Materials"
+\t\taccount: "Expenses:Supplies"
+\t\tquantity: 1
+\t\tprice: 100
+\t\ttaxable: false
+\t\ttax_included: false
+\tposted:
+\t\tdate: 2026-02-01
+\t\tdue: 2026-03-03
+\t\tap_account: "Liabilities:Accounts Payable"
+\t\tmemo: "Bill BILL-PARTIAL-100"
+\t\taccumulate: true
+\tpayment:
+\t\tdate: 2026-02-10
+\t\tamount: 40
+\t\tbank_account: "Assets:Bank"
+\t\tmemo: "First instalment"
+\tpayment:
+\t\tdate: 2026-02-20
+\t\tamount: 35
+\t\tbank_account: "Assets:Bank"
+\t\tmemo: "Second instalment"
+'''
+
+
+# C) One vendor, three bills in different payment states — to exercise
+#    detection across a whole vendor (paid / partial / overpaid).
+BILLS_MIXED = VENDOR + '''
+bill "BILL-PAID-100"
+\tvendor_id: "V001"
+\tcurrency: CAD
+\tdate_opened: 2026-03-01
+\tentry:
+\t\tdate: 2026-03-01
+\t\tdescription: "Fully paid"
+\t\taccount: "Expenses:Supplies"
+\t\tquantity: 1
+\t\tprice: 100
+\t\ttaxable: false
+\t\ttax_included: false
+\tposted:
+\t\tdate: 2026-03-01
+\t\tdue: 2026-03-31
+\t\tap_account: "Liabilities:Accounts Payable"
+\t\tmemo: "Bill BILL-PAID-100"
+\t\taccumulate: true
+\tpayment:
+\t\tdate: 2026-03-05
+\t\tamount: 100
+\t\tbank_account: "Assets:Bank"
+\t\tmemo: "Paid in full"
+
+bill "BILL-PART-100"
+\tvendor_id: "V001"
+\tcurrency: CAD
+\tdate_opened: 2026-03-02
+\tentry:
+\t\tdate: 2026-03-02
+\t\tdescription: "Partly paid"
+\t\taccount: "Expenses:Supplies"
+\t\tquantity: 1
+\t\tprice: 100
+\t\ttaxable: false
+\t\ttax_included: false
+\tposted:
+\t\tdate: 2026-03-02
+\t\tdue: 2026-04-01
+\t\tap_account: "Liabilities:Accounts Payable"
+\t\tmemo: "Bill BILL-PART-100"
+\t\taccumulate: true
+\tpayment:
+\t\tdate: 2026-03-06
+\t\tamount: 60
+\t\tbank_account: "Assets:Bank"
+\t\tmemo: "Part payment (40 outstanding)"
+
+bill "BILL-OVER-100"
+\tvendor_id: "V001"
+\tcurrency: CAD
+\tdate_opened: 2026-03-03
+\tentry:
+\t\tdate: 2026-03-03
+\t\tdescription: "Overpaid"
+\t\taccount: "Expenses:Supplies"
+\t\tquantity: 1
+\t\tprice: 100
+\t\ttaxable: false
+\t\ttax_included: false
+\tposted:
+\t\tdate: 2026-03-03
+\t\tdue: 2026-04-02
+\t\tap_account: "Liabilities:Accounts Payable"
+\t\tmemo: "Bill BILL-OVER-100"
+\t\taccumulate: true
+\tpayment:
+\t\tdate: 2026-03-07
+\t\tamount: 150
+\t\tbank_account: "Assets:Bank"
+\t\tmemo: "Overpaid by 50"
+\t\tprepayment: 50
+'''
+
+
+# D) Taxed bills (GST 5% + PST 7% on net 100 → total 112) overpaid and
+#    partially paid — to show payment works against the TAX-INCLUSIVE total.
+TAXTABLE = '''
+taxtable "GST+PST"
+\tentry:
+\t\taccount: "Liabilities:Tax:GST"
+\t\trate: 5.0%
+\t\ttype: PERCENT
+\tentry:
+\t\taccount: "Liabilities:Tax:PST"
+\t\trate: 7.0%
+\t\ttype: PERCENT
+'''
+
+TAXED_BILLS = TAXTABLE + VENDOR + '''
+bill "BILL-TAX-OVER-112"
+\tvendor_id: "V001"
+\tcurrency: CAD
+\tdate_opened: 2026-04-01
+\tentry:
+\t\tdate: 2026-04-01
+\t\tdescription: "Materials (net 100 + 12% tax = 112)"
+\t\taccount: "Expenses:Office Supplies"
+\t\tquantity: 1
+\t\tprice: 100
+\t\ttaxable: true
+\t\ttax_included: false
+\t\ttax_table: "GST+PST"
+\tposted:
+\t\tdate: 2026-04-01
+\t\tdue: 2026-05-01
+\t\tap_account: "Liabilities:Accounts Payable"
+\t\tmemo: "Bill BILL-TAX-OVER-112"
+\t\taccumulate: true
+\tpayment:
+\t\tdate: 2026-04-10
+\t\tamount: 150
+\t\tbank_account: "Assets:Bank"
+\t\tmemo: "Paid 150 on a 112 bill (overpaid 38)"
+
+bill "BILL-TAX-PART-112"
+\tvendor_id: "V001"
+\tcurrency: CAD
+\tdate_opened: 2026-04-02
+\tentry:
+\t\tdate: 2026-04-02
+\t\tdescription: "Materials (net 100 + 12% tax = 112)"
+\t\taccount: "Expenses:Office Supplies"
+\t\tquantity: 1
+\t\tprice: 100
+\t\ttaxable: true
+\t\ttax_included: false
+\t\ttax_table: "GST+PST"
+\tposted:
+\t\tdate: 2026-04-02
+\t\tdue: 2026-05-02
+\t\tap_account: "Liabilities:Accounts Payable"
+\t\tmemo: "Bill BILL-TAX-PART-112"
+\t\taccumulate: true
+\tpayment:
+\t\tdate: 2026-04-11
+\t\tamount: 60
+\t\tbank_account: "Assets:Bank"
+\t\tmemo: "Part payment (52 outstanding on a 112 bill)"
+'''
+
+
+def _setup(runner, tmp):
+    gf = tmp / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf), ACCOUNTS])
+    assert r.exit_code == 0, r.output
+    return gf
+
+
+def _balances(gf, names):
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        out = {}
+
+        def walk(a):
+            from infrastructure.gnucash.utils import get_account_full_name
+            out[get_account_full_name(a)] = round(a.GetBalance().to_double(), 2)
+            for c in a.get_children():
+                walk(c)
+        walk(repo.book.get_root_account())
+        return {n: out.get(n, 0.0) for n in names}
+    finally:
+        repo.close()
+
+
+def _dc(gf):
+    """Delete stale GnuCash backup/log files so two saves in the same wall
+    second don't collide on the backup filename (ERR_FILEIO_BACKUP_ERROR)."""
+    for stale in gf.parent.glob(gf.name + '.*'):
+        stale.unlink()
+
+
+def _import(runner, gf, text, name, tmp):
+    p = tmp / name
+    p.write_text(text)
+    _dc(gf)
+    r = runner.invoke(cli, ['import', str(gf), str(p),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+
+
+def _dump_posting_and_lots(gf, bill_id):
+    import gnucash.gnucash_business as gb
+    import gnucash.gnucash_core_c as gc
+    from gnucash import GncLot, Query, Split
+
+    from infrastructure.gnucash.utils import get_account_full_name
+    from repositories.gnucash_repository import GnuCashRepository
+
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        q = Query()
+        q.search_for('gncInvoice')
+        q.set_book(repo.book)
+        bill = next((gb.Invoice(instance=r) for r in q.run()
+                     if gb.Invoice(instance=r).GetID() == bill_id), None)
+        q.destroy()
+        assert bill is not None
+
+        tx = bill.GetPostedTxn()
+        print(f'  posting transaction splits ({bill_id}):')
+        for i in range(tx.CountSplits()):
+            sp = tx.GetSplit(i)
+            print(f'    {get_account_full_name(sp.GetAccount()):32s} '
+                  f'{sp.GetAmount().to_double():+.2f}')
+
+        # AP lots for this bill's vendor.
+        def find(acct, name):
+            if get_account_full_name(acct) == name:
+                return acct
+            for c in acct.get_children():
+                r = find(c, name)
+                if r:
+                    return r
+            return None
+        ap = find(repo.book.get_root_account(),
+                  'Liabilities:Accounts Payable')
+        seen = set()
+        lots = []
+        for s in ap.GetSplitList():
+            raw = s.GetLot()
+            if raw is None or int(raw) in seen:
+                continue
+            seen.add(int(raw))
+            lots.append(GncLot(instance=raw))
+        print(f'  AP account "{get_account_full_name(ap)}" lots:')
+        for lot in lots:
+            members = list(lot.get_split_list())
+            print(f'    lot closed={lot.is_closed()} '
+                  f'balance={lot.get_balance().to_double():+.2f} '
+                  f'({len(members)} splits):')
+            for raw_sp in members:
+                sp = Split(instance=raw_sp)
+                ptx = sp.GetParent()
+                is_posting = gc.gncInvoiceGetInvoiceFromTxn(
+                    ptx.instance) is not None
+                print(f'        {sp.GetAmount().to_double():+.2f}  '
+                      f'{"posting" if is_posting else "payment"}  '
+                      f'{ptx.GetDate().strftime("%Y-%m-%d")}  '
+                      f'"{sp.GetMemo()}"')
+    finally:
+        repo.close()
+
+
+def _bill_states(gf, bill_ids):
+    """For each bill id print IsPaid and the posted lot's balance (the
+    still-outstanding AP amount; 0 = settled, negative = still owed,
+    positive = overpaid credit)."""
+    import gnucash.gnucash_business as gb
+    import gnucash.gnucash_core_c as gc
+    from gnucash import Query
+
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gf))
+    repo.open()
+    try:
+        q = Query()
+        q.search_for('gncInvoice')
+        q.set_book(repo.book)
+        by_id = {gb.Invoice(instance=r).GetID(): gb.Invoice(instance=r)
+                 for r in q.run()}
+        q.destroy()
+        for bid in bill_ids:
+            bill = by_id.get(bid)
+            paid = bool(gc.gncInvoiceIsPaid(bill.instance))
+            lot = bill.GetPostedLot()
+            bal = lot.get_balance().to_double() if lot is not None else None
+            print(f'    {bid:18s} is_paid={paid!s:5s} '
+                  f'posted-lot balance={bal:+.2f}')
+    finally:
+        repo.close()
+
+
+def _export_block(runner, gf, bill_id, tmp):
+    out = tmp / 'export.txt'
+    r = runner.invoke(cli, ['export', str(gf), str(out),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    text = out.read_text()
+    block = []
+    grab = False
+    for line in text.splitlines():
+        if line.startswith(f'bill "{bill_id}"'):
+            grab = True
+        elif grab and line and not (line.startswith(' ')
+                                    or line.startswith('\t')):
+            break
+        if grab:
+            block.append(line)
+    print(f'  exported plaintext block ({bill_id}):')
+    for line in block:
+        print('    ' + line)
+
+
+def main():
+    runner = CliRunner()
+    tmp = Path(tempfile.mkdtemp())
+
+    print('=' * 70)
+    print('A) VENDOR-BILL OVERPAYMENT — $100 bill paid $150')
+    print('=' * 70)
+    gf = _setup(runner, tmp)
+    _import(runner, gf, BILL_OVERPAY, 'overpay.txt', tmp)
+    _dump_posting_and_lots(gf, 'BILL-OVERPAY-100')
+    _export_block(runner, gf, 'BILL-OVERPAY-100', tmp)
+
+    print()
+    print('=' * 70)
+    print('B) VENDOR-BILL PARTIAL PAYMENTS — $100 bill, $40 + $35, $25 open')
+    print('=' * 70)
+    gf2 = tmp / 'book2.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf2), ACCOUNTS])
+    assert r.exit_code == 0, r.output
+    _import(runner, gf2, BILL_PARTIAL, 'partial.txt', tmp)
+    _dump_posting_and_lots(gf2, 'BILL-PARTIAL-100')
+    _export_block(runner, gf2, 'BILL-PARTIAL-100', tmp)
+
+    print()
+    print('=' * 70)
+    print('C) DETECTION ACROSS ONE VENDOR — paid + partial + overpaid bills')
+    print('=' * 70)
+    gf3 = tmp / 'book3.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf3), ACCOUNTS])
+    assert r.exit_code == 0, r.output
+    _import(runner, gf3, BILLS_MIXED, 'mixed.txt', tmp)
+
+    ids = ['BILL-PAID-100', 'BILL-PART-100', 'BILL-OVER-100']
+    print('  per-bill posted-lot state (0=settled, -=still owed, +=overpaid):')
+    _bill_states(gf3, ids)
+
+    print()
+    print('  $ find-prepayments book.gnucash --vendor V001')
+    r = runner.invoke(cli, ['find-prepayments', str(gf3), '--vendor', 'V001'])
+    for line in r.output.splitlines():
+        print('    ' + line)
+
+    print()
+    print('  $ print-bill book.gnucash --vendor V001 --format plaintext -o -')
+    r = runner.invoke(cli, ['print-bill', str(gf3), '--vendor', 'V001',
+                            '--format', 'plaintext', '-o', '-'])
+    # Only show the bill headers + bill_total + payment amounts (compact).
+    for line in r.output.splitlines():
+        s = line.strip()
+        if (s.startswith('bill "') or s.startswith('bill_total:')
+                or s.startswith('amount:') or s.startswith('prepayment:')):
+            print('    ' + line)
+
+    print()
+    print('  AP account open_prepayment: block from `export`:')
+    out = tmp / 'mixed_export.txt'
+    r = runner.invoke(cli, ['export', str(gf3), str(out),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    grab = 0
+    for line in out.read_text().splitlines():
+        if 'Accounts Payable' in line and line.startswith(('2', '1')):
+            grab = 1
+        elif grab and line and not (line.startswith(' ') or line.startswith('\t')):
+            grab = 0
+        if grab and ('Accounts Payable' in line or 'open_prepayment'
+                     in line or line.strip().startswith(('owner:', 'amount:',
+                                                         'owner_guid:'))):
+            print('    ' + line)
+
+    print()
+    print('=' * 70)
+    print('D) TAXED BILLS (net 100 + GST5+PST7 = 112) — overpaid + partial')
+    print('=' * 70)
+    gf4 = tmp / 'book4.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gf4),
+                            'tests/fixtures/q019_accounts.txt'])
+    assert r.exit_code == 0, r.output
+    _import(runner, gf4, TAXED_BILLS, 'taxed.txt', tmp)
+    print('  --- overpaid taxed bill ($112 total, paid $150) ---')
+    _dump_posting_and_lots(gf4, 'BILL-TAX-OVER-112')
+    _export_block(runner, gf4, 'BILL-TAX-OVER-112', tmp)
+    print('  --- partially paid taxed bill ($112 total, paid $60) ---')
+    _dump_posting_and_lots(gf4, 'BILL-TAX-PART-112')
+    print('  per-bill posted-lot state:')
+    _bill_states(gf4, ['BILL-TAX-OVER-112', 'BILL-TAX-PART-112'])
+    print('  $ find-prepayments --vendor V001')
+    r = runner.invoke(cli, ['find-prepayments', str(gf4), '--vendor', 'V001'])
+    for line in r.output.splitlines():
+        if 'CAD' in line or 'Total credit' in line or 'Found' in line:
+            print('    ' + line)
+
+    print()
+    print('=' * 70)
+    print('E) REFUND ACCOUNTING — which accounts move? (is it an expense?)')
+    print('=' * 70)
+    names = ['Assets:Bank', 'Assets:Accounts Receivable',
+             'Liabilities:Accounts Payable', 'Income', 'Expenses:Supplies']
+
+    print('  --- CUSTOMER overpaid us by $50 (invoice 100 paid 150); we refund ---')
+    gfe = tmp / 'book_cust.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gfe), ACCOUNTS])
+    assert r.exit_code == 0, r.output
+    _import(runner, gfe, Path('tests/fixtures/q015_aac_primer_invoice.txt').read_text(),
+            'cprimer.txt', tmp)
+    print('    before refund:', _balances(gfe, names))
+    _import(runner, gfe, Path('tests/fixtures/q_refund_prepayment.txt').read_text(),
+            'crefund.txt', tmp)
+    print('    after  refund:', _balances(gfe, names))
+
+    print('  --- WE overpaid a vendor by $50 (bill 100 paid 150); vendor refunds us ---')
+    gfv = tmp / 'book_vend.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gfv), ACCOUNTS])
+    assert r.exit_code == 0, r.output
+    _import(runner, gfv, Path('tests/fixtures/q015_aac_primer_bill.txt').read_text(),
+            'vprimer.txt', tmp)
+    print('    before refund:', _balances(gfv, names))
+    _import(runner, gfv, Path('tests/fixtures/q_vendor_refund.txt').read_text(),
+            'vrefund.txt', tmp)
+    print('    after  refund:', _balances(gfv, names))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Vendor-bill entries are attached with gncBillAddEntry (the vendor-bill owner API) instead of Invoice.AddEntry (gncInvoiceAddEntry, the customer-invoice API). GnuCash's entry XML writer guards the bill-side tax flags behind `if (gncEntryGetBill(entry))`, so attaching on the invoice side dropped `entry:b-taxable` / `entry:b-taxincluded` on save: a bill's `tax_included: true` (and `taxable: false`) silently reverted on reload and over-taxed the bill. Bill entries also now call SetBillTaxIncluded. Both flags round-trip through export and re-import.

Tracks T-008.

Tax-inclusive pricing (the previously untested branch):
- Draft render and posted-split back-out for invoices and bills (gross 1120 -> net 1000 + GST 50 + PST 70), plus export/reimport preservation of `tax_included: true`.

Payment / credit reconciliation coverage:
- Overpayment and partial payment, with and without tax, on invoices and bills, asserted against the tax-inclusive payable total.
- A taxed bill settled by a fresh ApplyPayment plus a linked existing bank tx (txn_guid), then unapply (single / --all) and re-link, and settling from a prior vendor credit via auto_apply_credit.
- A credit consumed across two documents (the second goes partial when the credit runs out) and credit + cash settling two documents, on both the invoice and bill sides.
- Credit owner attribution across multiple vendors and customers.
- Refund tests assert the cash actually moves (bank delta) and that no expense or income is touched, on both sides.

Docs:
- New docs/bill-payment-reconciliation.md covers the vendor-bill (Accounts Payable) side: linking bank txs, partial and overpayment, detecting paid/partial/overpaid state, unapply corrections, and managing a vendor credit (consume / refund / write off).
- docs/invoice-payment-reconciliation.md is now invoice-only, with a customer-credit management section (consume / refund / forfeit).
- README and RELEASE_NOTES cross-reference both docs.
- business_objects_only.txt reflects the now-persisted `taxable: false`; CLAUDE.md finding #8 corrected to the real root cause.