### PR TITLE
Handle vendor bills as the Bill class throughout; drop ctypes entry helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,33 +327,41 @@ posting), so GnuCash puts it in a **new lot** instead of the bill's lot.
 `inv.GetPostedLot().get_split_list()` then returns only 1 split (the posting)
 and the exporter emits `payment: none` for a paid bill.
 
-### 8. Vendor-bill entries must be attached with `gncBillAddEntry`, not `Invoice.AddEntry`
+### 8. Vendor bills MUST be wrapped/constructed as the `Bill` class, not `Invoice`
 
-A `GncEntry` carries two owner-side field groups — customer-invoice (`i-*`) and
-vendor-bill (`b-*`) — and two owner pointers. `gncInvoiceAddEntry` (SWIG
-`Invoice.AddEntry`) sets the entry's **invoice** pointer; `gncBillAddEntry` sets
-its **bill** pointer. GnuCash's entry XML writer serialises the bill-side tax
-flags only inside `if (gncEntryGetBill(entry))`:
+GnuCash stores customer invoices and vendor bills in one `gncInvoice` QOF type
+(distinguished by owner). The Python bindings expose **two** classes:
+`Invoice`, and `Bill(Invoice)` — a real subclass (`Bill.add_methods_with_prefix('gncBill')`).
+The only methods `Bill` overrides are `AddEntry` → `gncBillAddEntry` and
+`RemoveEntry` → `gncBillRemoveEntry`; everything else is inherited, so a `Bill`
+is a strict, safe superset of `Invoice` for a vendor bill.
 
-- attached via `Invoice.AddEntry` → the file gets `<entry:invoice>` plus
-  `i-taxable` / `i-taxincluded`, and **omits** `entry:b-taxable` /
-  `entry:b-taxincluded`. On reload those default (`b-taxable`→true,
-  `b-taxincluded`→false), so `taxable: false` silently flips to `true` and
-  `tax_included: true` is lost (the price is then treated as tax-exclusive and
-  the bill is over-taxed).
-- attached via `gncBillAddEntry` → the file gets `<entry:bill>` plus
-  `b-taxable` / `b-taxincluded`, and both round-trip exactly as authored.
+A `GncEntry` carries two owner pointers, and GnuCash's entry XML writer
+serialises the bill-side tax flags only inside `if (gncEntryGetBill(entry))`:
 
-The importer attaches bill entries with `_bill_add_entry` (`gncBillAddEntry`);
-posting is unaffected because both APIs append to the same `invoice->entries`
-GList. This is symmetric to `_bill_remove_all_entries` (`gncBillRemoveEntry`),
-since `Invoice.RemoveEntry` is likewise customer-invoice-only.
+- entry added via `Invoice.AddEntry` (`gncInvoiceAddEntry`) sets the entry's
+  *invoice* pointer → the file gets `<entry:invoice>` + `i-taxincluded`, and
+  **omits** `entry:b-taxable` / `entry:b-taxincluded`. On reload those default
+  (`b-taxable`→true, `b-taxincluded`→false), so `taxable: false` flips to `true`
+  and `tax_included: true` is lost (the bill is over-taxed).
+- entry added via `Bill.AddEntry` (`gncBillAddEntry`) sets the *bill* pointer →
+  `<entry:bill>` + `b-taxable` / `b-taxincluded`, round-tripping as authored.
 
-**Impact on round-trip tests**: bill export now reflects the source `taxable:` /
-`tax_included:` values verbatim — reference fixtures use whatever the source
-declares (e.g. `taxable: false` stays `false`). This supersedes the earlier
-belief that GnuCash could not persist `bill_taxable = false`; the real cause was
-attaching bill entries on the customer-invoice side.
+**The fix is the Python class, not ctypes.** Construct new bills with
+`Bill(book, id, currency, vendor)` and wrap every `gncInvoice` query result with
+`wrap_invoice_or_bill(raw)` (`infrastructure/gnucash/utils.py`), which returns a
+`Bill` for a vendor owner (`GetOwnerType() == GNC_OWNER_VENDOR`) and an `Invoice`
+otherwise. Then `bill.AddEntry` / `bill.RemoveEntry` dispatch correctly and no
+ctypes helper is needed. A vendor bill wrapped as `Invoice` and mutated via
+`Invoice.RemoveEntry` was also the real cause of the GnuCash-3.8 rebuild
+segfault (wrong function → dangling entry pointers); `Bill.RemoveEntry` avoids
+it — verified on Ubuntu 20.04 (GnuCash 3.8).
+
+**Impact on round-trip tests**: bill export reflects the source `taxable:` /
+`tax_included:` values verbatim (e.g. `taxable: false` stays `false`). This
+supersedes the earlier belief that GnuCash could not persist
+`bill_taxable = false`; the real cause was handling bills with the
+customer-invoice class.
 
 ---
 

--- a/cli/bill_print_cmd.py
+++ b/cli/bill_print_cmd.py
@@ -19,9 +19,9 @@ from datetime import datetime
 from pathlib import Path
 
 import click
-import gnucash.gnucash_business as gb
 from gnucash import Query
 
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 from repositories.gnucash_repository import GnuCashRepository, SessionMode
 from services.bill_renderer import (
     render_to_html,
@@ -38,7 +38,7 @@ def _all_bills(book):
     q.set_book(book)
     results = []
     for r in q.run():
-        bill = gb.Invoice(instance=r)
+        bill = wrap_invoice_or_bill(r)
         # Vendor bills only (skip customer invoices).
         try:
             vendor = bill.GetOwner().GetVendor()

--- a/cli/invoice_print_cmd.py
+++ b/cli/invoice_print_cmd.py
@@ -17,9 +17,9 @@ from datetime import datetime
 from pathlib import Path
 
 import click
-import gnucash.gnucash_business as gb
 from gnucash import Query
 
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 from repositories.gnucash_repository import GnuCashRepository, SessionMode
 from services.invoice_renderer import (
     read_book_company_info,
@@ -36,7 +36,7 @@ def _all_invoices(book):
     q.set_book(book)
     results = []
     for r in q.run():
-        inv = gb.Invoice(instance=r)
+        inv = wrap_invoice_or_bill(r)
         # Customer invoices only (skip vendor bills)
         try:
             cust = inv.GetOwner().GetCustomer()

--- a/docs/issues/T-008-tax-included-and-payment-reconciliation-coverage.md
+++ b/docs/issues/T-008-tax-included-and-payment-reconciliation-coverage.md
@@ -30,6 +30,16 @@ the bill. Proven by an XML probe: an entry added via `gncBillAddEntry` writes
 This also explains — and supersedes — the earlier CLAUDE.md finding #8 belief
 that GnuCash "cannot persist `bill_taxable = false`".
 
+Root cause and fix: the importer built and looked up vendor bills with the
+**`Invoice`** class, so `bill.AddEntry` / `bill.RemoveEntry` resolved to the
+customer-invoice functions. The Python bindings do provide a `Bill(Invoice)`
+class whose `AddEntry` / `RemoveEntry` dispatch to `gncBill*`. All production
+paths now construct and wrap vendor bills as `Bill` (via `wrap_invoice_or_bill`),
+so the correct functions are used with no ctypes workarounds. Removing the
+ctypes helpers and using `Bill.RemoveEntry` also avoids the GnuCash-3.8 rebuild
+segfault the ctypes helper was originally added for — verified on Ubuntu 20.04,
+22.04 and Debian 13.
+
 ### Reconciliation coverage gaps (untested before this work)
 
 - overpayment / partial payment on a **taxed** invoice/bill (payment applied
@@ -46,8 +56,11 @@ that GnuCash "cannot persist `bill_taxable = false`".
 
 ## Affected files
 
-- `services/gnucash_importer.py` — bill entry attach (`_bill_add_entry` /
-  `gncBillAddEntry`) + `SetBillTaxIncluded`
+- `services/gnucash_importer.py` — vendor bills constructed/looked up as the
+  SWIG `Bill` class + `SetBillTaxIncluded`; `infrastructure/gnucash/utils.py`
+  `wrap_invoice_or_bill` classifies every `gncInvoice` query result
+- `use_cases/delete_business_objects.py`, `use_cases/export_business_objects.py`,
+  `cli/bill_print_cmd.py`, `cli/invoice_print_cmd.py` — bills wrapped as `Bill`
 - `services/invoice_renderer.py`, `services/bill_renderer.py` (branch under test)
 - `tests/integration/test_tax_included_pricing.py`,
   `test_overpayment_partial_payment_with_and_without_tax.py`,

--- a/infrastructure/gnucash/utils.py
+++ b/infrastructure/gnucash/utils.py
@@ -13,6 +13,25 @@ from typing import List, Optional, Union
 from gnucash import Account, GncCommodity, GncNumeric
 
 
+def wrap_invoice_or_bill(raw):
+    """Wrap a ``gncInvoice`` QOF query result as the correct SWIG class:
+    ``Bill`` for a vendor-owned document, ``Invoice`` for a customer-owned one.
+
+    GnuCash stores customer invoices and vendor bills in one ``gncInvoice`` QOF
+    type; only the Python class decides whether ``AddEntry`` / ``RemoveEntry``
+    dispatch to the ``gncBill*`` functions (vendor bill) or the ``gncInvoice*``
+    functions (customer invoice). A vendor bill MUST be wrapped as ``Bill`` so
+    those operations — and the bill-side tax-flag persistence they drive — are
+    correct. All read-only methods are inherited from ``Invoice``, so wrapping a
+    bill as ``Bill`` never loses anything.
+    """
+    from gnucash.gnucash_business import GNC_OWNER_VENDOR, Bill, Invoice
+    inv = Invoice(instance=raw)
+    if inv.GetOwnerType() == GNC_OWNER_VENDOR:
+        return Bill(instance=raw)
+    return inv
+
+
 def get_account_full_name(account: Account) -> str:
     """
     Get full hierarchical name of account (e.g., "Assets:Bank:Checking").

--- a/services/gnucash_importer.py
+++ b/services/gnucash_importer.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Optional
 
 import gnucash.gnucash_core_c as gc
 from gnucash import Account, Book, GncCommodity, GncNumeric, Split, Transaction
-from gnucash.gnucash_business import Customer, Entry, Invoice, TaxTable, TaxTableEntry, Vendor
+from gnucash.gnucash_business import Bill, Customer, Entry, Invoice, TaxTable, TaxTableEntry, Vendor
 from gnucash.gnucash_core_c import (
     ACCT_TYPE_ASSET,
     ACCT_TYPE_BANK,
@@ -46,7 +46,12 @@ from infrastructure.gnucash.kvp import (
     set_book_string_option,
     set_custom_metadata,
 )
-from infrastructure.gnucash.utils import find_account, get_account_full_name, string_to_gnc_numeric
+from infrastructure.gnucash.utils import (
+    find_account,
+    get_account_full_name,
+    string_to_gnc_numeric,
+    wrap_invoice_or_bill,
+)
 from services.plaintext_parser import DirectiveType, PlaintextDirective
 
 # Q-028: book-level `company` directive — plaintext key ↔ Business option slot.
@@ -257,13 +262,12 @@ def _find_invoices_by_id(book, id_: str):
     same lookup shape.
     """
     from gnucash import Query
-    from gnucash.gnucash_business import Invoice
     q = Query()
     q.search_for('gncInvoice')
     q.set_book(book)
     out = []
     for r in q.run():
-        inv = Invoice(instance=r)
+        inv = wrap_invoice_or_bill(r)
         if inv.GetOwnerType() == _GNC_OWNER_CUSTOMER and inv.GetID() == id_:
             out.append(inv)
     q.destroy()
@@ -273,13 +277,12 @@ def _find_invoices_by_id(book, id_: str):
 def _find_bills_by_id(book, id_: str):
     """All vendor bills with the given id."""
     from gnucash import Query
-    from gnucash.gnucash_business import Invoice
     q = Query()
     q.search_for('gncInvoice')
     q.set_book(book)
     out = []
     for r in q.run():
-        inv = Invoice(instance=r)
+        inv = wrap_invoice_or_bill(r)
         if inv.GetOwnerType() == _GNC_OWNER_VENDOR and inv.GetID() == id_:
             out.append(inv)
     q.destroy()
@@ -296,7 +299,6 @@ def _find_invoice_by_guid(book, guid_norm: str):
     import ctypes
 
     from gnucash import Query
-    from gnucash.gnucash_business import Invoice
     lib = ctypes.CDLL(None)
     lib.qof_instance_get_guid.argtypes = [ctypes.c_void_p]
     lib.qof_instance_get_guid.restype = ctypes.c_void_p
@@ -309,7 +311,7 @@ def _find_invoice_by_guid(book, guid_norm: str):
     q.set_book(book)
     found = None
     for r in q.run():
-        inv = Invoice(instance=r)
+        inv = wrap_invoice_or_bill(r)
         if inv.GetOwnerType() != _GNC_OWNER_CUSTOMER:
             continue
         guid_ptr = lib.qof_instance_get_guid(int(inv.instance))
@@ -328,7 +330,6 @@ def _find_bill_by_guid(book, guid_norm: str):
     import ctypes
 
     from gnucash import Query
-    from gnucash.gnucash_business import Invoice
     lib = ctypes.CDLL(None)
     lib.qof_instance_get_guid.argtypes = [ctypes.c_void_p]
     lib.qof_instance_get_guid.restype = ctypes.c_void_p
@@ -341,7 +342,7 @@ def _find_bill_by_guid(book, guid_norm: str):
     q.set_book(book)
     found = None
     for r in q.run():
-        inv = Invoice(instance=r)
+        inv = wrap_invoice_or_bill(r)
         if inv.GetOwnerType() != _GNC_OWNER_VENDOR:
             continue
         guid_ptr = lib.qof_instance_get_guid(int(inv.instance))
@@ -412,52 +413,6 @@ def _find_taxtable_by_guid(book, guid_norm: str):
         if _taxtable_guid_str(ptr) == guid_norm:
             return ptr
     return None
-
-
-def _bill_remove_all_entries(book, bill) -> None:
-    """Detach and destroy every entry on a vendor bill.
-
-    SWIG `Invoice.RemoveEntry(entry)` wraps `gncInvoiceRemoveEntry` which is
-    customer-invoice-specific and is a no-op (or worse) on vendor bills.
-    Use the C `gncBillRemoveEntry` directly via ctypes so the bill's entry
-    list is properly cleared before we rebuild from the directive. Without
-    this, `gncInvoicePostToAccount` later iterates a list with dangling
-    pointers from destroyed entries and segfaults on GnuCash 3.8.
-    """
-    import ctypes
-    lib = ctypes.CDLL(None)
-    lib.gncBillRemoveEntry.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-    lib.gncBillRemoveEntry.restype = None
-    bill_ptr = int(bill.instance)
-    for old_entry in list(bill.GetEntries()):
-        lib.gncBillRemoveEntry(bill_ptr, int(old_entry.instance))
-        old_entry.Destroy()
-
-
-def _bill_add_entry(bill, entry) -> None:
-    """Attach an entry to a vendor bill via the C `gncBillAddEntry`.
-
-    SWIG `Invoice.AddEntry(entry)` wraps `gncInvoiceAddEntry`, which sets the
-    entry's *customer-invoice* owner pointer (`gncEntrySetInvoice`). GnuCash's
-    entry XML writer guards the bill-side tax flags behind
-    `if (gncEntryGetBill(entry))`, so a bill entry attached the customer-invoice
-    way serialises on the invoice side (`entry:invoice`, `i-taxincluded`) and
-    never persists `entry:b-taxable` / `entry:b-taxincluded`. Its
-    `tax_included: true` is silently dropped on save and reads back false after
-    reload, so the price is treated as tax-exclusive and the bill is
-    over-taxed. `gncBillAddEntry` sets the entry's *bill* owner pointer
-    (`gncEntrySetBill`) so the writer emits `entry:bill` with `b-taxable` /
-    `b-taxincluded`, and the tax-inclusive flag survives the round-trip.
-    Symmetric to `_bill_remove_all_entries` (`gncBillRemoveEntry`); both append
-    to the same `invoice->entries` GList that posting iterates, so the only
-    behavioural change is that the bill-side owner link (and its tax flags) is
-    now recorded correctly.
-    """
-    import ctypes
-    lib = ctypes.CDLL(None)
-    lib.gncBillAddEntry.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-    lib.gncBillAddEntry.restype = None
-    lib.gncBillAddEntry(int(bill.instance), int(entry.instance))
 
 
 def _swig_invoice_guid_str(invoice) -> str:
@@ -3091,7 +3046,10 @@ class GnuCashImporter:
                 existing.Unpost(False)
 
         if existing is None:
-            # Bills are Invoice objects whose owner is a Vendor (no separate Bill class)
+            # A vendor bill is a gncInvoice with a Vendor owner; the SWIG
+            # `Bill` class (a subclass of Invoice) is what makes AddEntry /
+            # RemoveEntry dispatch to the gncBill* functions, so we construct
+            # it as Bill rather than Invoice.
             vendor = _resolve_cross_reference(
                 'vendor',
                 directive.metadata.get('vendor_id'),
@@ -3099,17 +3057,18 @@ class GnuCashImporter:
                 lambda i: _find_vendors_by_id(book, i),
                 lambda g: _find_vendor_by_guid(book, g),
             )
-            bill = Invoice(book, bill_id, book.get_table().lookup("CURRENCY", directive.metadata['currency']), vendor)
+            bill = Bill(book, bill_id, book.get_table().lookup("CURRENCY", directive.metadata['currency']), vendor)
             if must_set_guid is not None:
                 _set_object_guid(book, bill, 'bill', bill_id, must_set_guid)
         else:
             # Existing bill (unposted now, after the Unpost above if needed):
-            # reuse it, drop its current entries.
-            # NOTE: SWIG `Invoice.RemoveEntry` wraps `gncInvoiceRemoveEntry`
-            # which only handles customer invoices. For vendor bills we
-            # need `gncBillRemoveEntry` via ctypes — see _bill_remove_entry.
+            # reuse it, drop its current entries. `_find_bills_by_id` /
+            # `_find_bill_by_guid` return a Bill, so RemoveEntry dispatches to
+            # gncBillRemoveEntry (correctly clearing the bill's entry list).
             bill = existing
-            _bill_remove_all_entries(book, bill)
+            for old_entry in list(bill.GetEntries()):
+                bill.RemoveEntry(old_entry)
+                old_entry.Destroy()
         bill.BeginEdit()
         bill.SetDateOpened(datetime.strptime(directive.metadata['date_opened'], "%Y-%m-%d"))
 
@@ -3138,11 +3097,12 @@ class GnuCashImporter:
                     tt_ptr = gc.gncTaxTableLookupByName(book.instance, entry_directive.metadata['tax_table'])
                     if tt_ptr:
                         entry.SetBillTaxTable(TaxTable(instance=tt_ptr))
-                # Attach on the vendor-bill side (gncBillAddEntry), NOT the
-                # customer-invoice side (Invoice.AddEntry), so GnuCash persists
-                # the bill-side tax flags (b-taxable / b-taxincluded). See
-                # _bill_add_entry.
-                _bill_add_entry(bill, entry)
+                # `bill` is a Bill, so AddEntry dispatches to gncBillAddEntry,
+                # which sets the entry's bill-side owner pointer. GnuCash then
+                # persists the bill-side tax flags (b-taxable / b-taxincluded);
+                # the customer-invoice Invoice.AddEntry would drop them on save
+                # and over-tax the bill.
+                bill.AddEntry(entry)
                 entry.CommitEdit()
             elif entry_directive.type == DirectiveType.POSTED:
                 ap_acct_name = entry_directive.metadata['ap_account']

--- a/tests/fixtures/mixed_book_invoice_and_bill_posted_taxed.txt
+++ b/tests/fixtures/mixed_book_invoice_and_bill_posted_taxed.txt
@@ -1,0 +1,60 @@
+taxtable "GST+PST"
+	entry:
+		account: "Liabilities:Tax:GST"
+		rate: 5.0%
+		type: PERCENT
+	entry:
+		account: "Liabilities:Tax:PST"
+		rate: 7.0%
+		type: PERCENT
+
+customer "C-MIX-1"
+	name: "Mixed Book Customer"
+	currency: CAD
+
+vendor "V-MIX-1"
+	name: "Mixed Book Vendor"
+	currency: CAD
+
+invoice "INV-MIX-1"
+	customer_id: "C-MIX-1"
+	currency: CAD
+	date_opened: 2026-05-10
+	entry:
+		date: 2026-05-10
+		description: "Mixed-book invoice (net 1000 + GST 50 + PST 70 = 1120)"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 1000
+		taxable: true
+		tax_included: false
+		tax_table: "GST+PST"
+	posted:
+		date: 2026-05-10
+		due: 2026-06-09
+		ar_account: "Assets:Accounts Receivable"
+		memo: "Invoice INV-MIX-1"
+		accumulate: true
+	payment: none
+
+bill "BILL-MIX-1"
+	vendor_id: "V-MIX-1"
+	currency: CAD
+	date_opened: 2026-05-11
+	entry:
+		date: 2026-05-11
+		description: "Mixed-book bill (net 1000 + GST 50 + PST 70 = 1120)"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 1000
+		taxable: true
+		tax_included: false
+		tax_table: "GST+PST"
+	posted:
+		date: 2026-05-11
+		due: 2026-06-10
+		ap_account: "Liabilities:Accounts Payable"
+		memo: "Bill BILL-MIX-1"
+		accumulate: true
+	payment: none

--- a/tests/fixtures/mixed_book_invoice_and_bill_unposted.txt
+++ b/tests/fixtures/mixed_book_invoice_and_bill_unposted.txt
@@ -1,0 +1,38 @@
+customer "C-MIX-2"
+	name: "Mixed Book Customer Two"
+	currency: CAD
+
+vendor "V-MIX-2"
+	name: "Mixed Book Vendor Two"
+	currency: CAD
+
+invoice "INV-MIX-2"
+	customer_id: "C-MIX-2"
+	currency: CAD
+	date_opened: 2026-05-12
+	entry:
+		date: 2026-05-12
+		description: "Mixed-book unposted invoice"
+		action: "Hours"
+		account: "Income:Sales"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted: none
+	payment: none
+
+bill "BILL-MIX-2"
+	vendor_id: "V-MIX-2"
+	currency: CAD
+	date_opened: 2026-05-13
+	entry:
+		date: 2026-05-13
+		description: "Mixed-book unposted bill"
+		account: "Expenses:Office Supplies"
+		quantity: 1
+		price: 100
+		taxable: false
+		tax_included: false
+	posted: none
+	payment: none

--- a/tests/integration/test_credit_consumption_across_bills.py
+++ b/tests/integration/test_credit_consumption_across_bills.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from cli.main import cli
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 
 FIXTURES = Path('tests/fixtures')
 ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
@@ -58,8 +59,8 @@ def _lot(gf, bill_id):
         q = Query()
         q.search_for('gncInvoice')
         q.set_book(repo.book)
-        bill = next((gb.Invoice(instance=r) for r in q.run()
-                     if gb.Invoice(instance=r).GetID() == bill_id), None)
+        bill = next((wrap_invoice_or_bill(r) for r in q.run()
+                     if wrap_invoice_or_bill(r).GetID() == bill_id), None)
         q.destroy()
         assert bill is not None, f'{bill_id!r} not found'
         lot = bill.GetPostedLot()

--- a/tests/integration/test_credit_consumption_across_invoices.py
+++ b/tests/integration/test_credit_consumption_across_invoices.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from cli.main import cli
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 
 FIXTURES = Path('tests/fixtures')
 ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
@@ -57,8 +58,8 @@ def _lot(gf, invoice_id):
         q = Query()
         q.search_for('gncInvoice')
         q.set_book(repo.book)
-        inv = next((gb.Invoice(instance=r) for r in q.run()
-                    if gb.Invoice(instance=r).GetID() == invoice_id), None)
+        inv = next((wrap_invoice_or_bill(r) for r in q.run()
+                    if wrap_invoice_or_bill(r).GetID() == invoice_id), None)
         q.destroy()
         assert inv is not None, f'{invoice_id!r} not found'
         lot = inv.GetPostedLot()

--- a/tests/integration/test_delete_invoice_bill.py
+++ b/tests/integration/test_delete_invoice_bill.py
@@ -30,6 +30,7 @@ import pytest
 from click.testing import CliRunner
 
 from cli.main import cli
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 
 
 def _fixture(name: str) -> str:
@@ -118,7 +119,7 @@ def _record_ids_after_reload(gnc, search_for, owner_type_int):
         q.set_book(book)
         ids = []
         for r in q.run():
-            inv = Invoice(instance=r)
+            inv = wrap_invoice_or_bill(r)
             if inv.GetOwnerType() == owner_type_int:
                 ids.append(inv.GetID())
         q.destroy()
@@ -198,7 +199,7 @@ def _invoice_guid(gnc, inv_id):
         q.set_book(book)
         guid = None
         for r in q.run():
-            inv = Invoice(instance=r)
+            inv = wrap_invoice_or_bill(r)
             if inv.GetID() == inv_id:
                 guid = _swig_invoice_guid_str(inv)
                 break

--- a/tests/integration/test_kvp_all_objects.py
+++ b/tests/integration/test_kvp_all_objects.py
@@ -11,6 +11,8 @@ import tempfile
 
 import pytest
 
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
+
 # ---------------------------------------------------------------------------
 # Session helpers (same pattern as test_kvp_metadata.py)
 # ---------------------------------------------------------------------------
@@ -209,7 +211,7 @@ def _lookup_invoices(book):
     q = Query()
     q.search_for('gncInvoice')
     q.set_book(book)
-    invoices = [gb.Invoice(instance=r) for r in q.run()]
+    invoices = [wrap_invoice_or_bill(r) for r in q.run()]
     q.destroy()
     return invoices
 

--- a/tests/integration/test_mixed_book_invoice_and_bill_isolation.py
+++ b/tests/integration/test_mixed_book_invoice_and_bill_isolation.py
@@ -1,0 +1,251 @@
+"""A book that holds BOTH a customer invoice AND a vendor bill at once.
+
+GnuCash stores both under one QOF type (`gncInvoice`); every query in this
+codebase does `search_for('gncInvoice')` and then classifies each result by
+owner type (`wrap_invoice_or_bill`, or an inline `GetOwner().GetCustomer()` /
+`GetOwner().GetVendor()` filter). That classification step is exactly where
+the Bill-vs-Invoice class bug lived (see CLAUDE.md #8 / T-008): a vendor bill
+handled with the wrong SWIG class silently corrupted its tax flags. These
+tests exercise every mixed-owner query site with BOTH kinds of record
+present in the SAME book, to catch a regression where one type leaks into
+the other's result set or gets mutated with the wrong class.
+
+Covered: export (partition + no cross-contamination), print-invoice /
+print-bill (each excludes the other kind entirely, including by explicit
+selector), delete-invoices / delete-bills (deleting one leaves the other
+completely untouched), and re-import / update (both records updated in the
+same pass, tax flags surviving on both sides — the sharpest test of the
+AddEntry/RemoveEntry class-selection bug in a mixed result set).
+"""
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cli.main import cli
+
+FIXTURES = Path('tests/fixtures')
+ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
+POSTED_FIXTURE = 'mixed_book_invoice_and_bill_posted_taxed.txt'
+UNPOSTED_FIXTURE = 'mixed_book_invoice_and_bill_unposted.txt'
+
+
+def _fx(name):
+    return (FIXTURES / name).read_text()
+
+
+def _book(runner, tmp_path, fixture_name):
+    gnc = tmp_path / 'book.gnucash'
+    r = runner.invoke(cli, ['import', '--new', str(gnc), ACCOUNTS])
+    assert r.exit_code == 0, f'accounts: {r.output}'
+    fx = tmp_path / fixture_name
+    fx.write_text(_fx(fixture_name))
+    r = runner.invoke(cli, ['import', str(gnc), str(fx),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f'{fixture_name}: {r.output}'
+    return gnc
+
+
+def _entry_tax_included(gnc, business_id, is_bill):
+    """Read tax_included straight off the first entry, proving the correct
+    SWIG class (Bill vs Invoice) was used for the mutation, not just that
+    the flag string round-tripped through plaintext."""
+    import gnucash.gnucash_business as gb
+    from gnucash import Query
+
+    from repositories.gnucash_repository import GnuCashRepository
+    repo = GnuCashRepository(str(gnc))
+    repo.open()
+    try:
+        q = Query()
+        q.search_for('gncInvoice')
+        q.set_book(repo.book)
+        rec = next((gb.Invoice(instance=r) for r in q.run()
+                    if gb.Invoice(instance=r).GetID() == business_id), None)
+        q.destroy()
+        assert rec is not None, f'{business_id!r} not found'
+        entry = list(rec.GetEntries())[0]
+        return bool(entry.GetBillTaxIncluded() if is_bill
+                    else entry.GetInvTaxIncluded())
+    finally:
+        repo.close()
+
+
+# ── Export: partition, no cross-contamination ──────────────────────
+
+def test_export_partitions_invoice_and_bill_with_no_cross_contamination(tmp_path):
+    """Exporting a book with one invoice and one bill puts each ID in its
+    own block, with the invoice's fields never appearing in the bill block
+    (and vice versa)."""
+    runner = CliRunner()
+    gnc = _book(runner, tmp_path, POSTED_FIXTURE)
+    out = tmp_path / 'export.txt'
+    r = runner.invoke(cli, ['export', str(gnc), str(out),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    text = out.read_text()
+
+    assert 'invoice "INV-MIX-1"' in text
+    assert 'bill "BILL-MIX-1"' in text
+
+    inv_start = text.index('invoice "INV-MIX-1"')
+    bill_start = text.index('bill "BILL-MIX-1"')
+    inv_block = text[inv_start:bill_start] if inv_start < bill_start else \
+        text[inv_start:inv_start + text[inv_start:].index('\n\n')]
+    bill_block = text[bill_start:bill_start + text[bill_start:].index('\n\n')] \
+        if bill_start > inv_start else text[bill_start:inv_start]
+
+    assert 'ar_account' in inv_block and 'ap_account' not in inv_block, (
+        f'invoice block must not carry AP fields:\n{inv_block}')
+    assert 'ap_account' in bill_block and 'ar_account' not in bill_block, (
+        f'bill block must not carry AR fields:\n{bill_block}')
+    assert 'BILL-MIX-1' not in inv_block, 'bill id leaked into invoice block'
+    assert 'INV-MIX-1' not in bill_block, 'invoice id leaked into bill block'
+
+
+# ── print-invoice / print-bill: strict exclusion ───────────────────
+
+def test_print_invoice_excludes_the_bill_in_the_same_book(tmp_path):
+    """`print-invoice` on a mixed book renders only the invoice; the bill's
+    id/description never appears, and selecting the bill's id by
+    --invoice-id finds nothing (a bill is not a selectable invoice)."""
+    runner = CliRunner()
+    gnc = _book(runner, tmp_path, POSTED_FIXTURE)
+
+    out = tmp_path / 'inv.txt'
+    r = runner.invoke(cli, ['print-invoice', str(gnc),
+                            '--invoice-id', 'INV-MIX-1',
+                            '--format', 'plaintext', '-o', str(out)])
+    assert r.exit_code == 0, r.output
+    text = out.read_text()
+    assert 'INV-MIX-1' in text
+    assert 'BILL-MIX-1' not in text
+    assert 'Mixed-book bill' not in text
+
+    r = runner.invoke(cli, ['print-invoice', str(gnc),
+                            '--invoice-id', 'BILL-MIX-1',
+                            '--format', 'plaintext',
+                            '-o', str(tmp_path / 'nope.txt')])
+    assert r.exit_code != 0, (
+        'a bill id must not be selectable via print-invoice --invoice-id')
+
+
+def test_print_bill_excludes_the_invoice_in_the_same_book(tmp_path):
+    """Mirror: `print-bill` on a mixed book renders only the bill; the
+    invoice never appears, and selecting the invoice's id by --bill-id
+    finds nothing."""
+    runner = CliRunner()
+    gnc = _book(runner, tmp_path, POSTED_FIXTURE)
+
+    out = tmp_path / 'bill.txt'
+    r = runner.invoke(cli, ['print-bill', str(gnc),
+                            '--bill-id', 'BILL-MIX-1',
+                            '--format', 'plaintext', '-o', str(out)])
+    assert r.exit_code == 0, r.output
+    text = out.read_text()
+    assert 'BILL-MIX-1' in text
+    assert 'INV-MIX-1' not in text
+    assert 'Mixed-book invoice' not in text
+
+    r = runner.invoke(cli, ['print-bill', str(gnc),
+                            '--bill-id', 'INV-MIX-1',
+                            '--format', 'plaintext',
+                            '-o', str(tmp_path / 'nope.txt')])
+    assert r.exit_code != 0, (
+        'an invoice id must not be selectable via print-bill --bill-id')
+
+
+def test_print_invoice_glob_selection_in_mixed_book_never_matches_the_bill(tmp_path):
+    """A glob broad enough to match both ids by naive substring (`*MIX*`)
+    must still select only the invoice under print-invoice — proving the
+    owner-type filter, not just the id string, decides membership."""
+    runner = CliRunner()
+    gnc = _book(runner, tmp_path, POSTED_FIXTURE)
+    out = tmp_path / 'globbed.txt'
+    r = runner.invoke(cli, ['print-invoice', str(gnc), '*MIX*',
+                            '--format', 'plaintext', '-o', str(out)])
+    assert r.exit_code == 0, r.output
+    text = out.read_text()
+    assert 'invoice "INV-MIX-1"' in text
+    assert 'BILL-MIX-1' not in text
+
+
+# ── delete-invoices / delete-bills: strict isolation ───────────────
+
+def test_delete_invoice_in_mixed_book_leaves_bill_completely_untouched(tmp_path):
+    """Deleting INV-MIX-2 removes only the invoice; BILL-MIX-2 (unposted,
+    same book) still imports/exports afterward exactly as before."""
+    runner = CliRunner()
+    gnc = _book(runner, tmp_path, UNPOSTED_FIXTURE)
+
+    r = runner.invoke(cli, ['delete-invoices', str(gnc), 'INV-MIX-2'])
+    assert r.exit_code == 0, r.output
+
+    out = tmp_path / 'after.txt'
+    r = runner.invoke(cli, ['export', str(gnc), str(out),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    text = out.read_text()
+    assert 'invoice "INV-MIX-2"' not in text, 'invoice must be gone'
+    assert 'bill "BILL-MIX-2"' in text, 'bill must survive the invoice delete'
+    assert 'posted: none' in text.split('bill "BILL-MIX-2"', 1)[1], (
+        'the surviving bill must still be unposted/unaffected')
+
+
+def test_delete_bill_in_mixed_book_leaves_invoice_completely_untouched(tmp_path):
+    """Mirror: deleting BILL-MIX-2 removes only the bill; INV-MIX-2 survives
+    unaffected. This is the isolation check closest to the AddEntry /
+    RemoveEntry class bug — a wrong-class RemoveEntry on the bill would
+    risk corrupting shared state."""
+    runner = CliRunner()
+    gnc = _book(runner, tmp_path, UNPOSTED_FIXTURE)
+
+    r = runner.invoke(cli, ['delete-bills', str(gnc), 'BILL-MIX-2'])
+    assert r.exit_code == 0, r.output
+
+    out = tmp_path / 'after.txt'
+    r = runner.invoke(cli, ['export', str(gnc), str(out),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    text = out.read_text()
+    assert 'bill "BILL-MIX-2"' not in text, 'bill must be gone'
+    assert 'invoice "INV-MIX-2"' in text, 'invoice must survive the bill delete'
+    assert 'posted: none' in text.split('invoice "INV-MIX-2"', 1)[1], (
+        'the surviving invoice must still be unposted/unaffected')
+
+
+# ── Re-import (update path): both records touched in one pass ─────
+
+def test_reimport_update_path_preserves_tax_flags_on_both_sides_at_once(tmp_path):
+    """Re-importing the same mixed posted fixture triggers the UPDATE path
+    (existing invoice found, existing bill found) for both records in one
+    import call. Both entries' tax_included must still read back correctly
+    afterward — the sharpest proof that AddEntry/RemoveEntry dispatch is
+    correct per-record even when the query result set contains both kinds
+    together."""
+    runner = CliRunner()
+    gnc = _book(runner, tmp_path, POSTED_FIXTURE)
+
+    assert _entry_tax_included(gnc, 'INV-MIX-1', is_bill=False) is False
+    assert _entry_tax_included(gnc, 'BILL-MIX-1', is_bill=True) is False
+
+    # Re-import the identical fixture: both records already exist and are
+    # posted, so the importer takes the unpost/rebuild/repost path for each
+    # — exercising RemoveEntry + AddEntry on both an Invoice and a Bill in
+    # the same pass, against a book where both kinds are present together.
+    fx = tmp_path / 'reimport.txt'
+    fx.write_text(_fx(POSTED_FIXTURE))
+    r = runner.invoke(cli, ['import', str(gnc), str(fx),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, f're-import: {r.output}'
+
+    assert _entry_tax_included(gnc, 'INV-MIX-1', is_bill=False) is False
+    assert _entry_tax_included(gnc, 'BILL-MIX-1', is_bill=True) is False
+
+    # And the entries are still tax-correct end to end (net 1000 + 120 tax).
+    out = tmp_path / 'after.txt'
+    r = runner.invoke(cli, ['export', str(gnc), str(out),
+                            '--include-business-objects'])
+    assert r.exit_code == 0, r.output
+    text = out.read_text()
+    assert text.count('invoice "INV-MIX-1"') == 1, 'no duplicate invoice'
+    assert text.count('bill "BILL-MIX-1"') == 1, 'no duplicate bill'

--- a/tests/integration/test_overpayment_partial_payment_with_and_without_tax.py
+++ b/tests/integration/test_overpayment_partial_payment_with_and_without_tax.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from cli.main import cli
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 
 FIXTURES = Path('tests/fixtures')
 ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
@@ -46,7 +47,7 @@ def _find(repo, obj_id):
     try:
         q.search_for('gncInvoice')
         q.set_book(repo.book)
-        return next((i for raw in q.run() for i in [gb.Invoice(instance=raw)]
+        return next((i for raw in q.run() for i in [wrap_invoice_or_bill(raw)]
                      if i.GetID() == obj_id), None)
     finally:
         q.destroy()

--- a/tests/integration/test_posted_tx_roundtrip.py
+++ b/tests/integration/test_posted_tx_roundtrip.py
@@ -24,7 +24,7 @@ from click.testing import CliRunner
 from gnucash import Query
 
 from cli.main import cli
-from infrastructure.gnucash.utils import get_account_full_name
+from infrastructure.gnucash.utils import get_account_full_name, wrap_invoice_or_bill
 from repositories.gnucash_repository import GnuCashRepository
 
 ACCOUNTS = """\
@@ -185,7 +185,7 @@ def _snapshot(gnc_path):
             q.search_for('gncInvoice')
             q.set_book(repo.book)
             for raw in q.run():
-                inv = gb.Invoice(instance=raw)
+                inv = wrap_invoice_or_bill(raw)
                 if inv.GetPostedTxn() is None:
                     continue
                 # Key by (owner-kind, id) so the equality check still

--- a/tests/integration/test_q011_action_and_template.py
+++ b/tests/integration/test_q011_action_and_template.py
@@ -18,6 +18,7 @@ import pytest
 from click.testing import CliRunner
 
 from cli.main import cli
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DEFAULT_XSLT = _REPO_ROOT / "services" / "invoice.xslt"
@@ -76,7 +77,7 @@ def _render_invoice_html(gnc_path: str, invoice_id: str, xslt_path: str) -> str:
         q.search_for('gncInvoice')
         q.set_book(book)
         inv = next(
-            (i for r in q.run() for i in [Invoice(instance=r)] if i.GetID() == invoice_id),
+            (i for r in q.run() for i in [wrap_invoice_or_bill(r)] if i.GetID() == invoice_id),
             None,
         )
         q.destroy()

--- a/tests/integration/test_q012_print_unposted_invoice.py
+++ b/tests/integration/test_q012_print_unposted_invoice.py
@@ -24,6 +24,7 @@ import pytest
 from click.testing import CliRunner
 
 from cli.main import cli
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DEFAULT_XSLT = _REPO_ROOT / "services" / "invoice.xslt"
@@ -84,7 +85,7 @@ def _render_invoice_html(gnc_path: str, invoice_id: str) -> str:
         q.search_for('gncInvoice')
         q.set_book(book)
         inv = next(
-            (i for r in q.run() for i in [Invoice(instance=r)] if i.GetID() == invoice_id),
+            (i for r in q.run() for i in [wrap_invoice_or_bill(r)] if i.GetID() == invoice_id),
             None,
         )
         q.destroy()

--- a/tests/integration/test_q018_cash_basis_marker.py
+++ b/tests/integration/test_q018_cash_basis_marker.py
@@ -12,6 +12,7 @@ import gnucash.gnucash_core_c as gc
 from click.testing import CliRunner
 
 from cli.main import cli
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 
 FIXTURES = Path('tests/fixtures')
 ACCOUNTS = str(FIXTURES / 'q018_accounts.txt')
@@ -66,7 +67,7 @@ def _invoice_state(gnc, inv_id):
         q.search_for('gncInvoice')
         q.set_book(book)
         inv = next(
-            (i for r in q.run() for i in [BizInvoice(instance=r)]
+            (i for r in q.run() for i in [wrap_invoice_or_bill(r)]
              if i.GetID() == inv_id),
             None,
         )
@@ -279,7 +280,7 @@ def test_cash_basis_flag_does_not_appear_in_pdf_or_html(tmp_path):
             q.search_for('gncInvoice')
             q.set_book(repo.book)
             inv = next(
-                (i for r in q.run() for i in [BizInvoice(instance=r)]
+                (i for r in q.run() for i in [wrap_invoice_or_bill(r)]
                  if i.GetID() == 'INV-Q18-CASH-100'),
                 None,
             )
@@ -323,7 +324,7 @@ def _render_invoice(gnc, invoice_id):
         q.search_for('gncInvoice')
         q.set_book(repo.book)
         inv = next(
-            (i for r in q.run() for i in [BizInvoice(instance=r)]
+            (i for r in q.run() for i in [wrap_invoice_or_bill(r)]
              if i.GetID() == invoice_id),
             None,
         )

--- a/tests/integration/test_q019_draft_tax_render.py
+++ b/tests/integration/test_q019_draft_tax_render.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from cli.main import cli
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 
 FIXTURES = Path('tests/fixtures')
 ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
@@ -48,7 +49,7 @@ def _render_invoice_html(gnc, invoice_id):
         q.search_for('gncInvoice')
         q.set_book(repo.book)
         inv = next(
-            (i for r in q.run() for i in [BizInvoice(instance=r)]
+            (i for r in q.run() for i in [wrap_invoice_or_bill(r)]
              if i.GetID() == invoice_id),
             None,
         )
@@ -74,7 +75,7 @@ def _render_invoice_plaintext(gnc, invoice_id):
         q.search_for('gncInvoice')
         q.set_book(repo.book)
         inv = next(
-            (i for r in q.run() for i in [BizInvoice(instance=r)]
+            (i for r in q.run() for i in [wrap_invoice_or_bill(r)]
              if i.GetID() == invoice_id),
             None,
         )

--- a/tests/integration/test_tax_included_pricing.py
+++ b/tests/integration/test_tax_included_pricing.py
@@ -30,7 +30,7 @@ from click.testing import CliRunner
 from gnucash import Query
 
 from cli.main import cli
-from infrastructure.gnucash.utils import get_account_full_name
+from infrastructure.gnucash.utils import get_account_full_name, wrap_invoice_or_bill
 from repositories.gnucash_repository import GnuCashRepository
 
 FIXTURES = Path('tests/fixtures')
@@ -62,7 +62,7 @@ def _find_business_object(repo, business_id):
         q.search_for('gncInvoice')
         q.set_book(repo.book)
         return next(
-            (i for raw in q.run() for i in [gb.Invoice(instance=raw)]
+            (i for raw in q.run() for i in [wrap_invoice_or_bill(raw)]
              if i.GetID() == business_id),
             None,
         )

--- a/tests/integration/test_taxed_bill_mixed_payment_unapply_and_relink.py
+++ b/tests/integration/test_taxed_bill_mixed_payment_unapply_and_relink.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from cli.main import cli
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 
 FIXTURES = Path('tests/fixtures')
 ACCOUNTS = str(FIXTURES / 'q019_accounts.txt')
@@ -75,8 +76,8 @@ def _posted_lot_balance(gf, bill_id):
         q = Query()
         q.search_for('gncInvoice')
         q.set_book(repo.book)
-        bill = next((gb.Invoice(instance=r) for r in q.run()
-                     if gb.Invoice(instance=r).GetID() == bill_id), None)
+        bill = next((wrap_invoice_or_bill(r) for r in q.run()
+                     if wrap_invoice_or_bill(r).GetID() == bill_id), None)
         q.destroy()
         assert bill is not None, f'{bill_id!r} not found'
         lot = bill.GetPostedLot()

--- a/tests/integration/test_unpost_invoice_bill.py
+++ b/tests/integration/test_unpost_invoice_bill.py
@@ -31,6 +31,7 @@ import pytest
 from click.testing import CliRunner
 
 from cli.main import cli
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 
 
 def _fixture(name: str) -> str:
@@ -127,7 +128,7 @@ def _entry_guids_for_invoice(runner, gnc, inv_id):
         q.set_book(book)
         guids = []
         for r in q.run():
-            inv = Invoice(instance=r)
+            inv = wrap_invoice_or_bill(r)
             if inv.GetID() == inv_id:
                 # Each entry's GUID via ctypes (SWIG GetGUID is unreliable
                 # for Entry on some platforms).

--- a/tests/research/bill_payment_reconciliation_probe.py
+++ b/tests/research/bill_payment_reconciliation_probe.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from cli.main import cli
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 
 ACCOUNTS = 'tests/fixtures/payment_roundtrip_accounts.txt'
 
@@ -289,8 +290,8 @@ def _dump_posting_and_lots(gf, bill_id):
         q = Query()
         q.search_for('gncInvoice')
         q.set_book(repo.book)
-        bill = next((gb.Invoice(instance=r) for r in q.run()
-                     if gb.Invoice(instance=r).GetID() == bill_id), None)
+        bill = next((wrap_invoice_or_bill(r) for r in q.run()
+                     if wrap_invoice_or_bill(r).GetID() == bill_id), None)
         q.destroy()
         assert bill is not None
 
@@ -354,7 +355,7 @@ def _bill_states(gf, bill_ids):
         q = Query()
         q.search_for('gncInvoice')
         q.set_book(repo.book)
-        by_id = {gb.Invoice(instance=r).GetID(): gb.Invoice(instance=r)
+        by_id = {wrap_invoice_or_bill(r).GetID(): wrap_invoice_or_bill(r)
                  for r in q.run()}
         q.destroy()
         for bid in bill_ids:

--- a/tests/research/orphan_detection_probe.py
+++ b/tests/research/orphan_detection_probe.py
@@ -24,6 +24,7 @@ import shutil
 from click.testing import CliRunner
 
 from cli.main import cli
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 
 WORKTREE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 EXPORTS_DIR = os.path.join(WORKTREE, "exports")
@@ -685,8 +686,8 @@ def test_find_orphan_payments_prototype_bill(tmp_path):
         q = Query()
         q.search_for('gncInvoice')
         q.set_book(ses.book)
-        bill = next(Invoice(instance=res) for res in q.run()
-                    if Invoice(instance=res).GetID() == "BILL-001")
+        bill = next(wrap_invoice_or_bill(res) for res in q.run()
+                    if wrap_invoice_or_bill(res).GetID() == "BILL-001")
         pre_list = find_pre_unpost_payments(ses.book, bill)
         q.destroy()
     finally:
@@ -733,8 +734,8 @@ def test_find_orphan_payments_prototype(tmp_path):
         q = Query()
         q.search_for('gncInvoice')
         q.set_book(ses.book)
-        inv = next(Invoice(instance=res) for res in q.run()
-                   if Invoice(instance=res).GetID() == "INV-001")
+        inv = next(wrap_invoice_or_bill(res) for res in q.run()
+                   if wrap_invoice_or_bill(res).GetID() == "INV-001")
         pre_list = find_pre_unpost_payments(ses.book, inv)
         q.destroy()
     finally:

--- a/tests/research/test_post_pay_unpost_cycle.py
+++ b/tests/research/test_post_pay_unpost_cycle.py
@@ -22,6 +22,7 @@ import shutil
 from click.testing import CliRunner
 
 from cli.main import cli
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 
 # Resolve the repo root from this test file's location so the path is correct
 # both inside Docker (/workspace/tests/research/...) and on the host.
@@ -201,7 +202,7 @@ def _read_entry_guids(gnc_path, inv_id):
         q.set_book(book)
         guids = []
         for r in q.run():
-            inv = Invoice(instance=r)
+            inv = wrap_invoice_or_bill(r)
             if inv.GetID() == inv_id:
                 lib = ctypes.CDLL(None)
                 lib.qof_instance_get_guid.argtypes = [ctypes.c_void_p]

--- a/tests/research/test_post_pay_unpost_cycle_bill.py
+++ b/tests/research/test_post_pay_unpost_cycle_bill.py
@@ -17,6 +17,7 @@ import shutil
 from click.testing import CliRunner
 
 from cli.main import cli
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 
 WORKTREE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 EXPORTS_DIR = os.path.join(WORKTREE, "exports", "bill")
@@ -187,7 +188,7 @@ def _read_entry_guids(gnc_path, bill_id):
         q.set_book(book)
         guids = []
         for r in q.run():
-            inv = Invoice(instance=r)
+            inv = wrap_invoice_or_bill(r)
             if inv.GetID() == bill_id:
                 lib = ctypes.CDLL(None)
                 lib.qof_instance_get_guid.argtypes = [ctypes.c_void_p]

--- a/use_cases/delete_business_objects.py
+++ b/use_cases/delete_business_objects.py
@@ -29,15 +29,14 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import List
 
-import gnucash.gnucash_business as gb
 from gnucash import Book, Query
 
 from infrastructure.gnucash.guid_lookup import (
     find_customer_by_guid,
     find_vendor_by_guid,
 )
+from infrastructure.gnucash.utils import wrap_invoice_or_bill
 from services.gnucash_importer import (
-    _bill_remove_all_entries,
     _find_bill_by_guid,
     _find_bills_by_id,
     _find_invoice_by_guid,
@@ -119,7 +118,7 @@ def _count_invoices_for_owner(book: Book, owner_id: str, owner_type_int: int) ->
     q.destroy()
     count = 0
     for r in invoices:
-        inv = gb.Invoice(instance=r)
+        inv = wrap_invoice_or_bill(r)
         if inv.GetOwnerType() != owner_type_int:
             continue
         try:
@@ -272,20 +271,15 @@ def _resolve_invoice_or_bill(book: Book, id_or_guid: str, by_guid: bool,
     return rec, rec.GetID(), _swig_invoice_guid_str(rec)
 
 
-def _remove_all_entries(rec, kind: str, book: Book) -> None:
+def _remove_all_entries(rec) -> None:
     """Detach + destroy every entry on an unposted invoice or bill, so
     that `Invoice.Destroy()` doesn't leave dangling entry-to-parent
     references that revive the parent in the XML backend on save.
 
-    Mirrors the importer's rebuild path:
-      - customer invoice: SWIG `invoice.RemoveEntry(entry)` works.
-      - vendor bill: SWIG RemoveEntry is customer-only — we use
-        `_bill_remove_all_entries` which calls `gncBillRemoveEntry`
-        via ctypes (same finding as CLAUDE.md #8).
+    `rec` is the correctly-typed SWIG object — a `Bill` for a vendor bill,
+    an `Invoice` for a customer invoice (see the `_find_*` lookups) — so
+    `RemoveEntry` dispatches to the right `gncBill*` / `gncInvoice*` function.
     """
-    if kind == 'bill':
-        _bill_remove_all_entries(book, rec)
-        return
     for entry in list(rec.GetEntries()):
         rec.RemoveEntry(entry)
         entry.Destroy()
@@ -332,7 +326,7 @@ def _execute_delete_invoice_or_bill(book: Book, ids: List[str],
                 id=rid, guid=rguid,
                 status=DeleteInvoiceStatus.FAILED_POSTED, kind=kind))
             continue
-        _remove_all_entries(rec, kind, book)
+        _remove_all_entries(rec)
         rec.Destroy()
         results.append(DeleteInvoiceResult(
             id=rid, guid=rguid, status=DeleteInvoiceStatus.DELETED, kind=kind))

--- a/use_cases/export_business_objects.py
+++ b/use_cases/export_business_objects.py
@@ -26,6 +26,7 @@ from infrastructure.gnucash.utils import (
     encode_value_as_string,
     format_amount_for_commodity,
     get_account_full_name,
+    wrap_invoice_or_bill,
 )
 
 
@@ -339,7 +340,7 @@ class ExportBusinessObjectsUseCase:
         q = Query()
         q.search_for('gncInvoice')
         q.set_book(self.book)
-        all_invoices = [gb.Invoice(instance=r) for r in q.run()]
+        all_invoices = [wrap_invoice_or_bill(r) for r in q.run()]
         q.destroy()
 
         # Export all customer invoices (owner is Customer, not Vendor), including unposted
@@ -612,7 +613,7 @@ class ExportBusinessObjectsUseCase:
         q = Query()
         q.search_for('gncInvoice')
         q.set_book(self.book)
-        all_invoices = [gb.Invoice(instance=r) for r in q.run()]
+        all_invoices = [wrap_invoice_or_bill(r) for r in q.run()]
         q.destroy()
 
         # Export all vendor bills, including unposted


### PR DESCRIPTION
A vendor bill is a gncInvoice with a Vendor owner, and GnuCash's Python
bindings expose a real `Bill(Invoice)` subclass whose AddEntry / RemoveEntry
dispatch to gncBillAddEntry / gncBillRemoveEntry. The code previously wrapped
and constructed bills as the customer-invoice `Invoice` class, so those
mutations hit the wrong (customer-side) C functions — which is why bill-side
tax flags were dropped on save and why the older code needed ctypes shims.

Every production path now handles a vendor bill as `Bill`:

- New helper `infrastructure/gnucash/utils.py:wrap_invoice_or_bill(raw)` wraps a
  gncInvoice QOF result as `Bill` when its owner is a vendor
  (`GetOwnerType() == GNC_OWNER_VENDOR`), else `Invoice`.
- `services/gnucash_importer.py` constructs new bills with `Bill(...)`, wraps
  every lookup result through the helper, attaches entries with `bill.AddEntry`
  and clears them with `bill.RemoveEntry`. The `_bill_add_entry` and
  `_bill_remove_all_entries` ctypes helpers are removed.
- `use_cases/delete_business_objects.py` drops its bill special-case: `rec` is
  correctly typed, so `_remove_all_entries` just calls `rec.RemoveEntry`.
- `use_cases/export_business_objects.py`, `cli/bill_print_cmd.py` and
  `cli/invoice_print_cmd.py` classify query results through the helper.

Removing the ctypes RemoveEntry shim in favour of `Bill.RemoveEntry` also
resolves the GnuCash-3.8 rebuild segfault the shim was originally added for:
the segfault came from calling the customer-invoice RemoveEntry on a bill
(dangling entry pointers), which the correct Bill.RemoveEntry avoids. Verified
by the full suite on Debian 13, Ubuntu 22.04 and Ubuntu 20.04 (GnuCash 3.8),
including the multi-entry-bill delete/rebuild segfault regression tests.

Test and research helpers that inspect bills are swept to `wrap_invoice_or_bill`
so no bill is wrapped as `Invoice` anywhere. CLAUDE.md finding https://github.com/huangjimmy/gnucash-plaintext/pull/8 and T-008 are
updated to describe the Bill-class fix (there is a `Bill` class; the bug was a
wrong-class choice, not a missing API).